### PR TITLE
feat: 增加执行模式并发 profile

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,6 +131,16 @@ type ProviderRunner interface {
 - `hybrid` 也必须由 provider 显式声明支持。
 - provider 必须给出失败原因，例如“不支持 HTTP 提交”“需要登录”“命中验证”。
 
+## 执行模式资源 Profile
+
+高并发目标不能依赖浏览器堆数量。Go 版的核心路线是 HTTP-first：
+
+- `http`：轻量高并发主路径，当前 runner 已验证 1000 worker 调度基线，后续通过 benchmark 和资源池继续上调。
+- `hybrid`：优先 HTTP；只在 provider 明确需要时使用小规模 browser 兜底。
+- `browser`：兼容性路径，不作为高并发主线，默认按小池限制。
+
+这些 profile 是 core 层资源边界，不是 UI 建议值。未来轻量 GUI 或 TUI 可以做更漂亮的实时动画、worker 流、成功率面板，但不能把动画和桌面依赖带入 runner/provider/answer 热路径。
+
 ## Runner 设计
 
 Runner 只处理任务生命周期：

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -189,8 +189,12 @@ func (c RuntimeConfig) Validate() error {
 	if c.FailureThreshold < 0 {
 		return fmt.Errorf("run.failure_threshold must not be negative")
 	}
-	if _, err := engine.ParseMode(c.Mode.String()); err != nil {
+	mode, err := engine.ParseMode(c.Mode.String())
+	if err != nil {
 		return fmt.Errorf("run.mode: %w", err)
+	}
+	if err := engine.ValidateConcurrency(mode, c.Concurrency); err != nil {
+		return fmt.Errorf("run.concurrency: %w", err)
 	}
 	if err := c.SubmitInterval.Validate("run.submit_interval"); err != nil {
 		return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -188,6 +188,15 @@ func TestRuntimeConfigValidationRejectsInvalidValues(t *testing.T) {
 			want: "run.mode",
 		},
 		{
+			name: "browser concurrency profile",
+			cfg: RuntimeConfig{
+				Target:      1,
+				Concurrency: engine.BrowserWorkerConcurrencyLimit + 1,
+				Mode:        engine.ModeBrowser,
+			},
+			want: "run.concurrency",
+		},
+		{
 			name: "failure threshold",
 			cfg: RuntimeConfig{
 				Target:           1,
@@ -214,6 +223,21 @@ func TestRuntimeConfigValidationRejectsInvalidValues(t *testing.T) {
 			err := tt.cfg.Validate()
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("Validate() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRuntimeConfigValidationAllowsLightConcurrencyProfiles(t *testing.T) {
+	for _, mode := range []engine.Mode{engine.ModeHTTP, engine.ModeHybrid} {
+		t.Run(mode.String(), func(t *testing.T) {
+			cfg := RuntimeConfig{
+				Target:      1,
+				Concurrency: engine.LightWorkerConcurrencyBaseline,
+				Mode:        mode,
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate() returned error: %v", err)
 			}
 		})
 	}

--- a/internal/engine/profile.go
+++ b/internal/engine/profile.go
@@ -1,0 +1,59 @@
+package engine
+
+import "fmt"
+
+const (
+	LightWorkerConcurrencyBaseline = 1000
+	BrowserWorkerConcurrencyLimit  = 16
+)
+
+type ConcurrencyProfile struct {
+	Mode                 Mode
+	MaxWorkerConcurrency int
+	MaxBrowserSessions   int
+	HTTPFirst            bool
+}
+
+func ModeConcurrencyProfile(mode Mode) (ConcurrencyProfile, error) {
+	parsed, err := ParseMode(mode.String())
+	if err != nil {
+		return ConcurrencyProfile{}, err
+	}
+	switch parsed {
+	case ModeHTTP:
+		return ConcurrencyProfile{
+			Mode:                 ModeHTTP,
+			MaxWorkerConcurrency: LightWorkerConcurrencyBaseline,
+			HTTPFirst:            true,
+		}, nil
+	case ModeHybrid:
+		return ConcurrencyProfile{
+			Mode:                 ModeHybrid,
+			MaxWorkerConcurrency: LightWorkerConcurrencyBaseline,
+			MaxBrowserSessions:   BrowserWorkerConcurrencyLimit,
+			HTTPFirst:            true,
+		}, nil
+	case ModeBrowser:
+		return ConcurrencyProfile{
+			Mode:                 ModeBrowser,
+			MaxWorkerConcurrency: BrowserWorkerConcurrencyLimit,
+			MaxBrowserSessions:   BrowserWorkerConcurrencyLimit,
+		}, nil
+	default:
+		return ConcurrencyProfile{}, fmt.Errorf("unsupported engine mode %q", mode)
+	}
+}
+
+func ValidateConcurrency(mode Mode, concurrency int) error {
+	if concurrency <= 0 {
+		return fmt.Errorf("concurrency must be greater than 0")
+	}
+	profile, err := ModeConcurrencyProfile(mode)
+	if err != nil {
+		return err
+	}
+	if concurrency > profile.MaxWorkerConcurrency {
+		return fmt.Errorf("%s mode concurrency must not exceed %d", profile.Mode, profile.MaxWorkerConcurrency)
+	}
+	return nil
+}

--- a/internal/engine/profile_test.go
+++ b/internal/engine/profile_test.go
@@ -1,0 +1,62 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestModeConcurrencyProfile(t *testing.T) {
+	tests := []struct {
+		mode                 Mode
+		maxWorkerConcurrency int
+		maxBrowserSessions   int
+		httpFirst            bool
+	}{
+		{mode: ModeHTTP, maxWorkerConcurrency: LightWorkerConcurrencyBaseline, httpFirst: true},
+		{mode: ModeHybrid, maxWorkerConcurrency: LightWorkerConcurrencyBaseline, maxBrowserSessions: BrowserWorkerConcurrencyLimit, httpFirst: true},
+		{mode: ModeBrowser, maxWorkerConcurrency: BrowserWorkerConcurrencyLimit, maxBrowserSessions: BrowserWorkerConcurrencyLimit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mode.String(), func(t *testing.T) {
+			profile, err := ModeConcurrencyProfile(tt.mode)
+			if err != nil {
+				t.Fatalf("ModeConcurrencyProfile() returned error: %v", err)
+			}
+			if profile.MaxWorkerConcurrency != tt.maxWorkerConcurrency || profile.MaxBrowserSessions != tt.maxBrowserSessions || profile.HTTPFirst != tt.httpFirst {
+				t.Fatalf("profile = %+v, want worker %d browser %d httpFirst %v", profile, tt.maxWorkerConcurrency, tt.maxBrowserSessions, tt.httpFirst)
+			}
+		})
+	}
+}
+
+func TestValidateConcurrency(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        Mode
+		concurrency int
+		wantErr     string
+	}{
+		{name: "http baseline", mode: ModeHTTP, concurrency: LightWorkerConcurrencyBaseline},
+		{name: "hybrid baseline", mode: ModeHybrid, concurrency: LightWorkerConcurrencyBaseline},
+		{name: "browser small pool", mode: ModeBrowser, concurrency: BrowserWorkerConcurrencyLimit},
+		{name: "browser too high", mode: ModeBrowser, concurrency: BrowserWorkerConcurrencyLimit + 1, wantErr: "browser mode"},
+		{name: "zero", mode: ModeHTTP, concurrency: 0, wantErr: "greater than 0"},
+		{name: "unsupported", mode: Mode("magic"), concurrency: 1, wantErr: "unsupported"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateConcurrency(tt.mode, tt.concurrency)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateConcurrency() returned error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateConcurrency() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/runner/pool.go
+++ b/internal/runner/pool.go
@@ -12,7 +12,7 @@ import (
 type Task func(ctx context.Context, workerID int) error
 type SubmissionTask func(ctx context.Context, workerID int) (engine.SubmissionResult, error)
 
-const DefaultMaxWorkerConcurrency = 1000
+const DefaultMaxWorkerConcurrency = engine.LightWorkerConcurrencyBaseline
 
 type PoolOptions struct {
 	Concurrency      int

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -93,7 +93,8 @@ func CompilePlan(cfg config.RunConfig) (Plan, error) {
 }
 
 func (r *Runner) ValidatePlan(plan Plan) error {
-	if _, err := engine.ParseMode(plan.Mode.String()); err != nil {
+	mode, err := engine.ParseMode(plan.Mode.String())
+	if err != nil {
 		return err
 	}
 	if strings.TrimSpace(plan.Provider) == "" {
@@ -108,8 +109,8 @@ func (r *Runner) ValidatePlan(plan Plan) error {
 	if plan.Concurrency <= 0 {
 		return fmt.Errorf("concurrency must be greater than 0")
 	}
-	if plan.Concurrency > DefaultMaxWorkerConcurrency {
-		return fmt.Errorf("concurrency must not exceed %d", DefaultMaxWorkerConcurrency)
+	if err := engine.ValidateConcurrency(mode, plan.Concurrency); err != nil {
+		return err
 	}
 	if plan.FailureThreshold < 0 {
 		return fmt.Errorf("failure threshold must not be negative")

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -207,6 +207,7 @@ func TestValidatePlanRejectsInvalidValues(t *testing.T) {
 		{name: "target", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Concurrency: 1}, want: "target"},
 		{name: "concurrency", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Target: 1}, want: "concurrency"},
 		{name: "max concurrency", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Target: 1, Concurrency: DefaultMaxWorkerConcurrency + 1}, want: "concurrency"},
+		{name: "browser concurrency profile", plan: Plan{Mode: engine.ModeBrowser, Provider: "mock", URL: "https://example.com", Target: 1, Concurrency: engine.BrowserWorkerConcurrencyLimit + 1}, want: "browser mode"},
 		{name: "failure threshold", plan: Plan{Mode: engine.ModeHybrid, Provider: "mock", URL: "https://example.com", Target: 1, Concurrency: 1, FailureThreshold: -1}, want: "failure threshold"},
 	}
 
@@ -215,6 +216,23 @@ func TestValidatePlanRejectsInvalidValues(t *testing.T) {
 			err := New().ValidatePlan(tt.plan)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("ValidatePlan() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidatePlanAllowsLightConcurrencyProfiles(t *testing.T) {
+	for _, mode := range []engine.Mode{engine.ModeHTTP, engine.ModeHybrid} {
+		t.Run(mode.String(), func(t *testing.T) {
+			plan := Plan{
+				Mode:        mode,
+				Provider:    "mock",
+				URL:         "https://example.com",
+				Target:      1,
+				Concurrency: DefaultMaxWorkerConcurrency,
+			}
+			if err := New().ValidatePlan(plan); err != nil {
+				t.Fatalf("ValidatePlan() returned error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add engine-level concurrency profiles for `http`, `hybrid`, and `browser` modes
- keep HTTP/Hybrid on the current 1000 lightweight worker baseline while limiting Browser to a small compatibility pool
- reuse the same profile validation from config and runner so CLI config and RunPlan stay aligned
- document the HTTP-first/resource-profile architecture stance

## Notes
- 1000 remains the current tested lightweight scheduling baseline, not the long-term ceiling
- browser is not the high-concurrency route; it stays a compatibility/fallback path
- future CLI/TUI/GUI animation should sit above core and not enter runner/provider hot paths

## Validation
- go test ./internal/engine ./internal/config ./internal/runner -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #31


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture documentation to clarify execution mode resource profiles (HTTP, Hybrid, Browser) with HTTP-first approach and resource boundaries.

* **Improvements**
  * Enhanced runtime concurrency validation to enforce mode-specific limits; browser mode now capped at 16 concurrent workers, HTTP/Hybrid modes use baseline limits.

* **Tests**
  * Added comprehensive test coverage for concurrency validation across execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->