### PR TITLE
feat: runner 增加千并发调度上限与回归

### DIFF
--- a/internal/runner/pool.go
+++ b/internal/runner/pool.go
@@ -12,6 +12,8 @@ import (
 type Task func(ctx context.Context, workerID int) error
 type SubmissionTask func(ctx context.Context, workerID int) (engine.SubmissionResult, error)
 
+const DefaultMaxWorkerConcurrency = 1000
+
 type PoolOptions struct {
 	Concurrency      int
 	Target           int
@@ -27,6 +29,9 @@ type WorkerPool struct {
 func NewWorkerPool(options PoolOptions) (*WorkerPool, error) {
 	if options.Concurrency <= 0 {
 		return nil, fmt.Errorf("concurrency must be greater than 0")
+	}
+	if options.Concurrency > DefaultMaxWorkerConcurrency {
+		return nil, fmt.Errorf("concurrency must not exceed %d", DefaultMaxWorkerConcurrency)
 	}
 	if options.Target < 0 {
 		return nil, fmt.Errorf("target must not be negative")

--- a/internal/runner/pool_test.go
+++ b/internal/runner/pool_test.go
@@ -66,6 +66,24 @@ func TestWorkerPoolHonorsConcurrency(t *testing.T) {
 	}
 }
 
+func TestWorkerPoolSupportsThousandLightweightWorkers(t *testing.T) {
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: DefaultMaxWorkerConcurrency, Target: DefaultMaxWorkerConcurrency})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+	tasks := make([]Task, 0, DefaultMaxWorkerConcurrency)
+	for i := 0; i < DefaultMaxWorkerConcurrency; i++ {
+		tasks = append(tasks, func(context.Context, int) error {
+			return nil
+		})
+	}
+
+	snapshot := pool.Run(context.Background(), tasks)
+	if snapshot.Successes != DefaultMaxWorkerConcurrency || snapshot.Failures != 0 {
+		t.Fatalf("snapshot counts = %d/%d, want %d/0", snapshot.Successes, snapshot.Failures, DefaultMaxWorkerConcurrency)
+	}
+}
+
 func TestWorkerPoolStopsAtTarget(t *testing.T) {
 	pool, err := NewWorkerPool(PoolOptions{Concurrency: 1, Target: 2})
 	if err != nil {
@@ -215,6 +233,9 @@ func TestWorkerPoolRunSubmissionsRecordsTaskError(t *testing.T) {
 func TestNewWorkerPoolRejectsInvalidOptions(t *testing.T) {
 	if _, err := NewWorkerPool(PoolOptions{}); err == nil {
 		t.Fatal("NewWorkerPool(empty) returned nil error, want failure")
+	}
+	if _, err := NewWorkerPool(PoolOptions{Concurrency: DefaultMaxWorkerConcurrency + 1}); err == nil {
+		t.Fatal("NewWorkerPool(too much concurrency) returned nil error, want failure")
 	}
 	if _, err := NewWorkerPool(PoolOptions{Concurrency: 1, Target: -1}); err == nil {
 		t.Fatal("NewWorkerPool(negative target) returned nil error, want failure")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -108,6 +108,9 @@ func (r *Runner) ValidatePlan(plan Plan) error {
 	if plan.Concurrency <= 0 {
 		return fmt.Errorf("concurrency must be greater than 0")
 	}
+	if plan.Concurrency > DefaultMaxWorkerConcurrency {
+		return fmt.Errorf("concurrency must not exceed %d", DefaultMaxWorkerConcurrency)
+	}
 	if plan.FailureThreshold < 0 {
 		return fmt.Errorf("failure threshold must not be negative")
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -206,6 +206,7 @@ func TestValidatePlanRejectsInvalidValues(t *testing.T) {
 		{name: "url", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", Target: 1, Concurrency: 1}, want: "url"},
 		{name: "target", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Concurrency: 1}, want: "target"},
 		{name: "concurrency", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Target: 1}, want: "concurrency"},
+		{name: "max concurrency", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Target: 1, Concurrency: DefaultMaxWorkerConcurrency + 1}, want: "concurrency"},
 		{name: "failure threshold", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Target: 1, Concurrency: 1, FailureThreshold: -1}, want: "failure threshold"},
 	}
 


### PR DESCRIPTION
## Summary
- add `runner.DefaultMaxWorkerConcurrency` set to 1000
- reject worker pool and run plan concurrency above the bounded runner limit
- add a regression test that schedules 1000 lightweight workers/tasks successfully

## Notes
- 1000 is the runner lightweight scheduling baseline, not a browser-session limit
- browser, HTTP transport, proxy, and provider-specific resource pools will still apply tighter limits later
- future animations/visualization should live in CLI/UI layers, not core runner logic

## Validation
- go test ./internal/runner -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #29
