### PR TITLE
feat: 解析题目配置中的选项权重

### DIFF
--- a/internal/config/weights.go
+++ b/internal/config/weights.go
@@ -1,0 +1,167 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/LING71671/SurveyController-go/internal/answer"
+)
+
+func QuestionOptionWeights(question QuestionConfig) ([]answer.OptionWeight, error) {
+	raw, ok := question.Options["weights"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	return parseOptionWeights(raw, "options.weights")
+}
+
+func QuestionMatrixWeights(question QuestionConfig) (map[string][]answer.OptionWeight, error) {
+	raw, ok := question.Options["matrix_weights"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	rows, err := asList(raw, "options.matrix_weights")
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("options.matrix_weights must not be empty")
+	}
+
+	result := make(map[string][]answer.OptionWeight, len(rows))
+	for index, rawRow := range rows {
+		name := fmt.Sprintf("options.matrix_weights[%d]", index)
+		row, err := asMap(rawRow, name)
+		if err != nil {
+			return nil, err
+		}
+		rowID, err := requiredString(row["row_id"], name+".row_id")
+		if err != nil {
+			return nil, err
+		}
+		weights, err := parseOptionWeights(row["weights"], name+".weights")
+		if err != nil {
+			return nil, err
+		}
+		result[rowID] = weights
+	}
+	return result, nil
+}
+
+func parseOptionWeights(raw any, name string) ([]answer.OptionWeight, error) {
+	items, err := asList(raw, name)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, fmt.Errorf("%s must not be empty", name)
+	}
+
+	weights := make([]answer.OptionWeight, 0, len(items))
+	for index, item := range items {
+		itemName := fmt.Sprintf("%s[%d]", name, index)
+		fields, err := asMap(item, itemName)
+		if err != nil {
+			return nil, err
+		}
+		optionID, err := requiredString(fields["option_id"], itemName+".option_id")
+		if err != nil {
+			return nil, err
+		}
+		weight, err := numeric(fields["weight"], itemName+".weight")
+		if err != nil {
+			return nil, err
+		}
+		if weight < 0 {
+			return nil, fmt.Errorf("%s.weight must not be negative", itemName)
+		}
+		weights = append(weights, answer.OptionWeight{
+			OptionID: optionID,
+			Weight:   weight,
+		})
+	}
+	return weights, nil
+}
+
+func asList(raw any, name string) ([]any, error) {
+	switch value := raw.(type) {
+	case []any:
+		return value, nil
+	case []map[string]any:
+		items := make([]any, 0, len(value))
+		for _, item := range value {
+			items = append(items, item)
+		}
+		return items, nil
+	default:
+		return nil, fmt.Errorf("%s must be a list", name)
+	}
+}
+
+func asMap(raw any, name string) (map[string]any, error) {
+	switch value := raw.(type) {
+	case map[string]any:
+		return value, nil
+	case map[any]any:
+		result := make(map[string]any, len(value))
+		for key, item := range value {
+			result[fmt.Sprint(key)] = item
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("%s must be an object", name)
+	}
+}
+
+func requiredString(raw any, name string) (string, error) {
+	value := strings.TrimSpace(fmt.Sprint(raw))
+	if value == "" || value == "<nil>" {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	return value, nil
+}
+
+func numeric(raw any, name string) (float64, error) {
+	switch value := raw.(type) {
+	case int:
+		return float64(value), nil
+	case int8:
+		return float64(value), nil
+	case int16:
+		return float64(value), nil
+	case int32:
+		return float64(value), nil
+	case int64:
+		return float64(value), nil
+	case uint:
+		return float64(value), nil
+	case uint8:
+		return float64(value), nil
+	case uint16:
+		return float64(value), nil
+	case uint32:
+		return float64(value), nil
+	case uint64:
+		return float64(value), nil
+	case float32:
+		return float64(value), nil
+	case float64:
+		return value, nil
+	case json.Number:
+		parsed, err := strconv.ParseFloat(value.String(), 64)
+		if err != nil {
+			return 0, fmt.Errorf("%s must be numeric", name)
+		}
+		return parsed, nil
+	case string:
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if err != nil {
+			return 0, fmt.Errorf("%s must be numeric", name)
+		}
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("%s must be numeric", name)
+	}
+}

--- a/internal/config/weights_test.go
+++ b/internal/config/weights_test.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestQuestionOptionWeightsParsesYAMLWeights(t *testing.T) {
+	cfg := loadConfigYAML(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: hybrid
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 2
+        - option_id: b
+          weight: 0.5
+`)
+
+	weights, err := QuestionOptionWeights(cfg.Questions[0])
+	if err != nil {
+		t.Fatalf("QuestionOptionWeights() returned error: %v", err)
+	}
+	if len(weights) != 2 || weights[0].OptionID != "a" || weights[0].Weight != 2 || weights[1].Weight != 0.5 {
+		t.Fatalf("weights = %+v, want parsed YAML weights", weights)
+	}
+}
+
+func TestQuestionOptionWeightsParsesJSONNumberWeights(t *testing.T) {
+	var question QuestionConfig
+	decoder := json.NewDecoder(strings.NewReader(`{
+		"id": "q1",
+		"options": {
+			"weights": [
+				{"option_id": "a", "weight": 3}
+			]
+		}
+	}`))
+	decoder.UseNumber()
+	if err := decoder.Decode(&question); err != nil {
+		t.Fatalf("decode question json: %v", err)
+	}
+
+	weights, err := QuestionOptionWeights(question)
+	if err != nil {
+		t.Fatalf("QuestionOptionWeights() returned error: %v", err)
+	}
+	if len(weights) != 1 || weights[0].OptionID != "a" || weights[0].Weight != 3 {
+		t.Fatalf("weights = %+v, want parsed JSON number weight", weights)
+	}
+}
+
+func TestQuestionOptionWeightsMissingReturnsNil(t *testing.T) {
+	weights, err := QuestionOptionWeights(QuestionConfig{ID: "q1", Options: map[string]any{}})
+	if err != nil {
+		t.Fatalf("QuestionOptionWeights() returned error: %v", err)
+	}
+	if weights != nil {
+		t.Fatalf("weights = %+v, want nil", weights)
+	}
+}
+
+func TestQuestionOptionWeightsRejectsInvalidWeights(t *testing.T) {
+	tests := []struct {
+		name     string
+		question QuestionConfig
+		want     string
+	}{
+		{
+			name:     "empty",
+			question: QuestionConfig{Options: map[string]any{"weights": []any{}}},
+			want:     "must not be empty",
+		},
+		{
+			name: "missing option id",
+			question: QuestionConfig{Options: map[string]any{"weights": []any{
+				map[string]any{"weight": 1},
+			}}},
+			want: "option_id",
+		},
+		{
+			name: "negative",
+			question: QuestionConfig{Options: map[string]any{"weights": []any{
+				map[string]any{"option_id": "a", "weight": -1},
+			}}},
+			want: "negative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := QuestionOptionWeights(tt.question)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("QuestionOptionWeights() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuestionMatrixWeightsParsesRows(t *testing.T) {
+	cfg := loadConfigYAML(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: hybrid
+questions:
+  - id: m1
+    kind: matrix
+    options:
+      matrix_weights:
+        - row_id: row1
+          weights:
+            - option_id: a
+              weight: 1
+            - option_id: b
+              weight: 2
+`)
+
+	matrix, err := QuestionMatrixWeights(cfg.Questions[0])
+	if err != nil {
+		t.Fatalf("QuestionMatrixWeights() returned error: %v", err)
+	}
+	rowWeights := matrix["row1"]
+	if len(rowWeights) != 2 || rowWeights[1].OptionID != "b" || rowWeights[1].Weight != 2 {
+		t.Fatalf("matrix weights = %+v, want row option weights", matrix)
+	}
+}
+
+func loadConfigYAML(t *testing.T, body string) RunConfig {
+	t.Helper()
+	cfg := DefaultRunConfig()
+	if err := yaml.Unmarshal([]byte(body), &cfg); err != nil {
+		t.Fatalf("decode config yaml: %v", err)
+	}
+	return cfg
+}


### PR DESCRIPTION
## Summary
- add config helpers to parse `options.weights` into `answer.OptionWeight`
- add matrix row weight parsing for `options.matrix_weights`
- support YAML/JSON decoded numeric forms and clear validation errors for empty, missing, or negative weights

## Notes
- this is a pure config-layer helper for the next answer-planning step
- it does not change current runner behavior

## Validation
- go test ./internal/config -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for option and matrix row weights in question configurations, with validation for numeric values and required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->