### PR TITLE
feat: 增加 WJX HTTP AnswerPlan 映射

### DIFF
--- a/internal/provider/wjx/http_answer_plan.go
+++ b/internal/provider/wjx/http_answer_plan.go
@@ -1,0 +1,154 @@
+package wjx
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/LING71671/SurveyController-go/internal/domain"
+)
+
+type HTTPAnswerPlan struct {
+	Answers []HTTPQuestionAnswer
+}
+
+type HTTPQuestionAnswer struct {
+	QuestionID string
+	OptionIDs  []string
+	Value      string
+}
+
+func BuildHTTPSubmissionDraftFromAnswerPlan(survey domain.SurveyDefinition, plan HTTPAnswerPlan) (HTTPSubmissionDraft, error) {
+	answers, err := BuildHTTPAnswers(survey, plan)
+	if err != nil {
+		return HTTPSubmissionDraft{}, err
+	}
+	return BuildHTTPSubmissionDraft(survey.URL, answers)
+}
+
+func BuildHTTPAnswers(survey domain.SurveyDefinition, plan HTTPAnswerPlan) (map[string]string, error) {
+	if len(plan.Answers) == 0 {
+		return nil, fmt.Errorf("answer plan is required")
+	}
+
+	questions := indexQuestions(survey.Questions)
+	answers := make(map[string]string, len(plan.Answers))
+	for _, planned := range plan.Answers {
+		questionID := strings.TrimSpace(planned.QuestionID)
+		if questionID == "" {
+			return nil, fmt.Errorf("question id is required")
+		}
+		question, ok := questions[questionID]
+		if !ok {
+			return nil, fmt.Errorf("question %q is not defined", questionID)
+		}
+		if _, exists := answers[questionID]; exists {
+			return nil, fmt.Errorf("question %q has duplicate answers", questionID)
+		}
+
+		value, err := buildHTTPAnswerValue(question, planned)
+		if err != nil {
+			return nil, fmt.Errorf("question %q: %w", questionID, err)
+		}
+		answers[questionID] = value
+	}
+	return answers, nil
+}
+
+func indexQuestions(questions []domain.QuestionDefinition) map[string]domain.QuestionDefinition {
+	index := make(map[string]domain.QuestionDefinition, len(questions))
+	for _, question := range questions {
+		id := strings.TrimSpace(question.ID)
+		if id != "" {
+			index[id] = question
+		}
+	}
+	return index
+}
+
+func buildHTTPAnswerValue(question domain.QuestionDefinition, planned HTTPQuestionAnswer) (string, error) {
+	switch question.Kind {
+	case domain.QuestionKindSingle, domain.QuestionKindDropdown:
+		return buildSingleHTTPAnswerValue(question, planned)
+	case domain.QuestionKindMultiple:
+		return buildMultipleHTTPAnswerValue(question, planned)
+	case domain.QuestionKindRating:
+		return buildRatingHTTPAnswerValue(question, planned)
+	default:
+		return "", fmt.Errorf("kind %q is not supported for HTTP answer plan", question.Kind)
+	}
+}
+
+func buildSingleHTTPAnswerValue(question domain.QuestionDefinition, planned HTTPQuestionAnswer) (string, error) {
+	if len(planned.OptionIDs) > 1 {
+		return "", fmt.Errorf("single answer expects one option")
+	}
+	if len(planned.OptionIDs) == 1 {
+		return optionValue(question, planned.OptionIDs[0])
+	}
+	return directAnswerValue(planned.Value)
+}
+
+func buildMultipleHTTPAnswerValue(question domain.QuestionDefinition, planned HTTPQuestionAnswer) (string, error) {
+	if len(planned.OptionIDs) == 0 {
+		return directAnswerValue(planned.Value)
+	}
+
+	seen := map[string]bool{}
+	values := make([]string, 0, len(planned.OptionIDs))
+	for _, optionID := range planned.OptionIDs {
+		id := strings.TrimSpace(optionID)
+		if id == "" {
+			return "", fmt.Errorf("option id is required")
+		}
+		if seen[id] {
+			return "", fmt.Errorf("option %q is selected more than once", id)
+		}
+		seen[id] = true
+
+		value, err := optionValue(question, id)
+		if err != nil {
+			return "", err
+		}
+		values = append(values, value)
+	}
+	return strings.Join(values, ","), nil
+}
+
+func buildRatingHTTPAnswerValue(question domain.QuestionDefinition, planned HTTPQuestionAnswer) (string, error) {
+	if len(planned.OptionIDs) > 1 {
+		return "", fmt.Errorf("rating answer expects one option")
+	}
+	if len(planned.OptionIDs) == 1 {
+		return optionValue(question, planned.OptionIDs[0])
+	}
+	return directAnswerValue(planned.Value)
+}
+
+func directAnswerValue(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("answer value is required")
+	}
+	return value, nil
+}
+
+func optionValue(question domain.QuestionDefinition, optionID string) (string, error) {
+	optionID = strings.TrimSpace(optionID)
+	if optionID == "" {
+		return "", fmt.Errorf("option id is required")
+	}
+	for _, option := range question.Options {
+		if strings.TrimSpace(option.ID) != optionID {
+			continue
+		}
+		value := strings.TrimSpace(option.Value)
+		if value == "" {
+			value = strings.TrimSpace(option.ID)
+		}
+		if value == "" {
+			return "", fmt.Errorf("option %q value is required", optionID)
+		}
+		return value, nil
+	}
+	return "", fmt.Errorf("option %q is not defined", optionID)
+}

