### PR TITLE
feat: 增加 WJX HTTP mock executor

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -233,6 +233,16 @@
 - `hybrid` 模式能力选择。
 - provider runner/detector 契约。
 
+### Phase 1.5：HTTP-first 高并发主路径
+
+- WJX HTTP submission draft。
+- WJX HTTP mock executor，不访问网络。
+- WJX HTTP response detector。
+- AnswerPlan 最小闭环，先覆盖单选、多选、评分/量表。
+- HTTP path benchmark，覆盖 1000、5000 轻量任务和分配基线。
+- Provider capability gate：只有显式 `SubmitHTTP` 才允许 `http` 模式真实执行。
+- Browser 保持小池兼容兜底，不作为高并发主线。
+
 ### Phase 2：提交判定
 
 - 完成页识别。

--- a/internal/provider/wjx/http_submit_executor.go
+++ b/internal/provider/wjx/http_submit_executor.go
@@ -1,0 +1,89 @@
+package wjx
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type HTTPSubmissionResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       string
+}
+
+type HTTPSubmissionExecutor interface {
+	ExecuteHTTPSubmission(ctx context.Context, draft HTTPSubmissionDraft) (HTTPSubmissionResponse, error)
+}
+
+func ExecuteHTTPSubmission(ctx context.Context, executor HTTPSubmissionExecutor, draft HTTPSubmissionDraft) (HTTPSubmissionResponse, error) {
+	if executor == nil {
+		return HTTPSubmissionResponse{}, fmt.Errorf("http submission executor is required")
+	}
+	if err := validateHTTPSubmissionDraft(draft); err != nil {
+		return HTTPSubmissionResponse{}, err
+	}
+	response, err := executor.ExecuteHTTPSubmission(ctx, cloneHTTPSubmissionDraft(draft))
+	if err != nil {
+		return HTTPSubmissionResponse{}, err
+	}
+	return cloneHTTPSubmissionResponse(response), nil
+}
+
+func validateHTTPSubmissionDraft(draft HTTPSubmissionDraft) error {
+	if strings.TrimSpace(draft.Method) == "" {
+		return fmt.Errorf("submission method is required")
+	}
+	if strings.TrimSpace(draft.Endpoint) == "" {
+		return fmt.Errorf("submission endpoint is required")
+	}
+	if strings.TrimSpace(draft.SurveyID) == "" {
+		return fmt.Errorf("survey id is required")
+	}
+	if len(draft.Form) == 0 {
+		return fmt.Errorf("submission form is required")
+	}
+	return nil
+}
+
+func cloneHTTPSubmissionDraft(draft HTTPSubmissionDraft) HTTPSubmissionDraft {
+	return HTTPSubmissionDraft{
+		Method:   draft.Method,
+		Endpoint: draft.Endpoint,
+		Header:   cloneHTTPHeader(draft.Header),
+		Form:     cloneURLValues(draft.Form),
+		SurveyID: draft.SurveyID,
+	}
+}
+
+func cloneHTTPSubmissionResponse(response HTTPSubmissionResponse) HTTPSubmissionResponse {
+	return HTTPSubmissionResponse{
+		StatusCode: response.StatusCode,
+		Header:     cloneHTTPHeader(response.Header),
+		Body:       response.Body,
+	}
+}
+
+func cloneHTTPHeader(header http.Header) http.Header {
+	if len(header) == 0 {
+		return nil
+	}
+	cloned := make(http.Header, len(header))
+	for key, values := range header {
+		cloned[key] = append([]string(nil), values...)
+	}
+	return cloned
+}
+
+func cloneURLValues(values url.Values) url.Values {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(url.Values, len(values))
+	for key, items := range values {
+		cloned[key] = append([]string(nil), items...)
+	}
+	return cloned
+}

