### PR TITLE
feat: 增加 worker pool 提交预览任务

### DIFF
--- a/internal/runner/pool.go
+++ b/internal/runner/pool.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/LING71671/SurveyController-go/internal/engine"
 	"github.com/LING71671/SurveyController-go/internal/logging"
 )
 
 type Task func(ctx context.Context, workerID int) error
+type SubmissionTask func(ctx context.Context, workerID int) (engine.SubmissionResult, error)
 
 type PoolOptions struct {
 	Concurrency      int
@@ -78,6 +80,36 @@ enqueue:
 	return snapshot
 }
 
+func (p *WorkerPool) RunSubmissions(ctx context.Context, tasks []SubmissionTask) StateSnapshot {
+	p.emit(logging.NewEvent(logging.EventRunStarted, "run started"))
+	taskCh := make(chan SubmissionTask)
+	var wg sync.WaitGroup
+
+	for workerID := 1; workerID <= p.options.Concurrency; workerID++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			p.submissionWorker(ctx, id, taskCh)
+		}(workerID)
+	}
+
+enqueue:
+	for _, task := range tasks {
+		if p.state.ShouldStop() {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			break enqueue
+		case taskCh <- task:
+		}
+	}
+	close(taskCh)
+	wg.Wait()
+
+	return p.finishRun()
+}
+
 func (p *WorkerPool) worker(ctx context.Context, workerID int, tasks <-chan Task) {
 	p.state.SetWorkerStatus(workerID, WorkerStatusRunning, "worker started")
 	p.emit(logging.RunEvent{
@@ -115,6 +147,60 @@ func (p *WorkerPool) worker(ctx context.Context, workerID int, tasks <-chan Task
 			})
 		}
 	}
+}
+
+func (p *WorkerPool) submissionWorker(ctx context.Context, workerID int, tasks <-chan SubmissionTask) {
+	p.startWorker(workerID)
+	defer p.state.SetWorkerStatus(workerID, WorkerStatusStopped, "worker stopped")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case task, ok := <-tasks:
+			if !ok || p.state.ShouldStop() {
+				return
+			}
+			result, err := task(ctx, workerID)
+			if err != nil {
+				p.state.RecordFailure(workerID, err.Error())
+				p.emit(logging.RunEvent{
+					Type:     logging.EventSubmissionFailure,
+					Level:    logging.LevelError,
+					WorkerID: workerID,
+					Message:  err.Error(),
+				})
+				continue
+			}
+			p.state.RecordSubmissionResult(workerID, result)
+			p.emit(EventForSubmissionResult(workerID, result))
+		}
+	}
+}
+
+func (p *WorkerPool) startWorker(workerID int) {
+	p.state.SetWorkerStatus(workerID, WorkerStatusRunning, "worker started")
+	p.emit(logging.RunEvent{
+		Type:     logging.EventWorkerStarted,
+		Level:    logging.LevelInfo,
+		WorkerID: workerID,
+		Message:  "worker started",
+	})
+}
+
+func (p *WorkerPool) finishRun() StateSnapshot {
+	snapshot := p.state.Snapshot()
+	p.emit(logging.RunEvent{
+		Type:    logging.EventRunFinished,
+		Level:   logging.LevelInfo,
+		Message: "run finished",
+		Fields: map[string]any{
+			"successes":      snapshot.Successes,
+			"failures":       snapshot.Failures,
+			"stop_requested": snapshot.StopRequested,
+		},
+	})
+	return snapshot
 }
 
 func (p *WorkerPool) emit(event logging.RunEvent) {

--- a/internal/runner/pool_test.go
+++ b/internal/runner/pool_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LING71671/SurveyController-go/internal/apperr"
+	"github.com/LING71671/SurveyController-go/internal/engine"
 	"github.com/LING71671/SurveyController-go/internal/logging"
+	"github.com/LING71671/SurveyController-go/internal/provider"
 )
 
 func TestWorkerPoolRecordsSuccessAndFailure(t *testing.T) {
@@ -99,12 +102,118 @@ func TestWorkerPoolStopsOnContextCancel(t *testing.T) {
 	}
 }
 
