### PR TITLE
feat: 增加 fixture 到运行配置的生成命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ go test ./...
 go vet ./...
 go run ./cmd/surveyctl version
 go run ./cmd/surveyctl config validate examples/run.yaml
+go run ./cmd/surveyctl config generate --provider wjx --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx
 go run ./cmd/surveyctl run --dry-run examples/run.yaml
 go run ./cmd/surveyctl doctor
 go run ./cmd/surveyctl doctor browser

--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -11,9 +11,14 @@ import (
 
 	"github.com/LING71671/SurveyController-go/internal/config"
 	"github.com/LING71671/SurveyController-go/internal/doctor"
+	"github.com/LING71671/SurveyController-go/internal/domain"
 	"github.com/LING71671/SurveyController-go/internal/provider/builtin"
+	"github.com/LING71671/SurveyController-go/internal/provider/credamo"
+	"github.com/LING71671/SurveyController-go/internal/provider/tencent"
+	"github.com/LING71671/SurveyController-go/internal/provider/wjx"
 	"github.com/LING71671/SurveyController-go/internal/runner"
 	"github.com/LING71671/SurveyController-go/internal/version"
+	"gopkg.in/yaml.v3"
 )
 
 const usage = `surveyctl is the SurveyController-go command line tool.
@@ -21,6 +26,7 @@ const usage = `surveyctl is the SurveyController-go command line tool.
 Usage:
   surveyctl version
   surveyctl config validate [path]
+  surveyctl config generate --provider <id> --fixture <path> --url <url>
   surveyctl run --dry-run [path] [--json]
   surveyctl doctor [browser]
   surveyctl help
@@ -28,6 +34,7 @@ Usage:
 Commands:
   version          Print build version
   config validate  Validate a run configuration file
+  config generate  Generate a run configuration from a local fixture
   run              Compile and preview a run plan
   doctor           Run local environment checks
   help             Print this help message
