### PR TITLE
feat: 默认配置生成题目选项权重骨架

### DIFF
--- a/internal/config/generate.go
+++ b/internal/config/generate.go
@@ -23,11 +23,50 @@ func FromSurveyDefinition(survey domain.SurveyDefinition) (RunConfig, error) {
 			ID:       strings.TrimSpace(question.ID),
 			Kind:     question.Kind.String(),
 			Required: question.Required,
-			Options:  map[string]any{},
+			Options:  defaultQuestionOptions(question),
 		})
 	}
 	if err := cfg.Validate(); err != nil {
 		return RunConfig{}, err
 	}
 	return cfg, nil
+}
+
+func defaultQuestionOptions(question domain.QuestionDefinition) map[string]any {
+	options := map[string]any{}
+	if len(question.Options) > 0 {
+		options["weights"] = defaultOptionWeights(question.Options)
+	}
+	if len(question.Rows) > 0 && len(question.Options) > 0 {
+		rows := make([]map[string]any, 0, len(question.Rows))
+		for _, row := range question.Rows {
+			rowID := strings.TrimSpace(row.ID)
+			if rowID == "" {
+				continue
+			}
+			rows = append(rows, map[string]any{
+				"row_id":  rowID,
+				"weights": defaultOptionWeights(question.Options),
+			})
+		}
+		if len(rows) > 0 {
+			options["matrix_weights"] = rows
+		}
+	}
+	return options
+}
+
+func defaultOptionWeights(options []domain.OptionDefinition) []map[string]any {
+	weights := make([]map[string]any, 0, len(options))
+	for _, option := range options {
+		optionID := strings.TrimSpace(option.ID)
+		if optionID == "" {
+			continue
+		}
+		weights = append(weights, map[string]any{
+			"option_id": optionID,
+			"weight":    1,
+		})
+	}
+	return weights
 }

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -20,6 +20,10 @@ func TestFromSurveyDefinitionBuildsDefaultRunConfig(t *testing.T) {
 				Title:    "Choose one",
 				Kind:     domain.QuestionKindSingle,
 				Required: true,
+				Options: []domain.OptionDefinition{
+					{ID: "a", Label: "A"},
+					{ID: "b", Label: "B"},
+				},
 			},
 			{
 				ID:     "q2",
@@ -51,6 +55,62 @@ func TestFromSurveyDefinitionBuildsDefaultRunConfig(t *testing.T) {
 	}
 	if cfg.Questions[0].Options == nil {
 		t.Fatalf("first question options = nil, want editable empty map")
+	}
+	weights, ok := cfg.Questions[0].Options["weights"].([]map[string]any)
+	if !ok {
+		t.Fatalf("weights = %#v, want generated option weight maps", cfg.Questions[0].Options["weights"])
+	}
+	if len(weights) != 2 || weights[0]["option_id"] != "a" || weights[0]["weight"] != 1 {
+		t.Fatalf("weights = %+v, want default weights for options", weights)
+	}
+	if len(cfg.Questions[1].Options) != 0 {
+		t.Fatalf("text question options = %+v, want empty options", cfg.Questions[1].Options)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("generated config did not validate: %v", err)
+	}
+}
+
+func TestFromSurveyDefinitionBuildsMatrixWeightSkeleton(t *testing.T) {
+	survey := domain.SurveyDefinition{
+		Provider: domain.ProviderTencent,
+		Title:    "Matrix survey",
+		URL:      "https://wj.qq.com/s2/example",
+		Questions: []domain.QuestionDefinition{
+			{
+				ID:     "matrix1",
+				Number: 1,
+				Title:  "Matrix question",
+				Kind:   domain.QuestionKindMatrix,
+				Rows: []domain.OptionDefinition{
+					{ID: "row1", Label: "Row 1"},
+					{ID: "row2", Label: "Row 2"},
+				},
+				Options: []domain.OptionDefinition{
+					{ID: "opt1", Label: "Option 1"},
+					{ID: "opt2", Label: "Option 2"},
+				},
+			},
+		},
+	}
+
+	cfg, err := FromSurveyDefinition(survey)
+	if err != nil {
+		t.Fatalf("FromSurveyDefinition() returned error: %v", err)
+	}
+	matrixWeights, ok := cfg.Questions[0].Options["matrix_weights"].([]map[string]any)
+	if !ok {
+		t.Fatalf("matrix_weights = %#v, want generated matrix weight maps", cfg.Questions[0].Options["matrix_weights"])
+	}
+	if len(matrixWeights) != 2 || matrixWeights[0]["row_id"] != "row1" {
+		t.Fatalf("matrix_weights = %+v, want row weights", matrixWeights)
+	}
+	rowWeights, ok := matrixWeights[0]["weights"].([]map[string]any)
+	if !ok {
+		t.Fatalf("row weights = %#v, want option weight maps", matrixWeights[0]["weights"])
+	}
+	if len(rowWeights) != 2 || rowWeights[1]["option_id"] != "opt2" || rowWeights[1]["weight"] != 1 {
+		t.Fatalf("row weights = %+v, want default option weights", rowWeights)
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("generated config did not validate: %v", err)


### PR DESCRIPTION
## Summary
- add default `options.weights` skeletons when generating run config from parsed survey options
- add `options.matrix_weights` skeletons for row/option matrix questions
- keep text or option-less questions light with empty options

## Notes
- this only makes generated config easier to edit and closer to the original question wizard defaults
- it does not change runtime answer interpretation yet

## Validation
- go test ./internal/config -count=1
- go run ./cmd/surveyctl config generate --provider wjx --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Question configurations with options now automatically generate default weights, eliminating manual setup requirements
  * Matrix-type questions now properly initialize weight mappings for each row automatically, improving configuration reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->