### PR TITLE
feat: 将题目权重编译进 RunPlan

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/LING71671/SurveyController-go/internal/answer"
 	"github.com/LING71671/SurveyController-go/internal/config"
 	"github.com/LING71671/SurveyController-go/internal/engine"
 )
@@ -27,10 +28,12 @@ type Plan struct {
 }
 
 type QuestionPlan struct {
-	ID       string
-	Kind     string
-	Required bool
-	Options  map[string]any
+	ID            string
+	Kind          string
+	Required      bool
+	Options       map[string]any
+	Weights       []answer.OptionWeight
+	MatrixWeights map[string][]answer.OptionWeight
 }
 
 type Runner struct{}
@@ -62,14 +65,25 @@ func CompilePlan(cfg config.RunConfig) (Plan, error) {
 		Questions:        make([]QuestionPlan, 0, len(cfg.Questions)),
 	}
 	for _, question := range cfg.Questions {
-		if strings.TrimSpace(question.ID) == "" {
+		questionID := strings.TrimSpace(question.ID)
+		if questionID == "" {
 			return Plan{}, fmt.Errorf("question id is required")
 		}
+		weights, err := config.QuestionOptionWeights(question)
+		if err != nil {
+			return Plan{}, fmt.Errorf("question %q option weights: %w", questionID, err)
+		}
+		matrixWeights, err := config.QuestionMatrixWeights(question)
+		if err != nil {
+			return Plan{}, fmt.Errorf("question %q matrix weights: %w", questionID, err)
+		}
 		plan.Questions = append(plan.Questions, QuestionPlan{
-			ID:       strings.TrimSpace(question.ID),
-			Kind:     strings.TrimSpace(question.Kind),
-			Required: question.Required,
-			Options:  cloneOptions(question.Options),
+			ID:            questionID,
+			Kind:          strings.TrimSpace(question.Kind),
+			Required:      question.Required,
+			Options:       cloneOptions(question.Options),
+			Weights:       weights,
+			MatrixWeights: matrixWeights,
 		})
 	}
 	if err := New().ValidatePlan(plan); err != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -98,6 +98,71 @@ func TestCompilePlanClonesQuestionOptions(t *testing.T) {
 	}
 }
 
+func TestCompilePlanParsesQuestionWeights(t *testing.T) {
+	cfg := config.DefaultRunConfig()
+	cfg.Survey.URL = "https://example.com/survey"
+	cfg.Survey.Provider = "mock"
+	cfg.Questions = []config.QuestionConfig{
+		{
+			ID:   "q1",
+			Kind: "single",
+			Options: map[string]any{
+				"weights": []any{
+					map[string]any{"option_id": "a", "weight": 2},
+					map[string]any{"option_id": "b", "weight": 1},
+				},
+			},
+		},
+		{
+			ID:   "m1",
+			Kind: "matrix",
+			Options: map[string]any{
+				"matrix_weights": []any{
+					map[string]any{
+						"row_id": "row1",
+						"weights": []any{
+							map[string]any{"option_id": "x", "weight": 1},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	plan, err := CompilePlan(cfg)
+	if err != nil {
+		t.Fatalf("CompilePlan() returned error: %v", err)
+	}
+	if len(plan.Questions[0].Weights) != 2 || plan.Questions[0].Weights[0].OptionID != "a" || plan.Questions[0].Weights[0].Weight != 2 {
+		t.Fatalf("Weights = %+v, want parsed option weights", plan.Questions[0].Weights)
+	}
+	rowWeights := plan.Questions[1].MatrixWeights["row1"]
+	if len(rowWeights) != 1 || rowWeights[0].OptionID != "x" || rowWeights[0].Weight != 1 {
+		t.Fatalf("MatrixWeights = %+v, want parsed row weights", plan.Questions[1].MatrixWeights)
+	}
+}
+
+func TestCompilePlanRejectsInvalidQuestionWeights(t *testing.T) {
+	cfg := config.DefaultRunConfig()
+	cfg.Survey.URL = "https://example.com/survey"
+	cfg.Survey.Provider = "mock"
+	cfg.Questions = []config.QuestionConfig{
+		{
+			ID: "q1",
+			Options: map[string]any{
+				"weights": []any{
+					map[string]any{"option_id": "a", "weight": -1},
+				},
+			},
+		},
+	}
+
+	_, err := CompilePlan(cfg)
+	if err == nil || !strings.Contains(err.Error(), `question "q1" option weights`) {
+		t.Fatalf("CompilePlan() error = %v, want question weight context", err)
+	}
+}
+
 func TestCompilePlanClonesRandomUAConfig(t *testing.T) {
 	cfg := config.DefaultRunConfig()
 	cfg.Survey.URL = "https://example.com/survey"


### PR DESCRIPTION
## Summary
- add typed option and matrix weights to `runner.QuestionPlan`
- compile configured weights via config-layer helpers during `CompilePlan`
- return question-id context when configured weights are invalid

## Notes
- this extends the parser fixture -> generated config -> config parse -> RunPlan chain
- it does not change execution behavior yet

## Validation
- go test ./internal/runner ./internal/config -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for weighted scoring on question options
  * Added support for matrix-based weighted options for complex question structures
  * Added validation to reject invalid weight values with clear error messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->