### PR TITLE
feat: 增加 WJX HTTP response detector

### DIFF
--- a/internal/apperr/error.go
+++ b/internal/apperr/error.go
@@ -18,6 +18,7 @@ const (
 	CodeVerificationNeeded  Code = "verification_required"
 	CodeLoginRequired       Code = "login_required"
 	CodeDeviceQuotaLimited  Code = "device_quota_limited"
+	CodeRateLimited         Code = "rate_limited"
 	CodeProxyUnavailable    Code = "proxy_unavailable"
 	CodeSampleExhausted     Code = "sample_exhausted"
 	CodeUserCancelled       Code = "user_cancelled"

--- a/internal/engine/submission.go
+++ b/internal/engine/submission.go
@@ -70,7 +70,8 @@ func shouldStopForSubmissionState(state provider.SubmissionState) bool {
 	switch state {
 	case provider.SubmissionStateVerificationRequired,
 		provider.SubmissionStateLoginRequired,
-		provider.SubmissionStateDeviceQuotaLimited:
+		provider.SubmissionStateDeviceQuotaLimited,
+		provider.SubmissionStateRateLimited:
 		return true
 	default:
 		return false

--- a/internal/engine/submission_test.go
+++ b/internal/engine/submission_test.go
@@ -130,6 +130,18 @@ func TestResultFromDetectionMapsStates(t *testing.T) {
 			wantDefaultMessage: string(provider.SubmissionStateDeviceQuotaLimited),
 		},
 		{
+			name: "rate limited",
+			detection: provider.SubmissionDetection{
+				State: provider.SubmissionStateRateLimited,
+			},
+			wantTerminal:       true,
+			wantStop:           true,
+			wantErr:            true,
+			wantErrCode:        apperr.CodeRateLimited,
+			wantDefaultState:   provider.SubmissionStateRateLimited,
+			wantDefaultMessage: string(provider.SubmissionStateRateLimited),
+		},
+		{
 			name: "explicit stop",
 			detection: provider.SubmissionDetection{
 				State:      provider.SubmissionStateFailure,

--- a/internal/provider/detector.go
+++ b/internal/provider/detector.go
@@ -16,6 +16,7 @@ const (
 	SubmissionStateVerificationRequired SubmissionState = "verification_required"
 	SubmissionStateLoginRequired        SubmissionState = "login_required"
 	SubmissionStateDeviceQuotaLimited   SubmissionState = "device_quota_limited"
+	SubmissionStateRateLimited          SubmissionState = "rate_limited"
 )
 
 type SubmissionDetection struct {
@@ -45,7 +46,8 @@ func (s SubmissionState) Terminal() bool {
 		SubmissionStateFailure,
 		SubmissionStateVerificationRequired,
 		SubmissionStateLoginRequired,
-		SubmissionStateDeviceQuotaLimited:
+		SubmissionStateDeviceQuotaLimited,
+		SubmissionStateRateLimited:
 		return true
 	default:
 		return false
@@ -62,6 +64,8 @@ func (s SubmissionState) ErrorCode() (apperr.Code, bool) {
 		return apperr.CodeLoginRequired, true
 	case SubmissionStateDeviceQuotaLimited:
 		return apperr.CodeDeviceQuotaLimited, true
+	case SubmissionStateRateLimited:
+		return apperr.CodeRateLimited, true
 	default:
 		return "", false
 	}

--- a/internal/provider/detector_test.go
+++ b/internal/provider/detector_test.go
@@ -19,6 +19,7 @@ func TestSubmissionStateTerminal(t *testing.T) {
 		{state: SubmissionStateVerificationRequired, want: true},
 		{state: SubmissionStateLoginRequired, want: true},
 		{state: SubmissionStateDeviceQuotaLimited, want: true},
+		{state: SubmissionStateRateLimited, want: true},
 	}
 
 	for _, tt := range tests {
@@ -40,6 +41,7 @@ func TestSubmissionStateErrorCode(t *testing.T) {
 		{state: SubmissionStateVerificationRequired, code: apperr.CodeVerificationNeeded, ok: true},
 		{state: SubmissionStateLoginRequired, code: apperr.CodeLoginRequired, ok: true},
 		{state: SubmissionStateDeviceQuotaLimited, code: apperr.CodeDeviceQuotaLimited, ok: true},
+		{state: SubmissionStateRateLimited, code: apperr.CodeRateLimited, ok: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/provider/wjx/http_response_detector.go
+++ b/internal/provider/wjx/http_response_detector.go
@@ -1,0 +1,81 @@
+package wjx
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+type httpResponseSignal struct {
+	state   provider.SubmissionState
+	message string
+	stop    bool
+}
+
+func DetectHTTPSubmissionResponse(response HTTPSubmissionResponse) provider.SubmissionDetection {
+	statusCode := response.StatusCode
+	body := normalizeResponseText(response.Body)
+	contentType := strings.TrimSpace(response.Header.Get("Content-Type"))
+
+	signal := detectHTTPResponseSignal(statusCode, body, response.Header)
+	detection := provider.SubmissionDetection{
+		State:      signal.state,
+		Message:    signal.message,
+		ShouldStop: signal.stop,
+		ProviderRaw: map[string]any{
+			"status_code":  statusCode,
+			"content_type": contentType,
+		},
+	}
+	if detection.State == provider.SubmissionStateSuccess {
+		detection.CompletionDetected = true
+	}
+	return detection
+}
+
+func detectHTTPResponseSignal(statusCode int, body string, header http.Header) httpResponseSignal {
+	switch {
+	case statusCode == http.StatusTooManyRequests || header.Get("Retry-After") != "":
+		return terminalHTTPResponseSignal(provider.SubmissionStateRateLimited, "rate limited")
+	case containsAny(body, "过于频繁", "操作频繁", "too many requests", "rate limit", "稍后再试"):
+		return terminalHTTPResponseSignal(provider.SubmissionStateRateLimited, "rate limited")
+	case containsAny(body, "验证码", "智能验证", "滑块验证", "验证失败", "需要验证", "captcha"):
+		return terminalHTTPResponseSignal(provider.SubmissionStateVerificationRequired, "verification required")
+	case containsAny(body, "请先登录", "登录后", "login required", "sign in"):
+		return terminalHTTPResponseSignal(provider.SubmissionStateLoginRequired, "login required")
+	case containsAny(body, "每台设备", "每个设备", "每个ip", "每个 ip", "已经填写过", "已填写过", "只能填写一次", "重复提交"):
+		return terminalHTTPResponseSignal(provider.SubmissionStateDeviceQuotaLimited, "device quota limited")
+	case statusCode >= 500:
+		return terminalHTTPResponseSignal(provider.SubmissionStateFailure, "server rejected submission")
+	case statusCode == http.StatusBadRequest || statusCode == http.StatusUnprocessableEntity:
+		return terminalHTTPResponseSignal(provider.SubmissionStateFailure, "invalid submission")
+	case containsAny(body, "参数错误", "提交失败", "非法", "无效", "invalid", "failed"):
+		return terminalHTTPResponseSignal(provider.SubmissionStateFailure, "submission rejected")
+	case statusCode >= 200 && statusCode < 300 && containsAny(body, "提交成功", "答卷提交成功", "已完成", "success", "succeeded"):
+		return httpResponseSignal{state: provider.SubmissionStateSuccess, message: "submission accepted"}
+	default:
+		return httpResponseSignal{state: provider.SubmissionStateUnknown, message: "submission state unknown"}
+	}
+}
+
+func terminalHTTPResponseSignal(state provider.SubmissionState, message string) httpResponseSignal {
+	return httpResponseSignal{
+		state:   state,
+		message: message,
+		stop:    true,
+	}
+}
+
+func normalizeResponseText(body string) string {
+	return strings.ToLower(strings.Join(strings.Fields(body), " "))
+}
+
+func containsAny(value string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(value, strings.ToLower(needle)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/provider/wjx/http_response_detector_test.go
+++ b/internal/provider/wjx/http_response_detector_test.go
@@ -1,0 +1,126 @@
+package wjx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+func TestDetectHTTPSubmissionResponse(t *testing.T) {
+	tests := []struct {
+		name           string
+		response       HTTPSubmissionResponse
+		wantState      provider.SubmissionState
+		wantMessage    string
+		wantCompletion bool
+		wantStop       bool
+	}{
+		{
+			name: "success",
+			response: HTTPSubmissionResponse{
+				StatusCode: http.StatusOK,
+				Body:       "提交成功",
+			},
+			wantState:      provider.SubmissionStateSuccess,
+			wantMessage:    "submission accepted",
+			wantCompletion: true,
+		},
+		{
+			name: "verification",
+			response: HTTPSubmissionResponse{
+				StatusCode: http.StatusOK,
+				Body:       "请完成智能验证后继续",
+			},
+			wantState:   provider.SubmissionStateVerificationRequired,
+			wantMessage: "verification required",
+			wantStop:    true,
+		},
+		{
+			name: "login",
+			response: HTTPSubmissionResponse{
+				StatusCode: http.StatusOK,
+				Body:       "请先登录后再提交",
+			},
+			wantState:   provider.SubmissionStateLoginRequired,
+			wantMessage: "login required",
+			wantStop:    true,
+		},
+		{
+			name: "device quota",
+			response: HTTPSubmissionResponse{
+				StatusCode: http.StatusOK,
+				Body:       "每台设备只能填写一次",
+			},
+			wantState:   provider.SubmissionStateDeviceQuotaLimited,
+			wantMessage: "device quota limited",
+			wantStop:    true,
+		},
+		{
+			name: "rate limited status",
+			response: HTTPSubmissionResponse{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Retry-After": []string{"30"}},
+				Body:       "too many requests",
+			},
+			wantState:   provider.SubmissionStateRateLimited,
+			wantMessage: "rate limited",
+			wantStop:    true,
+		},
+		{
+			name: "validation failure",
+			response: HTTPSubmissionResponse{
+				StatusCode: http.StatusBadRequest,
+				Body:       "参数错误",
+			},
+			wantState:   provider.SubmissionStateFailure,
+			wantMessage: "invalid submission",
+			wantStop:    true,
+		},
+		{
+			name: "unknown",
+			response: HTTPSubmissionResponse{
+				StatusCode: http.StatusAccepted,
+				Header:     http.Header{"Content-Type": []string{"text/plain"}},
+				Body:       "queued",
+			},
+			wantState:   provider.SubmissionStateUnknown,
+			wantMessage: "submission state unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectHTTPSubmissionResponse(tt.response)
+			if got.State != tt.wantState {
+				t.Fatalf("State = %q, want %q", got.State, tt.wantState)
+			}
+			if got.Message != tt.wantMessage {
+				t.Fatalf("Message = %q, want %q", got.Message, tt.wantMessage)
+			}
+			if got.CompletionDetected != tt.wantCompletion {
+				t.Fatalf("CompletionDetected = %v, want %v", got.CompletionDetected, tt.wantCompletion)
+			}
+			if got.ShouldStop != tt.wantStop {
+				t.Fatalf("ShouldStop = %v, want %v", got.ShouldStop, tt.wantStop)
+			}
+			if got.ProviderRaw["status_code"] != tt.response.StatusCode {
+				t.Fatalf("ProviderRaw status_code = %+v, want %d", got.ProviderRaw["status_code"], tt.response.StatusCode)
+			}
+		})
+	}
+}
+
+func TestDetectHTTPSubmissionResponsePrioritizesSafetyBlocks(t *testing.T) {
+	got := DetectHTTPSubmissionResponse(HTTPSubmissionResponse{
+		StatusCode: http.StatusOK,
+		Body:       "提交成功，但是需要验证码",
+	})
+
+	if got.State != provider.SubmissionStateVerificationRequired {
+		t.Fatalf("State = %q, want verification required", got.State)
+	}
+	if !got.ShouldStop || got.CompletionDetected {
+		t.Fatalf("DetectHTTPSubmissionResponse() = %+v, want stop without completion", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add a WJX HTTP submission response detector for local/mock HTTP-first execution
- classify success, verification required, login required, device quota, rate limited, rejected, and unknown responses
- add a shared rate_limited submission state/error code so runner results stop safely instead of retrying blindly

## Safety

- no live network submission is added
- verification, login, quota, and rate-limit responses are terminal stop/report states
- this does not bypass verification, login, anti-abuse, or rate-limit controls

## Validation

- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- CGO_ENABLED=1 go test -race ./...

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and handling for rate-limited submission responses.
  * The system now properly stops submission attempts when rate limiting is detected, preventing unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->