### PR TITLE
feat: 从 SurveyDefinition 生成默认运行配置

### DIFF
--- a/internal/config/generate.go
+++ b/internal/config/generate.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/LING71671/SurveyController-go/internal/domain"
+)
+
+func FromSurveyDefinition(survey domain.SurveyDefinition) (RunConfig, error) {
+	if err := survey.Validate(); err != nil {
+		return RunConfig{}, fmt.Errorf("survey definition: %w", err)
+	}
+
+	cfg := DefaultRunConfig()
+	cfg.Survey = SurveyConfig{
+		URL:      strings.TrimSpace(survey.URL),
+		Provider: survey.Provider.String(),
+	}
+	cfg.Questions = make([]QuestionConfig, 0, len(survey.Questions))
+	for _, question := range survey.Questions {
+		cfg.Questions = append(cfg.Questions, QuestionConfig{
+			ID:       strings.TrimSpace(question.ID),
+			Kind:     question.Kind.String(),
+			Required: question.Required,
+			Options:  map[string]any{},
+		})
+	}
+	if err := cfg.Validate(); err != nil {
+		return RunConfig{}, err
+	}
+	return cfg, nil
+}

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/domain"
+	"github.com/LING71671/SurveyController-go/internal/engine"
+)
+
+func TestFromSurveyDefinitionBuildsDefaultRunConfig(t *testing.T) {
+	survey := domain.SurveyDefinition{
+		Provider: domain.ProviderWJX,
+		Title:    "Customer survey",
+		URL:      " https://www.wjx.cn/vm/example.aspx ",
+		Questions: []domain.QuestionDefinition{
+			{
+				ID:       " q1 ",
+				Number:   1,
+				Title:    "Choose one",
+				Kind:     domain.QuestionKindSingle,
+				Required: true,
+			},
+			{
+				ID:     "q2",
+				Number: 2,
+				Title:  "Comment",
+				Kind:   domain.QuestionKindText,
+			},
+		},
+	}
+
+	cfg, err := FromSurveyDefinition(survey)
+	if err != nil {
+		t.Fatalf("FromSurveyDefinition() returned error: %v", err)
+	}
+	if cfg.SchemaVersion != CurrentSchemaVersion {
+		t.Fatalf("SchemaVersion = %d, want %d", cfg.SchemaVersion, CurrentSchemaVersion)
+	}
+	if cfg.Survey.URL != "https://www.wjx.cn/vm/example.aspx" || cfg.Survey.Provider != "wjx" {
+		t.Fatalf("Survey = %+v, want trimmed url and wjx provider", cfg.Survey)
+	}
+	if cfg.Run.Mode != engine.ModeHybrid || cfg.Run.Target != 1 || cfg.Run.Concurrency != 1 {
+		t.Fatalf("Run defaults = %+v, want hybrid target 1 concurrency 1", cfg.Run)
+	}
+	if len(cfg.Questions) != 2 {
+		t.Fatalf("len(Questions) = %d, want 2", len(cfg.Questions))
+	}
+	if cfg.Questions[0].ID != "q1" || cfg.Questions[0].Kind != "single" || !cfg.Questions[0].Required {
+		t.Fatalf("first question = %+v, want mapped fields", cfg.Questions[0])
+	}
+	if cfg.Questions[0].Options == nil {
+		t.Fatalf("first question options = nil, want editable empty map")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("generated config did not validate: %v", err)
+	}
+}
+
+func TestFromSurveyDefinitionRejectsInvalidSurveyDefinition(t *testing.T) {
+	_, err := FromSurveyDefinition(domain.SurveyDefinition{
+		Provider: domain.ProviderWJX,
+		URL:      "https://www.wjx.cn/vm/example.aspx",
+	})
+	if err == nil || !strings.Contains(err.Error(), "survey title") {
+		t.Fatalf("FromSurveyDefinition(invalid survey) error = %v, want survey title error", err)
+	}
+}
+
+func TestFromSurveyDefinitionRejectsMissingURL(t *testing.T) {
+	_, err := FromSurveyDefinition(domain.SurveyDefinition{
+		Provider: domain.ProviderTencent,
+		Title:    "Tencent survey",
+		Questions: []domain.QuestionDefinition{
+			{
+				ID:     "q1",
+				Number: 1,
+				Title:  "Choose one",
+				Kind:   domain.QuestionKindSingle,
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "survey.url") {
+		t.Fatalf("FromSurveyDefinition(missing url) error = %v, want survey.url error", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `config.FromSurveyDefinition` to generate default run config from the standard survey model
- map provider, URL, question id, kind, and required flags into a validated `RunConfig`
- keep the generator pure so future parser-to-config CLI work can reuse it without network/browser side effects

## Validation
- go test ./internal/config -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration generation capability with validation for survey definitions, including URL trimming and provider mapping.

* **Tests**
  * Comprehensive test coverage for configuration generation, validating schema versions, field mapping, and error handling for invalid survey inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->