### PR TITLE
feat: run dry-run 支持 provider 自动识别

### DIFF
--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/LING71671/SurveyController-go/internal/config"
 	"github.com/LING71671/SurveyController-go/internal/doctor"
+	"github.com/LING71671/SurveyController-go/internal/provider/builtin"
 	"github.com/LING71671/SurveyController-go/internal/runner"
 	"github.com/LING71671/SurveyController-go/internal/version"
 )
@@ -166,6 +167,13 @@ func runRun(args []string, stdout io.Writer) error {
 	cfg, err := config.LoadRunConfig(path)
 	if err != nil {
 		return commandError(exitFailure, fmt.Sprintf("run dry-run failed: %v", err), "")
+	}
+	if strings.TrimSpace(cfg.Survey.Provider) == "" {
+		providerID, ok := builtin.DetectProvider(cfg.Survey.URL)
+		if !ok {
+			return commandError(exitFailure, fmt.Sprintf("run dry-run failed: provider is required or survey.url must match a built-in provider: %s", cfg.Survey.URL), "")
+		}
+		cfg.Survey.Provider = providerID.String()
 	}
 	plan, err := runner.CompilePlan(cfg)
 	if err != nil {

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -130,6 +130,57 @@ questions: []
 	}
 }
 
+func TestRunDryRunDetectsProviderFromURL(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://www.wjx.cn/vm/example.aspx"
+run:
+  target: 1
+  concurrency: 1
+  mode: hybrid
+questions: []
+`)
+
+	code := run([]string{"run", "--dry-run", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(dry-run detect provider) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "provider: wjx") {
+		t.Fatalf("stdout = %q, want detected wjx provider", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunDryRunKeepsExplicitProvider(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://www.wjx.cn/vm/example.aspx"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: hybrid
+questions: []
+`)
+
+	code := run([]string{"run", "--dry-run", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(dry-run explicit provider) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "provider: mock") {
+		t.Fatalf("stdout = %q, want explicit mock provider", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestRunRequiresDryRun(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -163,8 +214,8 @@ questions: []
 	if code != exitFailure {
 		t.Fatalf("run(dry-run invalid) exit code = %d, want %d", code, exitFailure)
 	}
-	if !strings.Contains(stderr.String(), "provider is required") {
-		t.Fatalf("stderr = %q, want provider error", stderr.String())
+	if !strings.Contains(stderr.String(), "survey.url must match a built-in provider") {
+		t.Fatalf("stderr = %q, want provider detection error", stderr.String())
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty", stdout.String())

--- a/internal/provider/builtin/registry.go
+++ b/internal/provider/builtin/registry.go
@@ -1,0 +1,28 @@
+package builtin
+
+import (
+	"github.com/LING71671/SurveyController-go/internal/provider"
+	"github.com/LING71671/SurveyController-go/internal/provider/credamo"
+	"github.com/LING71671/SurveyController-go/internal/provider/tencent"
+	"github.com/LING71671/SurveyController-go/internal/provider/wjx"
+)
+
+func NewRegistry() (*provider.Registry, error) {
+	return provider.NewRegistry(
+		wjx.Provider{},
+		tencent.Provider{},
+		credamo.Provider{},
+	)
+}
+
+func DetectProvider(rawURL string) (provider.ProviderID, bool) {
+	registry, err := NewRegistry()
+	if err != nil {
+		return "", false
+	}
+	matched, ok := registry.MatchURL(rawURL)
+	if !ok {
+		return "", false
+	}
+	return matched.ID(), true
+}

--- a/internal/provider/builtin/registry_test.go
+++ b/internal/provider/builtin/registry_test.go
@@ -1,0 +1,47 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/domain"
+)
+
+func TestDetectProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want domain.ProviderID
+	}{
+		{name: "wjx", url: "https://www.wjx.cn/vm/example.aspx", want: domain.ProviderWJX},
+		{name: "tencent", url: "https://wj.qq.com/s2/example", want: domain.ProviderTencent},
+		{name: "credamo", url: "https://www.credamo.com/s/example", want: domain.ProviderCredamo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := DetectProvider(tt.url)
+			if !ok || got != tt.want {
+				t.Fatalf("DetectProvider(%q) = (%q, %v), want (%q, true)", tt.url, got, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectProviderRejectsUnknownURL(t *testing.T) {
+	got, ok := DetectProvider("https://example.com/survey")
+	if ok || got != "" {
+		t.Fatalf("DetectProvider(unknown) = (%q, %v), want empty false", got, ok)
+	}
+}
+
+func TestNewRegistryContainsBuiltins(t *testing.T) {
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() returned error: %v", err)
+	}
+	for _, id := range []domain.ProviderID{domain.ProviderWJX, domain.ProviderTencent, domain.ProviderCredamo} {
+		if _, ok := registry.Get(id); !ok {
+			t.Fatalf("registry missing provider %q", id)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add an internal builtin provider registry for WJX, Tencent, and Credamo
- let `surveyctl run --dry-run` infer `survey.provider` from `survey.url` when the config omits it
- preserve explicit providers and return a clear dry-run error for unsupported URLs

## Safety
- provider detection only uses local URL matching
- dry-run still does not start a browser, access the network, or submit questionnaires

## Validation
- go test ./cmd/surveyctl ./internal/provider/builtin ./internal/provider ./internal/runner -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #17
