### PR TITLE
feat: 增加 run dry-run 预检命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ go test ./...
 go vet ./...
 go run ./cmd/surveyctl version
 go run ./cmd/surveyctl config validate examples/run.yaml
+go run ./cmd/surveyctl run --dry-run examples/run.yaml
 go run ./cmd/surveyctl doctor
 go run ./cmd/surveyctl doctor browser
 ```

--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/LING71671/SurveyController-go/internal/config"
 	"github.com/LING71671/SurveyController-go/internal/doctor"
+	"github.com/LING71671/SurveyController-go/internal/runner"
 	"github.com/LING71671/SurveyController-go/internal/version"
 )
 
@@ -18,12 +20,14 @@ const usage = `surveyctl is the SurveyController-go command line tool.
 Usage:
   surveyctl version
   surveyctl config validate [path]
+  surveyctl run --dry-run [path] [--json]
   surveyctl doctor [browser]
   surveyctl help
 
 Commands:
   version          Print build version
   config validate  Validate a run configuration file
+  run              Compile and preview a run plan
   doctor           Run local environment checks
   help             Print this help message
 `
@@ -34,6 +38,10 @@ const configUsage = `Usage:
 
 const doctorUsage = `Usage:
   surveyctl doctor [browser [--probe]]
+`
+
+const runUsage = `Usage:
+  surveyctl run --dry-run [path] [--json]
 `
 
 const (
@@ -88,6 +96,8 @@ func execute(args []string, stdout io.Writer) error {
 		return nil
 	case "config":
 		return runConfig(args[1:], stdout)
+	case "run":
+		return runRun(args[1:], stdout)
 	case "doctor":
 		return runDoctor(args[1:], stdout)
 	default:
@@ -121,6 +131,52 @@ func runConfig(args []string, stdout io.Writer) error {
 	}
 }
 
+func runRun(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return usageError("run requires --dry-run until execution is implemented", runUsage)
+	}
+	dryRun := false
+	jsonOutput := false
+	path := "survey.yaml"
+	pathSet := false
+	for _, arg := range args {
+		normalized := strings.ToLower(strings.TrimSpace(arg))
+		switch normalized {
+		case "":
+			continue
+		case "help", "-h", "--help":
+			fmt.Fprint(stdout, runUsage)
+			return nil
+		case "--dry-run":
+			dryRun = true
+		case "--json":
+			jsonOutput = true
+		default:
+			if pathSet {
+				return usageError("run accepts at most one path", runUsage)
+			}
+			path = arg
+			pathSet = true
+		}
+	}
+	if !dryRun {
+		return usageError("run requires --dry-run until execution is implemented", runUsage)
+	}
+
+	cfg, err := config.LoadRunConfig(path)
+	if err != nil {
+		return commandError(exitFailure, fmt.Sprintf("run dry-run failed: %v", err), "")
+	}
+	plan, err := runner.CompilePlan(cfg)
+	if err != nil {
+		return commandError(exitFailure, fmt.Sprintf("run dry-run failed: %v", err), "")
+	}
+	if err := printDryRunPlan(stdout, path, plan, jsonOutput); err != nil {
+		return err
+	}
+	return nil
+}
+
 func runDoctor(args []string, stdout io.Writer) error {
 	if len(args) > 0 {
 		switch strings.ToLower(strings.TrimSpace(args[0])) {
@@ -144,6 +200,61 @@ func runDoctor(args []string, stdout io.Writer) error {
 	}
 	fmt.Fprintln(stdout, "doctor checks: ok")
 	fmt.Fprintln(stdout, "run `surveyctl doctor browser` for browser preflight checks")
+	return nil
+}
+
+type dryRunPlanSummary struct {
+	Path             string `json:"path"`
+	Provider         string `json:"provider"`
+	URL              string `json:"url"`
+	Mode             string `json:"mode"`
+	Target           int    `json:"target"`
+	Concurrency      int    `json:"concurrency"`
+	FailureThreshold int    `json:"failure_threshold"`
+	FailStopEnabled  bool   `json:"fail_stop_enabled"`
+	Headless         bool   `json:"headless"`
+	QuestionCount    int    `json:"question_count"`
+	ProxyEnabled     bool   `json:"proxy_enabled"`
+	ReverseFill      bool   `json:"reverse_fill_enabled"`
+	RandomUA         bool   `json:"random_ua_enabled"`
+}
+
+func printDryRunPlan(stdout io.Writer, path string, plan runner.Plan, jsonOutput bool) error {
+	summary := dryRunPlanSummary{
+		Path:             path,
+		Provider:         plan.Provider,
+		URL:              plan.URL,
+		Mode:             plan.Mode.String(),
+		Target:           plan.Target,
+		Concurrency:      plan.Concurrency,
+		FailureThreshold: plan.FailureThreshold,
+		FailStopEnabled:  plan.FailStopEnabled,
+		Headless:         plan.Headless,
+		QuestionCount:    len(plan.Questions),
+		ProxyEnabled:     plan.Proxy.Enabled,
+		ReverseFill:      plan.ReverseFill.Enabled,
+		RandomUA:         plan.RandomUA.Enabled,
+	}
+	if jsonOutput {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		return encoder.Encode(summary)
+	}
+	fmt.Fprintln(stdout, "dry-run plan:")
+	fmt.Fprintf(stdout, "  path: %s\n", summary.Path)
+	fmt.Fprintf(stdout, "  provider: %s\n", summary.Provider)
+	fmt.Fprintf(stdout, "  url: %s\n", summary.URL)
+	fmt.Fprintf(stdout, "  mode: %s\n", summary.Mode)
+	fmt.Fprintf(stdout, "  target: %d\n", summary.Target)
+	fmt.Fprintf(stdout, "  concurrency: %d\n", summary.Concurrency)
+	fmt.Fprintf(stdout, "  failure_threshold: %d\n", summary.FailureThreshold)
+	fmt.Fprintf(stdout, "  fail_stop_enabled: %t\n", summary.FailStopEnabled)
+	fmt.Fprintf(stdout, "  headless: %t\n", summary.Headless)
+	fmt.Fprintf(stdout, "  questions: %d\n", summary.QuestionCount)
+	fmt.Fprintf(stdout, "  proxy_enabled: %t\n", summary.ProxyEnabled)
+	fmt.Fprintf(stdout, "  reverse_fill_enabled: %t\n", summary.ReverseFill)
+	fmt.Fprintf(stdout, "  random_ua_enabled: %t\n", summary.RandomUA)
+	fmt.Fprintln(stdout, "  submissions: 0 (dry run)")
 	return nil
 }
 

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +33,7 @@ func TestRunHelpListsV02CommandStubs(t *testing.T) {
 	if code != exitOK {
 		t.Fatalf("run(help) exit code = %d, want %d", code, exitOK)
 	}
-	for _, want := range []string{"config validate", "doctor", "version"} {
+	for _, want := range []string{"config validate", "doctor", "run", "version"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("help output = %q, want %q", stdout.String(), want)
 		}
@@ -64,6 +65,109 @@ questions: []
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunDryRunPrintsPlanSummary(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 2
+  concurrency: 2
+  mode: browser
+  failure_threshold: 3
+  headless: false
+questions:
+  - id: q1
+    kind: single
+`)
+
+	code := run([]string{"run", "--dry-run", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(dry-run) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	for _, want := range []string{"dry-run plan:", "provider: mock", "mode: browser", "target: 2", "questions: 1", "submissions: 0"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunDryRunJSONPrintsPlanSummary(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: hybrid
+questions: []
+`)
+
+	code := run([]string{"run", "--dry-run", "--json", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(dry-run json) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	var summary map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("json output decode failed: %v; output=%q", err, stdout.String())
+	}
+	if summary["provider"] != "mock" || summary["mode"] != "hybrid" || summary["question_count"] != float64(0) {
+		t.Fatalf("summary = %+v, want provider/mode/question count", summary)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunRequiresDryRun(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "survey.yaml"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(without dry-run) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "requires --dry-run") {
+		t.Fatalf("stderr = %q, want dry-run requirement", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunDryRunReportsInvalidConfig(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+run:
+  target: 1
+  concurrency: 1
+  mode: hybrid
+questions: []
+`)
+
+	code := run([]string{"run", "--dry-run", path}, &stdout, &stderr)
+	if code != exitFailure {
+		t.Fatalf("run(dry-run invalid) exit code = %d, want %d", code, exitFailure)
+	}
+	if !strings.Contains(stderr.String(), "provider is required") {
+		t.Fatalf("stderr = %q, want provider error", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `surveyctl run --dry-run [path] [--json]` to compile and preview run plans without executing submissions
- print text and JSON summaries for provider, URL, mode, target, concurrency, failure-stop settings, questions, and resource toggles
- document the dry-run command in the README quick-start flow

## Safety
- dry-run only reads local config and compiles the runner plan
- it does not start a browser, access the network, or submit questionnaires

## Validation
- go test ./cmd/surveyctl ./internal/runner ./internal/config -count=1
- go run ./cmd/surveyctl run --dry-run examples/run.yaml
- go run ./cmd/surveyctl run --dry-run --json examples/run.yaml
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #15