--- a/internal/provider/wjx/http_answer_plan_test.go
+++ b/internal/provider/wjx/http_answer_plan_test.go
@@ -1,0 +1,222 @@
+package wjx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/domain"
+)
+
+func TestBuildHTTPAnswers(t *testing.T) {
+	survey := testAnswerPlanSurvey()
+
+	got, err := BuildHTTPAnswers(survey, HTTPAnswerPlan{
+		Answers: []HTTPQuestionAnswer{
+			{QuestionID: "q1", OptionIDs: []string{"b"}},
+			{QuestionID: "q2", OptionIDs: []string{"a", "c"}},
+			{QuestionID: "q3", OptionIDs: []string{"score5"}},
+			{QuestionID: "q4", OptionIDs: []string{"city2"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildHTTPAnswers() returned error: %v", err)
+	}
+
+	want := map[string]string{
+		"q1": "2",
+		"q2": "A,C",
+		"q3": "5",
+		"q4": "shanghai",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len(answers) = %d, want %d: %+v", len(got), len(want), got)
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("answers[%q] = %q, want %q", key, got[key], value)
+		}
+	}
+}
+
+func TestBuildHTTPSubmissionDraftFromAnswerPlan(t *testing.T) {
+	draft, err := BuildHTTPSubmissionDraftFromAnswerPlan(testAnswerPlanSurvey(), HTTPAnswerPlan{
+		Answers: []HTTPQuestionAnswer{
+			{QuestionID: "q1", OptionIDs: []string{"a"}},
+			{QuestionID: "q2", OptionIDs: []string{"b", "c"}},
+			{QuestionID: "q3", Value: "4"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildHTTPSubmissionDraftFromAnswerPlan() returned error: %v", err)
+	}
+
+	if draft.SurveyID != "answerplan" {
+		t.Fatalf("SurveyID = %q, want answerplan", draft.SurveyID)
+	}
+	if draft.Form.Get("q1") != "1" || draft.Form.Get("q2") != "B,C" || draft.Form.Get("q3") != "4" {
+		t.Fatalf("Form = %+v, want mapped answers", draft.Form)
+	}
+}
+
+func TestBuildHTTPAnswersSupportsDirectValues(t *testing.T) {
+	survey := testAnswerPlanSurvey()
+
+	got, err := BuildHTTPAnswers(survey, HTTPAnswerPlan{
+		Answers: []HTTPQuestionAnswer{
+			{QuestionID: "q1", Value: "2"},
+			{QuestionID: "q2", Value: "A,C"},
+			{QuestionID: "q3", Value: "5"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildHTTPAnswers() returned error: %v", err)
+	}
+	if got["q1"] != "2" || got["q2"] != "A,C" || got["q3"] != "5" {
+		t.Fatalf("answers = %+v, want direct values", got)
+	}
+}
+
+func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
+	survey := testAnswerPlanSurvey()
+	tests := []struct {
+		name   string
+		survey domain.SurveyDefinition
+		plan   HTTPAnswerPlan
+		want   string
+	}{
+		{
+			name:   "empty plan",
+			survey: survey,
+			want:   "answer plan",
+		},
+		{
+			name:   "missing question id",
+			survey: survey,
+			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+				{QuestionID: " ", Value: "1"},
+			}},
+			want: "question id",
+		},
+		{
+			name:   "undefined question",
+			survey: survey,
+			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+				{QuestionID: "missing", Value: "1"},
+			}},
+			want: "not defined",
+		},
+		{
+			name:   "duplicate question",
+			survey: survey,
+			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+				{QuestionID: "q1", Value: "1"},
+				{QuestionID: "q1", Value: "2"},
+			}},
+			want: "duplicate",
+		},
+		{
+			name:   "unsupported kind",
+			survey: survey,
+			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+				{QuestionID: "q5", Value: "hello"},
+			}},
+			want: "not supported",
+		},
+		{
+			name:   "single multiple options",
+			survey: survey,
+			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+				{QuestionID: "q1", OptionIDs: []string{"a", "b"}},
+			}},
+			want: "expects one option",
+		},
+		{
+			name:   "unknown option",
+			survey: survey,
+			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+				{QuestionID: "q1", OptionIDs: []string{"missing"}},
+			}},
+			want: "not defined",
+		},
+		{
+			name:   "duplicate option",
+			survey: survey,
+			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+				{QuestionID: "q2", OptionIDs: []string{"a", "a"}},
+			}},
+			want: "more than once",
+		},
+		{
+			name:   "empty direct value",
+			survey: survey,
+			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+				{QuestionID: "q3", Value: " "},
+			}},
+			want: "answer value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := BuildHTTPAnswers(tt.survey, tt.plan)
+			if err == nil {
+				t.Fatalf("BuildHTTPAnswers() returned nil error, want %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("BuildHTTPAnswers() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func testAnswerPlanSurvey() domain.SurveyDefinition {
+	return domain.SurveyDefinition{
+		Provider: domain.ProviderWJX,
+		Title:    "Answer Plan",
+		URL:      "https://www.wjx.cn/vm/answerplan.aspx",
+		Questions: []domain.QuestionDefinition{
+			{
+				ID:    "q1",
+				Title: "Single",
+				Kind:  domain.QuestionKindSingle,
+				Options: []domain.OptionDefinition{
+					{ID: "a", Label: "A", Value: "1"},
+					{ID: "b", Label: "B", Value: "2"},
+				},
+			},
+			{
+				ID:    "q2",
+				Title: "Multiple",
+				Kind:  domain.QuestionKindMultiple,
+				Options: []domain.OptionDefinition{
+					{ID: "a", Label: "A", Value: "A"},
+					{ID: "b", Label: "B", Value: "B"},
+					{ID: "c", Label: "C", Value: "C"},
+				},
+			},
+			{
+				ID:    "q3",
+				Title: "Rating",
+				Kind:  domain.QuestionKindRating,
+				Options: []domain.OptionDefinition{
+					{ID: "score4", Label: "4", Value: "4"},
+					{ID: "score5", Label: "5", Value: "5"},
+				},
+			},
+			{
+				ID:    "q4",
+				Title: "Dropdown",
+				Kind:  domain.QuestionKindDropdown,
+				Options: []domain.OptionDefinition{
+					{ID: "city1", Label: "Beijing", Value: "beijing"},
+					{ID: "city2", Label: "Shanghai", Value: "shanghai"},
+				},
+			},
+			{
+				ID:    "q5",
+				Title: "Text",
+				Kind:  domain.QuestionKindText,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- add WJX HTTP answer plan types and mapping helpers
- convert single, dropdown, multiple, and rating answers into WJX HTTP form answer values
- support building an HTTPSubmissionDraft directly from a survey definition and answer plan

## Safety

- no live network submission is added
- this is a pure local mapping layer for mock/provider plumbing
- does not bypass login, verification, anti-abuse, quota, or rate-limit controls

## Follow-up

- opened #42 to clean up package boundaries around answer planning and provider-specific adapters

## Validation

- go test ./internal/provider/wjx -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- CGO_ENABLED=1 go test -race ./...

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added survey answer validation and HTTP submission conversion capabilities.
  * Supports various question types including single-choice, multiple-choice, and rating questions.
  * Provides structured error reporting for invalid answers.

* **Tests**
  * Added comprehensive test coverage for answer validation and conversion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->