### PR TITLE
feat: 扩展 runtime config schema

### DIFF
--- a/examples/run.yaml
+++ b/examples/run.yaml
@@ -6,4 +6,30 @@ run:
   target: 1
   concurrency: 1
   mode: hybrid
+  failure_threshold: 1
+  fail_stop_enabled: true
+  headless: true
+  submit_interval:
+    min_seconds: 0
+    max_seconds: 0
+  answer_duration:
+    min_seconds: 0
+    max_seconds: 0
+  timed_mode:
+    enabled: false
+    refresh_interval_seconds: 3
+proxy:
+  enabled: false
+  source: default
+  occupy_minutes: 1
+reverse_fill:
+  enabled: false
+  format: auto
+  start_row: 1
+random_ua:
+  enabled: false
+  ratios:
+    wechat: 33
+    mobile: 33
+    pc: 34
 questions: []

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,12 +13,14 @@ import (
 const CurrentSchemaVersion = 1
 
 type RunConfig struct {
-	SchemaVersion int              `json:"schema_version" yaml:"schema_version"`
-	Survey        SurveyConfig     `json:"survey" yaml:"survey"`
-	Run           RuntimeConfig    `json:"run" yaml:"run"`
-	Questions     []QuestionConfig `json:"questions" yaml:"questions"`
-	Proxy         map[string]any   `json:"proxy,omitempty" yaml:"proxy,omitempty"`
-	Answer        map[string]any   `json:"answer,omitempty" yaml:"answer,omitempty"`
+	SchemaVersion int               `json:"schema_version" yaml:"schema_version"`
+	Survey        SurveyConfig      `json:"survey" yaml:"survey"`
+	Run           RuntimeConfig     `json:"run" yaml:"run"`
+	Questions     []QuestionConfig  `json:"questions" yaml:"questions"`
+	Proxy         ProxyConfig       `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	ReverseFill   ReverseFillConfig `json:"reverse_fill,omitempty" yaml:"reverse_fill,omitempty"`
+	RandomUA      RandomUAConfig    `json:"random_ua,omitempty" yaml:"random_ua,omitempty"`
+	Answer        map[string]any    `json:"answer,omitempty" yaml:"answer,omitempty"`
 }
 
 type SurveyConfig struct {
@@ -27,9 +29,46 @@ type SurveyConfig struct {
 }
 
 type RuntimeConfig struct {
-	Target      int         `json:"target" yaml:"target"`
-	Concurrency int         `json:"concurrency" yaml:"concurrency"`
-	Mode        engine.Mode `json:"mode" yaml:"mode"`
+	Target           int             `json:"target" yaml:"target"`
+	Concurrency      int             `json:"concurrency" yaml:"concurrency"`
+	Mode             engine.Mode     `json:"mode" yaml:"mode"`
+	FailureThreshold int             `json:"failure_threshold" yaml:"failure_threshold"`
+	FailStopEnabled  bool            `json:"fail_stop_enabled" yaml:"fail_stop_enabled"`
+	Headless         bool            `json:"headless" yaml:"headless"`
+	SubmitInterval   DurationRange   `json:"submit_interval,omitempty" yaml:"submit_interval,omitempty"`
+	AnswerDuration   DurationRange   `json:"answer_duration,omitempty" yaml:"answer_duration,omitempty"`
+	TimedMode        TimedModeConfig `json:"timed_mode,omitempty" yaml:"timed_mode,omitempty"`
+}
+
+type DurationRange struct {
+	MinSeconds int `json:"min_seconds" yaml:"min_seconds"`
+	MaxSeconds int `json:"max_seconds" yaml:"max_seconds"`
+}
+
+type TimedModeConfig struct {
+	Enabled                bool `json:"enabled" yaml:"enabled"`
+	RefreshIntervalSeconds int  `json:"refresh_interval_seconds" yaml:"refresh_interval_seconds"`
+}
+
+type ProxyConfig struct {
+	Enabled       bool   `json:"enabled" yaml:"enabled"`
+	Source        string `json:"source,omitempty" yaml:"source,omitempty"`
+	CustomAPI     string `json:"custom_api,omitempty" yaml:"custom_api,omitempty"`
+	AreaCode      string `json:"area_code,omitempty" yaml:"area_code,omitempty"`
+	OccupyMinutes int    `json:"occupy_minutes,omitempty" yaml:"occupy_minutes,omitempty"`
+}
+
+type ReverseFillConfig struct {
+	Enabled    bool   `json:"enabled" yaml:"enabled"`
+	SourcePath string `json:"source_path,omitempty" yaml:"source_path,omitempty"`
+	Format     string `json:"format,omitempty" yaml:"format,omitempty"`
+	StartRow   int    `json:"start_row,omitempty" yaml:"start_row,omitempty"`
+}
+
+type RandomUAConfig struct {
+	Enabled bool           `json:"enabled" yaml:"enabled"`
+	Keys    []string       `json:"keys,omitempty" yaml:"keys,omitempty"`
+	Ratios  map[string]int `json:"ratios,omitempty" yaml:"ratios,omitempty"`
 }
 
 type QuestionConfig struct {
@@ -43,15 +82,48 @@ func DefaultRunConfig() RunConfig {
 	return RunConfig{
 		SchemaVersion: CurrentSchemaVersion,
 		Run:           DefaultRuntimeConfig(),
+		Proxy:         DefaultProxyConfig(),
+		ReverseFill:   DefaultReverseFillConfig(),
+		RandomUA:      DefaultRandomUAConfig(),
 		Questions:     []QuestionConfig{},
 	}
 }
 
 func DefaultRuntimeConfig() RuntimeConfig {
 	return RuntimeConfig{
-		Target:      1,
-		Concurrency: 1,
-		Mode:        engine.ModeHybrid,
+		Target:           1,
+		Concurrency:      1,
+		Mode:             engine.ModeHybrid,
+		FailureThreshold: 1,
+		FailStopEnabled:  true,
+		Headless:         true,
+		TimedMode: TimedModeConfig{
+			RefreshIntervalSeconds: 3,
+		},
+	}
+}
+
+func DefaultProxyConfig() ProxyConfig {
+	return ProxyConfig{
+		Source:        "default",
+		OccupyMinutes: 1,
+	}
+}
+
+func DefaultReverseFillConfig() ReverseFillConfig {
+	return ReverseFillConfig{
+		Format:   "auto",
+		StartRow: 1,
+	}
+}
+
+func DefaultRandomUAConfig() RandomUAConfig {
+	return RandomUAConfig{
+		Ratios: map[string]int{
+			"wechat": 33,
+			"mobile": 33,
+			"pc":     34,
+		},
 	}
 }
 
@@ -61,7 +133,7 @@ func LoadRunConfig(path string) (RunConfig, error) {
 		return RunConfig{}, fmt.Errorf("read config %q: %w", path, err)
 	}
 
-	var cfg RunConfig
+	cfg := DefaultRunConfig()
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&cfg); err != nil {
@@ -92,7 +164,19 @@ func (c RunConfig) Validate() error {
 	if strings.TrimSpace(c.Survey.URL) == "" {
 		return fmt.Errorf("survey.url is required")
 	}
-	return c.Run.Validate()
+	if err := c.Run.Validate(); err != nil {
+		return err
+	}
+	if err := c.Proxy.Validate(); err != nil {
+		return fmt.Errorf("proxy: %w", err)
+	}
+	if err := c.ReverseFill.Validate(); err != nil {
+		return fmt.Errorf("reverse_fill: %w", err)
+	}
+	if err := c.RandomUA.Validate(); err != nil {
+		return fmt.Errorf("random_ua: %w", err)
+	}
+	return nil
 }
 
 func (c RuntimeConfig) Validate() error {
@@ -102,8 +186,83 @@ func (c RuntimeConfig) Validate() error {
 	if c.Concurrency <= 0 {
 		return fmt.Errorf("run.concurrency must be greater than 0")
 	}
+	if c.FailureThreshold < 0 {
+		return fmt.Errorf("run.failure_threshold must not be negative")
+	}
 	if _, err := engine.ParseMode(c.Mode.String()); err != nil {
 		return fmt.Errorf("run.mode: %w", err)
+	}
+	if err := c.SubmitInterval.Validate("run.submit_interval"); err != nil {
+		return err
+	}
+	if err := c.AnswerDuration.Validate("run.answer_duration"); err != nil {
+		return err
+	}
+	if c.TimedMode.RefreshIntervalSeconds < 0 {
+		return fmt.Errorf("run.timed_mode.refresh_interval_seconds must not be negative")
+	}
+	return nil
+}
+
+func (r DurationRange) Validate(name string) error {
+	if r.MinSeconds < 0 {
+		return fmt.Errorf("%s.min_seconds must not be negative", name)
+	}
+	if r.MaxSeconds < 0 {
+		return fmt.Errorf("%s.max_seconds must not be negative", name)
+	}
+	if r.MaxSeconds > 0 && r.MinSeconds > r.MaxSeconds {
+		return fmt.Errorf("%s.min_seconds must be less than or equal to max_seconds", name)
+	}
+	return nil
+}
+
+func (c ProxyConfig) Validate() error {
+	source := strings.TrimSpace(c.Source)
+	if source == "" {
+		source = "default"
+	}
+	switch source {
+	case "default", "custom":
+	default:
+		return fmt.Errorf("source %q is unsupported", c.Source)
+	}
+	if c.Enabled && source == "custom" && strings.TrimSpace(c.CustomAPI) == "" {
+		return fmt.Errorf("custom_api is required when source is custom")
+	}
+	if c.OccupyMinutes < 0 {
+		return fmt.Errorf("occupy_minutes must not be negative")
+	}
+	return nil
+}
+
+func (c ReverseFillConfig) Validate() error {
+	format := strings.TrimSpace(c.Format)
+	if format == "" {
+		format = "auto"
+	}
+	switch format {
+	case "auto", "wjx_sequence", "wjx_score", "wjx_text":
+	default:
+		return fmt.Errorf("format %q is unsupported", c.Format)
+	}
+	if c.Enabled && strings.TrimSpace(c.SourcePath) == "" {
+		return fmt.Errorf("source_path is required when enabled")
+	}
+	if c.StartRow < 0 {
+		return fmt.Errorf("start_row must not be negative")
+	}
+	return nil
+}
+
+func (c RandomUAConfig) Validate() error {
+	for key, ratio := range c.Ratios {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("ratio key is required")
+		}
+		if ratio < 0 {
+			return fmt.Errorf("ratio %q must not be negative", key)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,15 @@ func TestDefaultRunConfigIsValidAfterSurveyURL(t *testing.T) {
 	if cfg.Run.Mode != engine.ModeHybrid {
 		t.Fatalf("Run.Mode = %q, want %q", cfg.Run.Mode, engine.ModeHybrid)
 	}
+	if !cfg.Run.Headless || !cfg.Run.FailStopEnabled || cfg.Run.FailureThreshold != 1 {
+		t.Fatalf("default runtime = %+v, want headless fail-stop threshold 1", cfg.Run)
+	}
+	if cfg.Proxy.Source != "default" || cfg.Proxy.OccupyMinutes != 1 {
+		t.Fatalf("default proxy = %+v, want default source and occupy minute 1", cfg.Proxy)
+	}
+	if cfg.ReverseFill.Format != "auto" || cfg.ReverseFill.StartRow != 1 {
+		t.Fatalf("default reverse fill = %+v, want auto start row 1", cfg.ReverseFill)
+	}
 }
 
 func TestLoadRunConfigReadsYAML(t *testing.T) {
@@ -33,6 +42,35 @@ run:
   target: 3
   concurrency: 2
   mode: browser
+  failure_threshold: 5
+  fail_stop_enabled: true
+  headless: false
+  submit_interval:
+    min_seconds: 1
+    max_seconds: 3
+  answer_duration:
+    min_seconds: 10
+    max_seconds: 20
+  timed_mode:
+    enabled: true
+    refresh_interval_seconds: 5
+proxy:
+  enabled: true
+  source: custom
+  custom_api: "https://proxy.example/api"
+  area_code: "110000"
+  occupy_minutes: 2
+reverse_fill:
+  enabled: true
+  source_path: "samples.xlsx"
+  format: wjx_sequence
+  start_row: 2
+random_ua:
+  enabled: true
+  keys: ["wechat", "pc"]
+  ratios:
+    wechat: 60
+    pc: 40
 questions: []
 `)
 
@@ -48,6 +86,51 @@ questions: []
 	}
 	if cfg.Run.Mode != engine.ModeBrowser {
 		t.Fatalf("Run.Mode = %q, want %q", cfg.Run.Mode, engine.ModeBrowser)
+	}
+	if cfg.Run.FailureThreshold != 5 || cfg.Run.Headless {
+		t.Fatalf("Run = %+v, want failure threshold 5 and headless false", cfg.Run)
+	}
+	if cfg.Run.SubmitInterval.MinSeconds != 1 || cfg.Run.AnswerDuration.MaxSeconds != 20 {
+		t.Fatalf("Run duration ranges = %+v/%+v, want configured values", cfg.Run.SubmitInterval, cfg.Run.AnswerDuration)
+	}
+	if !cfg.Proxy.Enabled || cfg.Proxy.Source != "custom" || cfg.Proxy.OccupyMinutes != 2 {
+		t.Fatalf("Proxy = %+v, want custom proxy settings", cfg.Proxy)
+	}
+	if !cfg.ReverseFill.Enabled || cfg.ReverseFill.Format != "wjx_sequence" || cfg.ReverseFill.StartRow != 2 {
+		t.Fatalf("ReverseFill = %+v, want configured settings", cfg.ReverseFill)
+	}
+	if !cfg.RandomUA.Enabled || cfg.RandomUA.Ratios["wechat"] != 60 {
+		t.Fatalf("RandomUA = %+v, want configured ratios", cfg.RandomUA)
+	}
+}
+
+func TestLoadRunConfigAppliesDefaultsForOmittedRuntimeFields(t *testing.T) {
+	path := writeRunConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: hybrid
+questions: []
+`)
+
+	cfg, err := LoadRunConfig(path)
+	if err != nil {
+		t.Fatalf("LoadRunConfig() returned error: %v", err)
+	}
+	if !cfg.Run.Headless || !cfg.Run.FailStopEnabled || cfg.Run.FailureThreshold != 1 {
+		t.Fatalf("Run defaults = %+v, want headless fail-stop threshold 1", cfg.Run)
+	}
+	if cfg.Proxy.Source != "default" || cfg.Proxy.OccupyMinutes != 1 {
+		t.Fatalf("Proxy defaults = %+v, want default source occupy minute 1", cfg.Proxy)
+	}
+	if cfg.ReverseFill.Format != "auto" || cfg.ReverseFill.StartRow != 1 {
+		t.Fatalf("ReverseFill defaults = %+v, want auto start row 1", cfg.ReverseFill)
+	}
+	if cfg.RandomUA.Ratios["pc"] != 34 {
+		t.Fatalf("RandomUA defaults = %+v, want pc ratio", cfg.RandomUA)
 	}
 }
 
@@ -104,11 +187,75 @@ func TestRuntimeConfigValidationRejectsInvalidValues(t *testing.T) {
 			},
 			want: "run.mode",
 		},
+		{
+			name: "failure threshold",
+			cfg: RuntimeConfig{
+				Target:           1,
+				Concurrency:      1,
+				Mode:             engine.ModeHybrid,
+				FailureThreshold: -1,
+			},
+			want: "run.failure_threshold",
+		},
+		{
+			name: "submit interval",
+			cfg: RuntimeConfig{
+				Target:         1,
+				Concurrency:    1,
+				Mode:           engine.ModeHybrid,
+				SubmitInterval: DurationRange{MinSeconds: 5, MaxSeconds: 1},
+			},
+			want: "run.submit_interval",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunConfigValidationRejectsInvalidNestedRuntimeSettings(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*RunConfig)
+		want string
+	}{
+		{
+			name: "proxy custom api",
+			edit: func(cfg *RunConfig) {
+				cfg.Proxy.Enabled = true
+				cfg.Proxy.Source = "custom"
+			},
+			want: "proxy: custom_api",
+		},
+		{
+			name: "reverse fill source",
+			edit: func(cfg *RunConfig) {
+				cfg.ReverseFill.Enabled = true
+			},
+			want: "reverse_fill: source_path",
+		},
+		{
+			name: "random ua ratio",
+			edit: func(cfg *RunConfig) {
+				cfg.RandomUA.Ratios = map[string]int{"pc": -1}
+			},
+			want: "random_ua: ratio",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultRunConfig()
+			cfg.Survey.URL = "https://example.com/survey"
+			tt.edit(&cfg)
+
+			err := cfg.Validate()
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("Validate() error = %v, want %q", err, tt.want)
 			}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -9,12 +9,21 @@ import (
 )
 
 type Plan struct {
-	Mode        engine.Mode
-	Provider    string
-	URL         string
-	Target      int
-	Concurrency int
-	Questions   []QuestionPlan
+	Mode             engine.Mode
+	Provider         string
+	URL              string
+	Target           int
+	Concurrency      int
+	FailureThreshold int
+	FailStopEnabled  bool
+	Headless         bool
+	SubmitInterval   config.DurationRange
+	AnswerDuration   config.DurationRange
+	TimedMode        config.TimedModeConfig
+	Proxy            config.ProxyConfig
+	ReverseFill      config.ReverseFillConfig
+	RandomUA         config.RandomUAConfig
+	Questions        []QuestionPlan
 }
 
 type QuestionPlan struct {
@@ -36,12 +45,21 @@ func CompilePlan(cfg config.RunConfig) (Plan, error) {
 	}
 
 	plan := Plan{
-		Mode:        cfg.Run.Mode,
-		Provider:    strings.TrimSpace(cfg.Survey.Provider),
-		URL:         strings.TrimSpace(cfg.Survey.URL),
-		Target:      cfg.Run.Target,
-		Concurrency: cfg.Run.Concurrency,
-		Questions:   make([]QuestionPlan, 0, len(cfg.Questions)),
+		Mode:             cfg.Run.Mode,
+		Provider:         strings.TrimSpace(cfg.Survey.Provider),
+		URL:              strings.TrimSpace(cfg.Survey.URL),
+		Target:           cfg.Run.Target,
+		Concurrency:      cfg.Run.Concurrency,
+		FailureThreshold: cfg.Run.FailureThreshold,
+		FailStopEnabled:  cfg.Run.FailStopEnabled,
+		Headless:         cfg.Run.Headless,
+		SubmitInterval:   cfg.Run.SubmitInterval,
+		AnswerDuration:   cfg.Run.AnswerDuration,
+		TimedMode:        cfg.Run.TimedMode,
+		Proxy:            cfg.Proxy,
+		ReverseFill:      cfg.ReverseFill,
+		RandomUA:         cloneRandomUAConfig(cfg.RandomUA),
+		Questions:        make([]QuestionPlan, 0, len(cfg.Questions)),
 	}
 	for _, question := range cfg.Questions {
 		if strings.TrimSpace(question.ID) == "" {
@@ -76,6 +94,9 @@ func (r *Runner) ValidatePlan(plan Plan) error {
 	if plan.Concurrency <= 0 {
 		return fmt.Errorf("concurrency must be greater than 0")
 	}
+	if plan.FailureThreshold < 0 {
+		return fmt.Errorf("failure threshold must not be negative")
+	}
 	return nil
 }
 
@@ -86,6 +107,20 @@ func cloneOptions(options map[string]any) map[string]any {
 	cloned := make(map[string]any, len(options))
 	for key, value := range options {
 		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneRandomUAConfig(cfg config.RandomUAConfig) config.RandomUAConfig {
+	cloned := cfg
+	if len(cfg.Keys) > 0 {
+		cloned.Keys = append([]string(nil), cfg.Keys...)
+	}
+	if len(cfg.Ratios) > 0 {
+		cloned.Ratios = make(map[string]int, len(cfg.Ratios))
+		for key, value := range cfg.Ratios {
+			cloned.Ratios[key] = value
+		}
 	}
 	return cloned
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -15,6 +15,19 @@ func TestCompilePlan(t *testing.T) {
 	cfg.Run.Target = 3
 	cfg.Run.Concurrency = 2
 	cfg.Run.Mode = engine.ModeBrowser
+	cfg.Run.FailureThreshold = 4
+	cfg.Run.FailStopEnabled = true
+	cfg.Run.Headless = false
+	cfg.Run.SubmitInterval = config.DurationRange{MinSeconds: 1, MaxSeconds: 2}
+	cfg.Run.AnswerDuration = config.DurationRange{MinSeconds: 10, MaxSeconds: 20}
+	cfg.Run.TimedMode = config.TimedModeConfig{Enabled: true, RefreshIntervalSeconds: 5}
+	cfg.Proxy = config.ProxyConfig{Enabled: true, Source: "custom", CustomAPI: "https://proxy.example/api", OccupyMinutes: 2}
+	cfg.ReverseFill = config.ReverseFillConfig{Enabled: true, SourcePath: "samples.xlsx", Format: "wjx_text", StartRow: 2}
+	cfg.RandomUA = config.RandomUAConfig{
+		Enabled: true,
+		Keys:    []string{"wechat", "pc"},
+		Ratios:  map[string]int{"wechat": 60, "pc": 40},
+	}
 	cfg.Questions = []config.QuestionConfig{
 		{
 			ID:       " q1 ",
@@ -41,6 +54,21 @@ func TestCompilePlan(t *testing.T) {
 	}
 	if plan.Target != 3 || plan.Concurrency != 2 {
 		t.Fatalf("target/concurrency = %d/%d, want 3/2", plan.Target, plan.Concurrency)
+	}
+	if plan.FailureThreshold != 4 || !plan.FailStopEnabled || plan.Headless {
+		t.Fatalf("runtime flags = %+v, want failure threshold 4 fail-stop true headless false", plan)
+	}
+	if plan.SubmitInterval.MinSeconds != 1 || plan.AnswerDuration.MaxSeconds != 20 || !plan.TimedMode.Enabled {
+		t.Fatalf("runtime timing = %+v/%+v/%+v, want configured timing", plan.SubmitInterval, plan.AnswerDuration, plan.TimedMode)
+	}
+	if !plan.Proxy.Enabled || plan.Proxy.Source != "custom" || plan.Proxy.OccupyMinutes != 2 {
+		t.Fatalf("Proxy = %+v, want custom proxy", plan.Proxy)
+	}
+	if !plan.ReverseFill.Enabled || plan.ReverseFill.Format != "wjx_text" {
+		t.Fatalf("ReverseFill = %+v, want configured reverse fill", plan.ReverseFill)
+	}
+	if !plan.RandomUA.Enabled || plan.RandomUA.Ratios["wechat"] != 60 {
+		t.Fatalf("RandomUA = %+v, want configured random ua", plan.RandomUA)
 	}
 	if len(plan.Questions) != 1 || plan.Questions[0].ID != "q1" {
 		t.Fatalf("Questions = %+v, want q1", plan.Questions)
@@ -70,6 +98,27 @@ func TestCompilePlanClonesQuestionOptions(t *testing.T) {
 	}
 }
 
+func TestCompilePlanClonesRandomUAConfig(t *testing.T) {
+	cfg := config.DefaultRunConfig()
+	cfg.Survey.URL = "https://example.com/survey"
+	cfg.Survey.Provider = "mock"
+	cfg.RandomUA = config.RandomUAConfig{
+		Enabled: true,
+		Keys:    []string{"wechat"},
+		Ratios:  map[string]int{"wechat": 100},
+	}
+
+	plan, err := CompilePlan(cfg)
+	if err != nil {
+		t.Fatalf("CompilePlan() returned error: %v", err)
+	}
+	cfg.RandomUA.Keys[0] = "pc"
+	cfg.RandomUA.Ratios["wechat"] = 1
+	if plan.RandomUA.Keys[0] != "wechat" || plan.RandomUA.Ratios["wechat"] != 100 {
+		t.Fatalf("compiled random ua changed after source mutation: %+v", plan.RandomUA)
+	}
+}
+
 func TestCompilePlanRejectsInvalidQuestion(t *testing.T) {
 	cfg := config.DefaultRunConfig()
 	cfg.Survey.URL = "https://example.com/survey"
@@ -92,6 +141,7 @@ func TestValidatePlanRejectsInvalidValues(t *testing.T) {
 		{name: "url", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", Target: 1, Concurrency: 1}, want: "url"},
 		{name: "target", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Concurrency: 1}, want: "target"},
 		{name: "concurrency", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Target: 1}, want: "concurrency"},
+		{name: "failure threshold", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Target: 1, Concurrency: 1, FailureThreshold: -1}, want: "failure threshold"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- extend the runtime config schema with failure-stop, headless, timing, proxy, reverse-fill, and random UA settings
- preserve defaults when optional runtime fields are omitted from YAML
- propagate the new runtime settings into runner plans with clone coverage for mutable random UA data

## Validation
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added failure handling controls with configurable failure threshold and fail-stop behavior
  * Added execution mode settings including headless mode support
  * Added timing constraint controls for submit interval and answer duration ranges
  * Introduced timed mode with configurable refresh intervals
  * Added proxy, reverse-fill, and random user-agent configuration sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->