### PR TITLE
feat: 增加 WJX HTTP 提交草稿构建器

### DIFF
--- a/internal/provider/wjx/http_submit.go
+++ b/internal/provider/wjx/http_submit.go
@@ -1,0 +1,101 @@
+package wjx
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+)
+
+const processJQPath = "/joinnew/processjq.ashx"
+
+type HTTPSubmissionDraft struct {
+	Method   string
+	Endpoint string
+	Header   http.Header
+	Form     url.Values
+	SurveyID string
+}
+
+func BuildHTTPSubmissionDraft(rawSurveyURL string, answers map[string]string) (HTTPSubmissionDraft, error) {
+	if !(Provider{}).MatchURL(rawSurveyURL) {
+		return HTTPSubmissionDraft{}, fmt.Errorf("wjx url is required")
+	}
+	surveyID, err := ExtractSurveyID(rawSurveyURL)
+	if err != nil {
+		return HTTPSubmissionDraft{}, err
+	}
+	if len(answers) == 0 {
+		return HTTPSubmissionDraft{}, fmt.Errorf("answers are required")
+	}
+
+	endpoint, err := processEndpoint(rawSurveyURL)
+	if err != nil {
+		return HTTPSubmissionDraft{}, err
+	}
+	form := url.Values{}
+	form.Set("curID", surveyID)
+	form.Set("submittype", "1")
+	for _, key := range sortedKeys(answers) {
+		value := strings.TrimSpace(answers[key])
+		if strings.TrimSpace(key) == "" {
+			return HTTPSubmissionDraft{}, fmt.Errorf("answer key is required")
+		}
+		form.Set(strings.TrimSpace(key), value)
+	}
+
+	return HTTPSubmissionDraft{
+		Method:   http.MethodPost,
+		Endpoint: endpoint,
+		Header: http.Header{
+			"Content-Type": []string{"application/x-www-form-urlencoded"},
+			"Referer":      []string{strings.TrimSpace(rawSurveyURL)},
+		},
+		Form:     form,
+		SurveyID: surveyID,
+	}, nil
+}
+
+func ExtractSurveyID(rawSurveyURL string) (string, error) {
+	parsed, err := url.Parse(rawSurveyURL)
+	if err != nil {
+		return "", fmt.Errorf("parse wjx url: %w", err)
+	}
+	base := path.Base(parsed.EscapedPath())
+	if base == "." || base == "/" || base == "" {
+		return "", fmt.Errorf("survey id is required")
+	}
+	id := strings.TrimSuffix(base, path.Ext(base))
+	id, err = url.PathUnescape(id)
+	if err != nil {
+		return "", fmt.Errorf("decode survey id: %w", err)
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("survey id is required")
+	}
+	return id, nil
+}
+
+func processEndpoint(rawSurveyURL string) (string, error) {
+	parsed, err := url.Parse(rawSurveyURL)
+	if err != nil {
+		return "", fmt.Errorf("parse wjx url: %w", err)
+	}
+	parsed.Path = processJQPath
+	parsed.RawPath = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func sortedKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/provider/wjx/http_submit_test.go
+++ b/internal/provider/wjx/http_submit_test.go
@@ -1,0 +1,81 @@
+package wjx
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestBuildHTTPSubmissionDraft(t *testing.T) {
+	draft, err := BuildHTTPSubmissionDraft("https://www.wjx.cn/vm/example.aspx", map[string]string{
+		"q1": "a",
+		"q2": "b,c",
+	})
+	if err != nil {
+		t.Fatalf("BuildHTTPSubmissionDraft() returned error: %v", err)
+	}
+	if draft.Method != http.MethodPost {
+		t.Fatalf("Method = %q, want POST", draft.Method)
+	}
+	if draft.Endpoint != "https://www.wjx.cn/joinnew/processjq.ashx" {
+		t.Fatalf("Endpoint = %q, want processjq endpoint", draft.Endpoint)
+	}
+	if draft.SurveyID != "example" || draft.Form.Get("curID") != "example" {
+		t.Fatalf("survey id/form = %q/%q, want example", draft.SurveyID, draft.Form.Get("curID"))
+	}
+	if draft.Form.Get("submittype") != "1" || draft.Form.Get("q1") != "a" || draft.Form.Get("q2") != "b,c" {
+		t.Fatalf("Form = %+v, want submit type and answers", draft.Form)
+	}
+	if draft.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+		t.Fatalf("Content-Type = %q, want form encoding", draft.Header.Get("Content-Type"))
+	}
+	if draft.Header.Get("Referer") != "https://www.wjx.cn/vm/example.aspx" {
+		t.Fatalf("Referer = %q, want survey url", draft.Header.Get("Referer"))
+	}
+}
+
+func TestBuildHTTPSubmissionDraftSupportsVJPath(t *testing.T) {
+	draft, err := BuildHTTPSubmissionDraft("https://sub.wjx.top/vj/abc123.aspx?from=qr", map[string]string{"q1": "x"})
+	if err != nil {
+		t.Fatalf("BuildHTTPSubmissionDraft() returned error: %v", err)
+	}
+	if draft.SurveyID != "abc123" {
+		t.Fatalf("SurveyID = %q, want abc123", draft.SurveyID)
+	}
+	if draft.Endpoint != "https://sub.wjx.top/joinnew/processjq.ashx" {
+		t.Fatalf("Endpoint = %q, want query-free process endpoint", draft.Endpoint)
+	}
+}
+
+func TestBuildHTTPSubmissionDraftRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		answers map[string]string
+		want    string
+	}{
+		{name: "host", rawURL: "https://example.com/vm/demo.aspx", answers: map[string]string{"q1": "a"}, want: "wjx url"},
+		{name: "survey id", rawURL: "https://www.wjx.cn/", answers: map[string]string{"q1": "a"}, want: "survey id"},
+		{name: "answers", rawURL: "https://www.wjx.cn/vm/demo.aspx", want: "answers"},
+		{name: "answer key", rawURL: "https://www.wjx.cn/vm/demo.aspx", answers: map[string]string{" ": "a"}, want: "answer key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := BuildHTTPSubmissionDraft(tt.rawURL, tt.answers)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("BuildHTTPSubmissionDraft() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractSurveyID(t *testing.T) {
+	got, err := ExtractSurveyID("https://www.wjx.cn/vm/demo%201.aspx")
+	if err != nil {
+		t.Fatalf("ExtractSurveyID() returned error: %v", err)
+	}
+	if got != "demo 1" {
+		t.Fatalf("ExtractSurveyID() = %q, want decoded id", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a WJX HTTP submission draft builder that prepares method, endpoint, headers, and form fields locally
- extract WJX survey IDs from `vm`/`vj` style URLs
- validate WJX hosts, survey IDs, answer fields, and preserve answer form data in a copied draft

## Safety
- this does not execute network requests
- this does not start a browser
- `Capabilities().SubmitHTTP` remains disabled until an executor, mock path, and submission detection chain are in place

## Validation
- go test ./internal/provider/wjx -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #33


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WJX survey submission functionality with automatic URL parsing and survey ID extraction.
  * Implemented form construction and request validation for HTTP-based survey submissions.

* **Tests**
  * Added comprehensive test coverage for submission workflows, including validation of URLs, survey identifiers, form data, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->