+func TestWorkerPoolRunSubmissionsRecordsResults(t *testing.T) {
+	events := make(chan logging.RunEvent, 16)
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 1, Target: 3, Events: events})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+	tasks := []SubmissionTask{
+		submissionResultTask(engine.SubmissionResult{
+			State:    provider.SubmissionStateSuccess,
+			Message:  "done",
+			Success:  true,
+			Terminal: true,
+		}),
+		submissionResultTask(engine.SubmissionResult{
+			State:   provider.SubmissionStateUnknown,
+			Message: "waiting",
+		}),
+		submissionResultTask(engine.SubmissionResult{
+			State:    provider.SubmissionStateFailure,
+			Message:  "failed",
+			Terminal: true,
+			Error:    apperr.New(apperr.CodeSubmitFailed, "failed"),
+		}),
+	}
+
+	snapshot := pool.RunSubmissions(context.Background(), tasks)
+	if snapshot.Successes != 1 || snapshot.Failures != 1 {
+		t.Fatalf("snapshot counts = %d/%d, want 1/1", snapshot.Successes, snapshot.Failures)
+	}
+	if snapshot.Workers[1].Message != "worker stopped" {
+		t.Fatalf("worker progress = %+v, want stopped message", snapshot.Workers[1])
+	}
+	if !hasEvent(events, logging.EventSubmissionSuccess) {
+		t.Fatalf("events did not include submission success")
+	}
+	if !hasEvent(events, logging.EventWorkerProgress) {
+		t.Fatalf("events did not include worker progress")
+	}
+	if !hasEvent(events, logging.EventSubmissionFailure) {
+		t.Fatalf("events did not include submission failure")
+	}
+}
+
+func TestWorkerPoolRunSubmissionsStopsOnSubmissionSignal(t *testing.T) {
+	events := make(chan logging.RunEvent, 16)
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 1, Target: 10, FailureThreshold: 10, Events: events})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+	var calls int32
+	tasks := []SubmissionTask{
+		func(context.Context, int) (engine.SubmissionResult, error) {
+			atomic.AddInt32(&calls, 1)
+			return engine.SubmissionResult{
+				State:      provider.SubmissionStateVerificationRequired,
+				Message:    "captcha",
+				Terminal:   true,
+				ShouldStop: true,
+				Error:      apperr.New(apperr.CodeVerificationNeeded, "captcha"),
+			}, nil
+		},
+		func(context.Context, int) (engine.SubmissionResult, error) {
+			atomic.AddInt32(&calls, 1)
+			return engine.SubmissionResult{State: provider.SubmissionStateSuccess, Success: true}, nil
+		},
+	}
+
+	snapshot := pool.RunSubmissions(context.Background(), tasks)
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+	if snapshot.Failures != 1 || !snapshot.StopRequested || snapshot.StopReason != "captcha" {
+		t.Fatalf("snapshot = %+v, want stop after verification", snapshot)
+	}
+	if !hasEvent(events, logging.EventVerificationNeeded) {
+		t.Fatalf("events did not include verification needed")
+	}
+}
+
+func TestWorkerPoolRunSubmissionsRecordsTaskError(t *testing.T) {
+	events := make(chan logging.RunEvent, 16)
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 1, Events: events})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+
+	snapshot := pool.RunSubmissions(context.Background(), []SubmissionTask{
+		func(context.Context, int) (engine.SubmissionResult, error) {
+			return engine.SubmissionResult{}, errors.New("browser crashed")
+		},
+	})
+
+	if snapshot.Successes != 0 || snapshot.Failures != 1 {
+		t.Fatalf("counts = %d/%d, want 0/1", snapshot.Successes, snapshot.Failures)
+	}
+	if !hasEvent(events, logging.EventSubmissionFailure) {
+		t.Fatalf("events did not include submission failure")
+	}
+}
+
 func TestNewWorkerPoolRejectsInvalidOptions(t *testing.T) {
 	if _, err := NewWorkerPool(PoolOptions{}); err == nil {
 		t.Fatal("NewWorkerPool(empty) returned nil error, want failure")
 	}
 	if _, err := NewWorkerPool(PoolOptions{Concurrency: 1, Target: -1}); err == nil {
 		t.Fatal("NewWorkerPool(negative target) returned nil error, want failure")
+	}
+}
+
+func submissionResultTask(result engine.SubmissionResult) SubmissionTask {
+	return func(context.Context, int) (engine.SubmissionResult, error) {
+		return result, nil
 	}
 }
 


### PR DESCRIPTION
## Summary

- add SubmissionTask for worker pool runtime preview flows
- add WorkerPool.RunSubmissions to consume engine.SubmissionResult directly
- emit submission preview events and honor stop signals from verification/login/quota style results
- keep the existing Task/error worker pool API unchanged

Closes #3

## Validation

- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added concurrent submission processing enabling parallel task execution with improved event tracking and progress monitoring.

* **Tests**
  * Added comprehensive test coverage for submission processing including concurrent execution, early termination, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->