--- a/internal/provider/wjx/http_submit_executor_test.go
+++ b/internal/provider/wjx/http_submit_executor_test.go
@@ -1,0 +1,119 @@
+package wjx
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestExecuteHTTPSubmissionUsesExecutor(t *testing.T) {
+	draft := mustDraft(t)
+	executor := &recordingHTTPSubmissionExecutor{
+		response: HTTPSubmissionResponse{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"X-Test": []string{"ok"}},
+			Body:       "success",
+		},
+	}
+
+	response, err := ExecuteHTTPSubmission(context.Background(), executor, draft)
+	if err != nil {
+		t.Fatalf("ExecuteHTTPSubmission() returned error: %v", err)
+	}
+	if response.StatusCode != http.StatusOK || response.Body != "success" || response.Header.Get("X-Test") != "ok" {
+		t.Fatalf("response = %+v, want configured mock response", response)
+	}
+	if len(executor.calls) != 1 || executor.calls[0].SurveyID != draft.SurveyID {
+		t.Fatalf("calls = %+v, want one cloned draft call", executor.calls)
+	}
+}
+
+func TestExecuteHTTPSubmissionRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		executor HTTPSubmissionExecutor
+		draft    HTTPSubmissionDraft
+		want     string
+	}{
+		{name: "executor", draft: mustDraft(t), want: "executor"},
+		{name: "method", executor: &recordingHTTPSubmissionExecutor{}, draft: HTTPSubmissionDraft{Endpoint: "https://example.com", SurveyID: "s", Form: mapValues("q1", "a")}, want: "method"},
+		{name: "endpoint", executor: &recordingHTTPSubmissionExecutor{}, draft: HTTPSubmissionDraft{Method: http.MethodPost, SurveyID: "s", Form: mapValues("q1", "a")}, want: "endpoint"},
+		{name: "form", executor: &recordingHTTPSubmissionExecutor{}, draft: HTTPSubmissionDraft{Method: http.MethodPost, Endpoint: "https://example.com", SurveyID: "s"}, want: "form"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ExecuteHTTPSubmission(context.Background(), tt.executor, tt.draft)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ExecuteHTTPSubmission() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteHTTPSubmissionReturnsExecutorError(t *testing.T) {
+	wantErr := errors.New("offline")
+	_, err := ExecuteHTTPSubmission(context.Background(), &recordingHTTPSubmissionExecutor{err: wantErr}, mustDraft(t))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ExecuteHTTPSubmission() error = %v, want executor error", err)
+	}
+}
+
+func TestExecuteHTTPSubmissionClonesDraftAndResponse(t *testing.T) {
+	draft := mustDraft(t)
+	executor := &recordingHTTPSubmissionExecutor{
+		response: HTTPSubmissionResponse{
+			StatusCode: http.StatusAccepted,
+			Header:     http.Header{"X-Original": []string{"value"}},
+			Body:       "accepted",
+		},
+	}
+
+	response, err := ExecuteHTTPSubmission(context.Background(), executor, draft)
+	if err != nil {
+		t.Fatalf("ExecuteHTTPSubmission() returned error: %v", err)
+	}
+	draft.Form.Set("q1", "mutated")
+	draft.Header.Set("Referer", "mutated")
+	response.Header.Set("X-Original", "mutated")
+
+	if executor.calls[0].Form.Get("q1") != "a" || executor.calls[0].Header.Get("Referer") != "https://www.wjx.cn/vm/example.aspx" {
+		t.Fatalf("recorded draft was mutated: %+v", executor.calls[0])
+	}
+	if executor.response.Header.Get("X-Original") != "value" {
+		t.Fatalf("executor response header was mutated: %+v", executor.response.Header)
+	}
+}
+
+type recordingHTTPSubmissionExecutor struct {
+	response HTTPSubmissionResponse
+	err      error
+	calls    []HTTPSubmissionDraft
+}
+
+func (e *recordingHTTPSubmissionExecutor) ExecuteHTTPSubmission(ctx context.Context, draft HTTPSubmissionDraft) (HTTPSubmissionResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return HTTPSubmissionResponse{}, err
+	}
+	e.calls = append(e.calls, cloneHTTPSubmissionDraft(draft))
+	if e.err != nil {
+		return HTTPSubmissionResponse{}, e.err
+	}
+	return cloneHTTPSubmissionResponse(e.response), nil
+}
+
+func mustDraft(t *testing.T) HTTPSubmissionDraft {
+	t.Helper()
+	draft, err := BuildHTTPSubmissionDraft("https://www.wjx.cn/vm/example.aspx", map[string]string{"q1": "a"})
+	if err != nil {
+		t.Fatalf("BuildHTTPSubmissionDraft() returned error: %v", err)
+	}
+	return draft
+}
+
+func mapValues(key string, value string) url.Values {
+	return url.Values{key: []string{value}}
+}


### PR DESCRIPTION
## Summary
- write the HTTP-first WJX execution queue into the roadmap
- add a WJX HTTP submission executor interface around the existing submission draft
- add local recording/mock-style tests for executor success, errors, validation, and draft/response cloning

## Safety
- no network requests are executed
- no browser is started
- `SubmitHTTP` remains gated off until response detection and capability gating are complete

## Validation
- go test ./internal/provider/wjx -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- $env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...

Closes #37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap introducing Phase 1.5 with HTTP-first execution approach, offline mock execution capabilities, and explicit performance benchmarks for enhanced concurrency support.

* **New Features**
  * Implemented HTTP submission execution with comprehensive input validation, response handling, and data integrity safeguards designed for high-concurrency workflows.

* **Tests**
  * Added comprehensive test coverage for HTTP submission execution validation and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->