### PR TITLE
feat: 接入 runner 提交预览结果

### DIFF
--- a/internal/runner/state.go
+++ b/internal/runner/state.go
@@ -16,12 +16,14 @@ type StateOptions struct {
 }
 
 type RunState struct {
-	mu        sync.Mutex
-	target    int
-	threshold int
-	success   int
-	failure   int
-	workers   map[int]WorkerProgress
+	mu            sync.Mutex
+	target        int
+	threshold     int
+	success       int
+	failure       int
+	stopRequested bool
+	stopReason    string
+	workers       map[int]WorkerProgress
 }
 
 type WorkerProgress struct {
@@ -37,6 +39,8 @@ type StateSnapshot struct {
 	FailureThreshold int
 	Successes        int
 	Failures         int
+	StopRequested    bool
+	StopReason       string
 	Workers          map[int]WorkerProgress
 }
 
@@ -81,6 +85,14 @@ func (s *RunState) SetWorkerStatus(workerID int, status WorkerStatus, message st
 	s.workers[workerID] = progress
 }
 
+func (s *RunState) RequestStop(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.stopRequested = true
+	s.stopReason = reason
+}
+
 func (s *RunState) Snapshot() StateSnapshot {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -94,13 +106,15 @@ func (s *RunState) Snapshot() StateSnapshot {
 		FailureThreshold: s.threshold,
 		Successes:        s.success,
 		Failures:         s.failure,
+		StopRequested:    s.stopRequested,
+		StopReason:       s.stopReason,
 		Workers:          workers,
 	}
 }
 
 func (s *RunState) ShouldStop() bool {
 	snapshot := s.Snapshot()
-	return snapshot.TargetReached() || snapshot.FailureThresholdReached()
+	return snapshot.StopRequested || snapshot.TargetReached() || snapshot.FailureThresholdReached()
 }
 
 func (s StateSnapshot) TargetReached() bool {

--- a/internal/runner/state_test.go
+++ b/internal/runner/state_test.go
@@ -53,6 +53,16 @@ func TestRunStateShouldStop(t *testing.T) {
 	if !state.ShouldStop() {
 		t.Fatalf("ShouldStop() = false after failure threshold reached, want true")
 	}
+
+	state = NewRunState(StateOptions{Target: 10, FailureThreshold: 10})
+	state.RequestStop("verification required")
+	if !state.ShouldStop() {
+		t.Fatalf("ShouldStop() = false after explicit stop, want true")
+	}
+	snapshot := state.Snapshot()
+	if !snapshot.StopRequested || snapshot.StopReason != "verification required" {
+		t.Fatalf("explicit stop snapshot = %+v, want stop reason", snapshot)
+	}
 }
 
 func TestRunStateIsConcurrentSafe(t *testing.T) {

--- a/internal/runner/submission.go
+++ b/internal/runner/submission.go
@@ -1,0 +1,59 @@
+package runner
+
+import (
+	"github.com/LING71671/SurveyController-go/internal/engine"
+	"github.com/LING71671/SurveyController-go/internal/logging"
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+func (s *RunState) RecordSubmissionResult(workerID int, result engine.SubmissionResult) {
+	switch {
+	case result.Success:
+		s.RecordSuccess(workerID)
+	case result.Error != nil:
+		s.RecordFailure(workerID, result.Message)
+	default:
+		s.SetWorkerStatus(workerID, WorkerStatusRunning, result.Message)
+	}
+
+	if result.ShouldStop {
+		s.RequestStop(result.Message)
+	}
+}
+
+func EventForSubmissionResult(workerID int, result engine.SubmissionResult) logging.RunEvent {
+	event := logging.RunEvent{
+		Type:     logging.EventWorkerProgress,
+		Level:    logging.LevelInfo,
+		WorkerID: workerID,
+		Message:  result.Message,
+		Fields: map[string]any{
+			"state":               string(result.State),
+			"terminal":            result.Terminal,
+			"completion_detected": result.CompletionDetected,
+			"should_stop":         result.ShouldStop,
+			"should_rotate_proxy": result.ShouldRotateProxy,
+		},
+	}
+
+	switch {
+	case result.Success:
+		event.Type = logging.EventSubmissionSuccess
+		event.Message = messageOrDefault(result.Message, "submission succeeded")
+	case result.State == provider.SubmissionStateVerificationRequired:
+		event.Type = logging.EventVerificationNeeded
+		event.Level = logging.LevelWarn
+	case result.Error != nil:
+		event.Type = logging.EventSubmissionFailure
+		event.Level = logging.LevelError
+	}
+
+	return event
+}
+
+func messageOrDefault(message string, fallback string) string {
+	if message == "" {
+		return fallback
+	}
+	return message
+}

--- a/internal/runner/submission_test.go
+++ b/internal/runner/submission_test.go
@@ -1,0 +1,158 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/apperr"
+	"github.com/LING71671/SurveyController-go/internal/engine"
+	"github.com/LING71671/SurveyController-go/internal/logging"
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+func TestRecordSubmissionResultCountsSuccess(t *testing.T) {
+	state := NewRunState(StateOptions{Target: 1})
+
+	state.RecordSubmissionResult(1, engine.SubmissionResult{
+		State:    provider.SubmissionStateSuccess,
+		Message:  "done",
+		Success:  true,
+		Terminal: true,
+	})
+
+	snapshot := state.Snapshot()
+	if snapshot.Successes != 1 || snapshot.Failures != 0 {
+		t.Fatalf("counts = %d/%d, want 1/0", snapshot.Successes, snapshot.Failures)
+	}
+	if snapshot.Workers[1].Successes != 1 || snapshot.Workers[1].Message != "" {
+		t.Fatalf("worker progress = %+v, want success recorded", snapshot.Workers[1])
+	}
+}
+
+func TestRecordSubmissionResultCountsFailure(t *testing.T) {
+	state := NewRunState(StateOptions{FailureThreshold: 2})
+
+	state.RecordSubmissionResult(2, engine.SubmissionResult{
+		State:    provider.SubmissionStateFailure,
+		Message:  "submit failed",
+		Terminal: true,
+		Error:    apperr.New(apperr.CodeSubmitFailed, "submit failed"),
+	})
+
+	snapshot := state.Snapshot()
+	if snapshot.Successes != 0 || snapshot.Failures != 1 {
+		t.Fatalf("counts = %d/%d, want 0/1", snapshot.Successes, snapshot.Failures)
+	}
+	if snapshot.Workers[2].Failures != 1 || snapshot.Workers[2].Message != "submit failed" {
+		t.Fatalf("worker progress = %+v, want failure message", snapshot.Workers[2])
+	}
+	if snapshot.StopRequested {
+		t.Fatalf("StopRequested = true, want false")
+	}
+}
+
+func TestRecordSubmissionResultRequestsStop(t *testing.T) {
+	state := NewRunState(StateOptions{Target: 10, FailureThreshold: 10})
+
+	state.RecordSubmissionResult(3, engine.SubmissionResult{
+		State:      provider.SubmissionStateVerificationRequired,
+		Message:    "verification required",
+		Terminal:   true,
+		ShouldStop: true,
+		Error:      apperr.New(apperr.CodeVerificationNeeded, "verification required"),
+	})
+
+	snapshot := state.Snapshot()
+	if snapshot.Failures != 1 || !snapshot.StopRequested || snapshot.StopReason != "verification required" {
+		t.Fatalf("snapshot = %+v, want failure and explicit stop", snapshot)
+	}
+	if !state.ShouldStop() {
+		t.Fatalf("ShouldStop() = false, want true")
+	}
+}
+
+func TestRecordSubmissionResultRecordsProgressForUnknown(t *testing.T) {
+	state := NewRunState(StateOptions{})
+
+	state.RecordSubmissionResult(4, engine.SubmissionResult{
+		State:   provider.SubmissionStateUnknown,
+		Message: "waiting for completion",
+	})
+
+	snapshot := state.Snapshot()
+	if snapshot.Successes != 0 || snapshot.Failures != 0 {
+		t.Fatalf("counts = %d/%d, want 0/0", snapshot.Successes, snapshot.Failures)
+	}
+	if snapshot.Workers[4].Message != "waiting for completion" {
+		t.Fatalf("worker progress = %+v, want progress message", snapshot.Workers[4])
+	}
+}
+
+func TestEventForSubmissionResult(t *testing.T) {
+	tests := []struct {
+		name      string
+		result    engine.SubmissionResult
+		wantType  logging.EventType
+		wantLevel logging.Level
+	}{
+		{
+			name: "success",
+			result: engine.SubmissionResult{
+				State:              provider.SubmissionStateSuccess,
+				Message:            "done",
+				Success:            true,
+				Terminal:           true,
+				CompletionDetected: true,
+			},
+			wantType:  logging.EventSubmissionSuccess,
+			wantLevel: logging.LevelInfo,
+		},
+		{
+			name: "verification",
+			result: engine.SubmissionResult{
+				State:      provider.SubmissionStateVerificationRequired,
+				Message:    "captcha",
+				Terminal:   true,
+				ShouldStop: true,
+				Error:      apperr.New(apperr.CodeVerificationNeeded, "captcha"),
+			},
+			wantType:  logging.EventVerificationNeeded,
+			wantLevel: logging.LevelWarn,
+		},
+		{
+			name: "failure",
+			result: engine.SubmissionResult{
+				State:             provider.SubmissionStateFailure,
+				Message:           "failed",
+				Terminal:          true,
+				ShouldRotateProxy: true,
+				Error:             apperr.New(apperr.CodeSubmitFailed, "failed"),
+			},
+			wantType:  logging.EventSubmissionFailure,
+			wantLevel: logging.LevelError,
+		},
+		{
+			name: "progress",
+			result: engine.SubmissionResult{
+				State:   provider.SubmissionStateUnknown,
+				Message: "pending",
+			},
+			wantType:  logging.EventWorkerProgress,
+			wantLevel: logging.LevelInfo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := EventForSubmissionResult(7, tt.result)
+			if event.Type != tt.wantType || event.Level != tt.wantLevel || event.WorkerID != 7 {
+				t.Fatalf("event = %+v, want type %q level %q worker 7", event, tt.wantType, tt.wantLevel)
+			}
+			if event.Fields["state"] != string(tt.result.State) {
+				t.Fatalf("state field = %v, want %q", event.Fields["state"], tt.result.State)
+			}
+			if event.Fields["should_rotate_proxy"] != tt.result.ShouldRotateProxy {
+				t.Fatalf("should_rotate_proxy field = %v, want %v", event.Fields["should_rotate_proxy"], tt.result.ShouldRotateProxy)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add runner-side recording for engine submission preview results
- track explicit stop requests and stop reasons in RunState snapshots
- map submission preview results to RunEvent types and fields for success, failure, verification, and progress states

Closes #1

## Validation

- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Added explicit stop signal tracking with customizable stop reasons.
  * Enhanced submission result handling to update runner state appropriately.
  * Stop requests now properly propagate through the system state.

* **Tests**
  * Added comprehensive test coverage for stop signal and submission result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->