@@ -35,6 +42,7 @@ Commands:
 
 const configUsage = `Usage:
   surveyctl config validate [path]
+  surveyctl config generate --provider <id> --fixture <path> --url <url>
 `
 
 const doctorUsage = `Usage:
@@ -127,9 +135,107 @@ func runConfig(args []string, stdout io.Writer) error {
 		}
 		fmt.Fprintf(stdout, "config valid: %s\n", path)
 		return nil
+	case "generate":
+		return runConfigGenerate(args[1:], stdout)
 	default:
 		return usageError(fmt.Sprintf("unknown config command %q", args[0]), configUsage)
 	}
+}
+
+func runConfigGenerate(args []string, stdout io.Writer) error {
+	var providerID string
+	var fixturePath string
+	var rawURL string
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		switch strings.ToLower(arg) {
+		case "":
+			continue
+		case "help", "-h", "--help":
+			fmt.Fprint(stdout, configUsage)
+			return nil
+		case "--provider":
+			value, next, err := readFlagValue(args, i, "--provider")
+			if err != nil {
+				return err
+			}
+			providerID = value
+			i = next
+		case "--fixture":
+			value, next, err := readFlagValue(args, i, "--fixture")
+			if err != nil {
+				return err
+			}
+			fixturePath = value
+			i = next
+		case "--url":
+			value, next, err := readFlagValue(args, i, "--url")
+			if err != nil {
+				return err
+			}
+			rawURL = value
+			i = next
+		default:
+			return usageError(fmt.Sprintf("unknown config generate argument %q", arg), configUsage)
+		}
+	}
+	if strings.TrimSpace(providerID) == "" {
+		return usageError("config generate requires --provider", configUsage)
+	}
+	if strings.TrimSpace(fixturePath) == "" {
+		return usageError("config generate requires --fixture", configUsage)
+	}
+	if strings.TrimSpace(rawURL) == "" {
+		return usageError("config generate requires --url", configUsage)
+	}
+
+	cfg, err := generateConfigFromFixture(providerID, fixturePath, rawURL)
+	if err != nil {
+		return commandError(exitFailure, fmt.Sprintf("config generate failed: %v", err), "")
+	}
+	encoder := yaml.NewEncoder(stdout)
+	if err := encoder.Encode(cfg); err != nil {
+		_ = encoder.Close()
+		return err
+	}
+	return encoder.Close()
+}
+
+func generateConfigFromFixture(providerID string, fixturePath string, rawURL string) (config.RunConfig, error) {
+	id, err := domain.ParseProviderID(providerID)
+	if err != nil {
+		return config.RunConfig{}, err
+	}
+	file, err := os.Open(fixturePath)
+	if err != nil {
+		return config.RunConfig{}, fmt.Errorf("open fixture %q: %w", fixturePath, err)
+	}
+	defer file.Close()
+
+	var survey domain.SurveyDefinition
+	switch id {
+	case domain.ProviderWJX:
+		survey, err = wjx.ParseHTML(file, rawURL)
+	case domain.ProviderTencent:
+		survey, err = tencent.ParseAPI(file, rawURL)
+	case domain.ProviderCredamo:
+		survey, err = credamo.ParseSnapshot(file, rawURL)
+	default:
+		return config.RunConfig{}, fmt.Errorf("unsupported provider %q", providerID)
+	}
+	if err != nil {
+		return config.RunConfig{}, err
+	}
+	survey.URL = strings.TrimSpace(rawURL)
+	return config.FromSurveyDefinition(survey)
+}
+
+func readFlagValue(args []string, index int, flag string) (string, int, error) {
+	next := index + 1
+	if next >= len(args) || strings.TrimSpace(args[next]) == "" {
+		return "", index, usageError(fmt.Sprintf("%s requires a value", flag), configUsage)
+	}
+	return args[next], next, nil
 }
 
 func runRun(args []string, stdout io.Writer) error {

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/config"
+	"gopkg.in/yaml.v3"
 )
 
 func TestRunVersion(t *testing.T) {
@@ -33,7 +36,7 @@ func TestRunHelpListsV02CommandStubs(t *testing.T) {
 	if code != exitOK {
 		t.Fatalf("run(help) exit code = %d, want %d", code, exitOK)
 	}
-	for _, want := range []string{"config validate", "doctor", "run", "version"} {
+	for _, want := range []string{"config validate", "config generate", "doctor", "run", "version"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("help output = %q, want %q", stdout.String(), want)
 		}
@@ -65,6 +68,94 @@ questions: []
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunConfigGenerateFromFixtures(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		fixture  string
+		url      string
+	}{
+		{
+			name:     "wjx",
+			provider: "wjx",
+			fixture:  filepath.Join("..", "..", "internal", "provider", "wjx", "testdata", "survey.html"),
+			url:      "https://www.wjx.cn/vm/example.aspx",
+		},
+		{
+			name:     "tencent",
+			provider: "tencent",
+			fixture:  filepath.Join("..", "..", "internal", "provider", "tencent", "testdata", "survey_api.json"),
+			url:      "https://wj.qq.com/s2/example",
+		},
+		{
+			name:     "credamo",
+			provider: "credamo",
+			fixture:  filepath.Join("..", "..", "internal", "provider", "credamo", "testdata", "snapshot.json"),
+			url:      "https://www.credamo.com/s/example",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := run([]string{"config", "generate", "--provider", tt.provider, "--fixture", tt.fixture, "--url", tt.url}, &stdout, &stderr)
+			if code != exitOK {
+				t.Fatalf("run(config generate) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+			}
+			var cfg config.RunConfig
+			if err := yaml.Unmarshal(stdout.Bytes(), &cfg); err != nil {
+				t.Fatalf("decode generated yaml: %v; output=%q", err, stdout.String())
+			}
+			if cfg.Survey.Provider != tt.provider || cfg.Survey.URL != tt.url {
+				t.Fatalf("Survey = %+v, want provider %q url %q", cfg.Survey, tt.provider, tt.url)
+			}
+			if len(cfg.Questions) == 0 {
+				t.Fatalf("generated config has no questions: %+v", cfg)
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("generated config did not validate: %v", err)
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunConfigGenerateRequiresProvider(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"config", "generate", "--fixture", "survey.html", "--url", "https://example.com"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(config generate missing provider) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "requires --provider") {
+		t.Fatalf("stderr = %q, want provider requirement", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunConfigGenerateRejectsUnsupportedProvider(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"config", "generate", "--provider", "nope", "--fixture", "survey.html", "--url", "https://example.com"}, &stdout, &stderr)
+	if code != exitFailure {
+		t.Fatalf("run(config generate unsupported provider) exit code = %d, want %d", code, exitFailure)
+	}
+	if !strings.Contains(stderr.String(), "unsupported provider") {
+		t.Fatalf("stderr = %q, want unsupported provider", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `surveyctl config generate --provider <id> --fixture <path> --url <url>`
- wire the local WJX HTML, Tencent API JSON, and Credamo DOM snapshot parsers into config generation
- emit validated run config YAML to stdout and document the WJX fixture example in the README

## Safety
- generation only reads a local fixture file
- it does not access the network, start a browser, or submit questionnaires
- the CLI `--url` value is used as the generated config target URL even if a fixture embeds another URL

## Validation
- go test ./cmd/surveyctl -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...
- go run ./cmd/surveyctl config generate --provider wjx --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx

Closes #21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `config generate` subcommand that accepts provider, fixture, and URL parameters to generate configuration output as YAML.

* **Documentation**
  * Updated README with usage example for the new `config generate` command.

* **Tests**
  * Added comprehensive test coverage validating the new command's output and error handling for missing or invalid parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->