### PR TITLE
refactor: 梳理 AnswerPlan 与 provider adapter 边界

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,7 @@ cmd/surveyctl
               -> internal/browser
               -> internal/httpclient
           -> internal/answer
+          -> internal/answerplan
           -> internal/proxy
           -> internal/sample
       -> internal/logging
@@ -51,7 +52,8 @@ cmd/surveyctl
 | `internal/engine` | 单份问卷执行流程和运行模式选择 |
 | `internal/browser` | Playwright Go 封装、浏览器池、页面会话 |
 | `internal/httpclient` | HTTP 连接池、代理 transport、重试和超时 |
-| `internal/answer` | 题型配置、答案计划、概率、严格比例、信效度 |
+| `internal/answer` | 纯答案算法：概率、严格比例、多选限制、随机文本、信效度 |
+| `internal/answerplan` | 通用答案计划和单题答案结构，不包含任何平台表单或 DOM 细节 |
 | `internal/proxy` | 代理租约、代理池、地区、TTL、健康检查 |
 | `internal/sample` | 反填数据源、样本租约、提交和回滚 |
 | `internal/logging` | 结构化日志、事件输出、脱敏 |
@@ -70,6 +72,7 @@ cmd/surveyctl
 - `RunPlan`：启动前编译好的不可变计划。
 - `QuestionPlan`：某题的答案策略和运行元数据。
 - `Answer`：运行时产生的单题答案。
+- `AnswerPlan`：通用答案计划，只表达“某题选择哪些选项或使用哪个直接值”。
 - `SubmissionResult`：单份提交结果。
 - `RunState`：并发安全的运行状态。
 - `RunEvent`：CLI 和未来 UI 订阅的进度事件。
@@ -237,6 +240,8 @@ HTTP 快速路径必须通过 provider 能力声明开启。
 
 Provider 只负责“把答案填进去”，不负责“决定答案是什么”。
 
+`internal/answerplan` 位于算法层和 provider 之间：`internal/answer` 可以生成选择结果，`internal/answerplan` 承载通用单题答案，`internal/provider/wjx`、`internal/provider/tencent` 等包再把它编译成各自平台需要的 HTTP form、API payload 或浏览器操作。这样 provider adapter 可以做高效的预索引和字段映射，但不反向承担抽样策略。
+
 ## 配置
 
 配置文件必须包含 schema version。
@@ -279,6 +284,7 @@ answer: {}
 - `verification_required`
 - `login_required`
 - `device_quota_limited`
+- `rate_limited`
 - `proxy_unavailable`
 - `sample_exhausted`
 - `user_cancelled`

--- a/internal/answerplan/plan.go
+++ b/internal/answerplan/plan.go
@@ -1,0 +1,29 @@
+package answerplan
+
+import "strings"
+
+type Plan struct {
+	Answers []QuestionAnswer
+}
+
+type QuestionAnswer struct {
+	QuestionID string
+	OptionIDs  []string
+	Value      string
+}
+
+func (p Plan) Empty() bool {
+	return len(p.Answers) == 0
+}
+
+func (a QuestionAnswer) NormalizedQuestionID() string {
+	return strings.TrimSpace(a.QuestionID)
+}
+
+func (a QuestionAnswer) HasOptionIDs() bool {
+	return len(a.OptionIDs) > 0
+}
+
+func (a QuestionAnswer) DirectValue() string {
+	return strings.TrimSpace(a.Value)
+}

--- a/internal/answerplan/plan_test.go
+++ b/internal/answerplan/plan_test.go
@@ -1,0 +1,29 @@
+package answerplan
+
+import "testing"
+
+func TestPlanEmpty(t *testing.T) {
+	if !(Plan{}).Empty() {
+		t.Fatal("empty plan returned false")
+	}
+	if (Plan{Answers: []QuestionAnswer{{QuestionID: "q1"}}}).Empty() {
+		t.Fatal("plan with answers returned true")
+	}
+}
+
+func TestQuestionAnswerHelpers(t *testing.T) {
+	answer := QuestionAnswer{
+		QuestionID: " q1 ",
+		OptionIDs:  []string{"a"},
+		Value:      " 1 ",
+	}
+	if answer.NormalizedQuestionID() != "q1" {
+		t.Fatalf("NormalizedQuestionID() = %q, want q1", answer.NormalizedQuestionID())
+	}
+	if !answer.HasOptionIDs() {
+		t.Fatal("HasOptionIDs() = false, want true")
+	}
+	if answer.DirectValue() != "1" {
+		t.Fatalf("DirectValue() = %q, want 1", answer.DirectValue())
+	}
+}

--- a/internal/provider/wjx/http_answer_plan.go
+++ b/internal/provider/wjx/http_answer_plan.go
@@ -4,20 +4,24 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
 	"github.com/LING71671/SurveyController-go/internal/domain"
 )
 
-type HTTPAnswerPlan struct {
-	Answers []HTTPQuestionAnswer
+type HTTPAnswerPlan = answerplan.Plan
+type HTTPQuestionAnswer = answerplan.QuestionAnswer
+
+type httpAnswerSchema struct {
+	questions map[string]httpQuestionSpec
 }
 
-type HTTPQuestionAnswer struct {
-	QuestionID string
-	OptionIDs  []string
-	Value      string
+type httpQuestionSpec struct {
+	id      string
+	kind    domain.QuestionKind
+	options map[string]string
 }
 
-func BuildHTTPSubmissionDraftFromAnswerPlan(survey domain.SurveyDefinition, plan HTTPAnswerPlan) (HTTPSubmissionDraft, error) {
+func BuildHTTPSubmissionDraftFromAnswerPlan(survey domain.SurveyDefinition, plan answerplan.Plan) (HTTPSubmissionDraft, error) {
 	answers, err := BuildHTTPAnswers(survey, plan)
 	if err != nil {
 		return HTTPSubmissionDraft{}, err
@@ -25,27 +29,24 @@ func BuildHTTPSubmissionDraftFromAnswerPlan(survey domain.SurveyDefinition, plan
 	return BuildHTTPSubmissionDraft(survey.URL, answers)
 }
 
-func BuildHTTPAnswers(survey domain.SurveyDefinition, plan HTTPAnswerPlan) (map[string]string, error) {
-	if len(plan.Answers) == 0 {
+func BuildHTTPAnswers(survey domain.SurveyDefinition, plan answerplan.Plan) (map[string]string, error) {
+	if plan.Empty() {
 		return nil, fmt.Errorf("answer plan is required")
 	}
 
-	questions := indexQuestions(survey.Questions)
+	schema, err := compileHTTPAnswerSchema(survey.Questions)
+	if err != nil {
+		return nil, err
+	}
+
 	answers := make(map[string]string, len(plan.Answers))
 	for _, planned := range plan.Answers {
-		questionID := strings.TrimSpace(planned.QuestionID)
-		if questionID == "" {
-			return nil, fmt.Errorf("question id is required")
-		}
-		question, ok := questions[questionID]
-		if !ok {
-			return nil, fmt.Errorf("question %q is not defined", questionID)
-		}
+		questionID := planned.NormalizedQuestionID()
 		if _, exists := answers[questionID]; exists {
 			return nil, fmt.Errorf("question %q has duplicate answers", questionID)
 		}
 
-		value, err := buildHTTPAnswerValue(question, planned)
+		value, err := schema.mapAnswer(planned)
 		if err != nil {
 			return nil, fmt.Errorf("question %q: %w", questionID, err)
 		}
@@ -54,42 +55,95 @@ func BuildHTTPAnswers(survey domain.SurveyDefinition, plan HTTPAnswerPlan) (map[
 	return answers, nil
 }
 
-func indexQuestions(questions []domain.QuestionDefinition) map[string]domain.QuestionDefinition {
-	index := make(map[string]domain.QuestionDefinition, len(questions))
+func compileHTTPAnswerSchema(questions []domain.QuestionDefinition) (httpAnswerSchema, error) {
+	schema := httpAnswerSchema{
+		questions: make(map[string]httpQuestionSpec, len(questions)),
+	}
 	for _, question := range questions {
-		id := strings.TrimSpace(question.ID)
-		if id != "" {
-			index[id] = question
+		spec, err := compileHTTPQuestionSpec(question)
+		if err != nil {
+			return httpAnswerSchema{}, err
+		}
+		if spec.id != "" {
+			if _, exists := schema.questions[spec.id]; exists {
+				return httpAnswerSchema{}, fmt.Errorf("question %q is defined more than once", spec.id)
+			}
+			schema.questions[spec.id] = spec
 		}
 	}
-	return index
+	return schema, nil
 }
 
-func buildHTTPAnswerValue(question domain.QuestionDefinition, planned HTTPQuestionAnswer) (string, error) {
-	switch question.Kind {
+func compileHTTPQuestionSpec(question domain.QuestionDefinition) (httpQuestionSpec, error) {
+	spec := httpQuestionSpec{
+		id:      strings.TrimSpace(question.ID),
+		kind:    question.Kind,
+		options: make(map[string]string, len(question.Options)),
+	}
+	for _, option := range question.Options {
+		id, value, err := compileHTTPOptionValue(option)
+		if err != nil {
+			return httpQuestionSpec{}, fmt.Errorf("question %q option: %w", spec.id, err)
+		}
+		if id != "" {
+			if _, exists := spec.options[id]; exists {
+				return httpQuestionSpec{}, fmt.Errorf("question %q option %q is defined more than once", spec.id, id)
+			}
+			spec.options[id] = value
+		}
+	}
+	return spec, nil
+}
+
+func compileHTTPOptionValue(option domain.OptionDefinition) (string, string, error) {
+	id := strings.TrimSpace(option.ID)
+	value := strings.TrimSpace(option.Value)
+	if value == "" {
+		value = id
+	}
+	if id != "" && value == "" {
+		return "", "", fmt.Errorf("option %q value is required", id)
+	}
+	return id, value, nil
+}
+
+func (s httpAnswerSchema) mapAnswer(planned answerplan.QuestionAnswer) (string, error) {
+	questionID := planned.NormalizedQuestionID()
+	if questionID == "" {
+		return "", fmt.Errorf("question id is required")
+	}
+	question, ok := s.questions[questionID]
+	if !ok {
+		return "", fmt.Errorf("question %q is not defined", questionID)
+	}
+	return question.mapAnswer(planned)
+}
+
+func (q httpQuestionSpec) mapAnswer(planned answerplan.QuestionAnswer) (string, error) {
+	switch q.kind {
 	case domain.QuestionKindSingle, domain.QuestionKindDropdown:
-		return buildSingleHTTPAnswerValue(question, planned)
+		return q.mapSingleAnswer(planned)
 	case domain.QuestionKindMultiple:
-		return buildMultipleHTTPAnswerValue(question, planned)
+		return q.mapMultipleAnswer(planned)
 	case domain.QuestionKindRating:
-		return buildRatingHTTPAnswerValue(question, planned)
+		return q.mapRatingAnswer(planned)
 	default:
-		return "", fmt.Errorf("kind %q is not supported for HTTP answer plan", question.Kind)
+		return "", fmt.Errorf("kind %q is not supported for HTTP answer plan", q.kind)
 	}
 }
 
-func buildSingleHTTPAnswerValue(question domain.QuestionDefinition, planned HTTPQuestionAnswer) (string, error) {
+func (q httpQuestionSpec) mapSingleAnswer(planned answerplan.QuestionAnswer) (string, error) {
 	if len(planned.OptionIDs) > 1 {
 		return "", fmt.Errorf("single answer expects one option")
 	}
-	if len(planned.OptionIDs) == 1 {
-		return optionValue(question, planned.OptionIDs[0])
+	if planned.HasOptionIDs() {
+		return q.optionValue(planned.OptionIDs[0])
 	}
 	return directAnswerValue(planned.Value)
 }
 
-func buildMultipleHTTPAnswerValue(question domain.QuestionDefinition, planned HTTPQuestionAnswer) (string, error) {
-	if len(planned.OptionIDs) == 0 {
+func (q httpQuestionSpec) mapMultipleAnswer(planned answerplan.QuestionAnswer) (string, error) {
+	if !planned.HasOptionIDs() {
 		return directAnswerValue(planned.Value)
 	}
 
@@ -105,7 +159,7 @@ func buildMultipleHTTPAnswerValue(question domain.QuestionDefinition, planned HT
 		}
 		seen[id] = true
 
-		value, err := optionValue(question, id)
+		value, err := q.optionValue(id)
 		if err != nil {
 			return "", err
 		}
@@ -114,12 +168,12 @@ func buildMultipleHTTPAnswerValue(question domain.QuestionDefinition, planned HT
 	return strings.Join(values, ","), nil
 }
 
-func buildRatingHTTPAnswerValue(question domain.QuestionDefinition, planned HTTPQuestionAnswer) (string, error) {
+func (q httpQuestionSpec) mapRatingAnswer(planned answerplan.QuestionAnswer) (string, error) {
 	if len(planned.OptionIDs) > 1 {
 		return "", fmt.Errorf("rating answer expects one option")
 	}
-	if len(planned.OptionIDs) == 1 {
-		return optionValue(question, planned.OptionIDs[0])
+	if planned.HasOptionIDs() {
+		return q.optionValue(planned.OptionIDs[0])
 	}
 	return directAnswerValue(planned.Value)
 }
@@ -132,22 +186,13 @@ func directAnswerValue(value string) (string, error) {
 	return value, nil
 }
 
-func optionValue(question domain.QuestionDefinition, optionID string) (string, error) {
+func (q httpQuestionSpec) optionValue(optionID string) (string, error) {
 	optionID = strings.TrimSpace(optionID)
 	if optionID == "" {
 		return "", fmt.Errorf("option id is required")
 	}
-	for _, option := range question.Options {
-		if strings.TrimSpace(option.ID) != optionID {
-			continue
-		}
-		value := strings.TrimSpace(option.Value)
-		if value == "" {
-			value = strings.TrimSpace(option.ID)
-		}
-		if value == "" {
-			return "", fmt.Errorf("option %q value is required", optionID)
-		}
+	value, ok := q.options[optionID]
+	if ok {
 		return value, nil
 	}
 	return "", fmt.Errorf("option %q is not defined", optionID)

--- a/internal/provider/wjx/http_answer_plan_test.go
+++ b/internal/provider/wjx/http_answer_plan_test.go
@@ -4,14 +4,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
 	"github.com/LING71671/SurveyController-go/internal/domain"
 )
 
 func TestBuildHTTPAnswers(t *testing.T) {
 	survey := testAnswerPlanSurvey()
 
-	got, err := BuildHTTPAnswers(survey, HTTPAnswerPlan{
-		Answers: []HTTPQuestionAnswer{
+	got, err := BuildHTTPAnswers(survey, answerplan.Plan{
+		Answers: []answerplan.QuestionAnswer{
 			{QuestionID: "q1", OptionIDs: []string{"b"}},
 			{QuestionID: "q2", OptionIDs: []string{"a", "c"}},
 			{QuestionID: "q3", OptionIDs: []string{"score5"}},
@@ -39,8 +40,8 @@ func TestBuildHTTPAnswers(t *testing.T) {
 }
 
 func TestBuildHTTPSubmissionDraftFromAnswerPlan(t *testing.T) {
-	draft, err := BuildHTTPSubmissionDraftFromAnswerPlan(testAnswerPlanSurvey(), HTTPAnswerPlan{
-		Answers: []HTTPQuestionAnswer{
+	draft, err := BuildHTTPSubmissionDraftFromAnswerPlan(testAnswerPlanSurvey(), answerplan.Plan{
+		Answers: []answerplan.QuestionAnswer{
 			{QuestionID: "q1", OptionIDs: []string{"a"}},
 			{QuestionID: "q2", OptionIDs: []string{"b", "c"}},
 			{QuestionID: "q3", Value: "4"},
@@ -61,8 +62,8 @@ func TestBuildHTTPSubmissionDraftFromAnswerPlan(t *testing.T) {
 func TestBuildHTTPAnswersSupportsDirectValues(t *testing.T) {
 	survey := testAnswerPlanSurvey()
 
-	got, err := BuildHTTPAnswers(survey, HTTPAnswerPlan{
-		Answers: []HTTPQuestionAnswer{
+	got, err := BuildHTTPAnswers(survey, answerplan.Plan{
+		Answers: []answerplan.QuestionAnswer{
 			{QuestionID: "q1", Value: "2"},
 			{QuestionID: "q2", Value: "A,C"},
 			{QuestionID: "q3", Value: "5"},
@@ -81,7 +82,7 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 	tests := []struct {
 		name   string
 		survey domain.SurveyDefinition
-		plan   HTTPAnswerPlan
+		plan   answerplan.Plan
 		want   string
 	}{
 		{
@@ -92,7 +93,7 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 		{
 			name:   "missing question id",
 			survey: survey,
-			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
 				{QuestionID: " ", Value: "1"},
 			}},
 			want: "question id",
@@ -100,7 +101,7 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 		{
 			name:   "undefined question",
 			survey: survey,
-			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
 				{QuestionID: "missing", Value: "1"},
 			}},
 			want: "not defined",
@@ -108,16 +109,32 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 		{
 			name:   "duplicate question",
 			survey: survey,
-			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
 				{QuestionID: "q1", Value: "1"},
 				{QuestionID: "q1", Value: "2"},
 			}},
 			want: "duplicate",
 		},
 		{
+			name:   "duplicate survey question definition",
+			survey: appendQuestion(survey, survey.Questions[0]),
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
+				{QuestionID: "q1", Value: "1"},
+			}},
+			want: "defined more than once",
+		},
+		{
+			name:   "duplicate option definition",
+			survey: replaceQuestion(survey, 0, duplicateOptionQuestion()),
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
+				{QuestionID: "q1", OptionIDs: []string{"a"}},
+			}},
+			want: "defined more than once",
+		},
+		{
 			name:   "unsupported kind",
 			survey: survey,
-			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
 				{QuestionID: "q5", Value: "hello"},
 			}},
 			want: "not supported",
@@ -125,7 +142,7 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 		{
 			name:   "single multiple options",
 			survey: survey,
-			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
 				{QuestionID: "q1", OptionIDs: []string{"a", "b"}},
 			}},
 			want: "expects one option",
@@ -133,7 +150,7 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 		{
 			name:   "unknown option",
 			survey: survey,
-			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
 				{QuestionID: "q1", OptionIDs: []string{"missing"}},
 			}},
 			want: "not defined",
@@ -141,7 +158,7 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 		{
 			name:   "duplicate option",
 			survey: survey,
-			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
 				{QuestionID: "q2", OptionIDs: []string{"a", "a"}},
 			}},
 			want: "more than once",
@@ -149,7 +166,7 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 		{
 			name:   "empty direct value",
 			survey: survey,
-			plan: HTTPAnswerPlan{Answers: []HTTPQuestionAnswer{
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
 				{QuestionID: "q3", Value: " "},
 			}},
 			want: "answer value",
@@ -166,6 +183,29 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 				t.Fatalf("BuildHTTPAnswers() error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func appendQuestion(survey domain.SurveyDefinition, question domain.QuestionDefinition) domain.SurveyDefinition {
+	survey.Questions = append(append([]domain.QuestionDefinition(nil), survey.Questions...), question)
+	return survey
+}
+
+func replaceQuestion(survey domain.SurveyDefinition, index int, question domain.QuestionDefinition) domain.SurveyDefinition {
+	survey.Questions = append([]domain.QuestionDefinition(nil), survey.Questions...)
+	survey.Questions[index] = question
+	return survey
+}
+
+func duplicateOptionQuestion() domain.QuestionDefinition {
+	return domain.QuestionDefinition{
+		ID:    "q1",
+		Title: "Single",
+		Kind:  domain.QuestionKindSingle,
+		Options: []domain.OptionDefinition{
+			{ID: "a", Label: "A", Value: "1"},
+			{ID: "a", Label: "A again", Value: "2"},
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

- add internal/answerplan for provider-neutral answer plans
- keep WJX as the HTTP form adapter through type aliases and answerplan.Plan inputs
- split WJX HTTP answer mapping into schema/spec/mapping helpers
- pre-index question and option values and reject duplicate question/option definitions early
- document the answer/answerplan/provider boundary in architecture.md

## Performance / maintainability

- WJX answer mapping now builds a question/option schema once per mapping call instead of scanning options for every selected answer
- smaller helper functions make the adapter easier to inspect and test

## Validation

- go test ./internal/answerplan ./internal/provider/wjx -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- CGO_ENABLED=1 go test -race ./...

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to describe the new answer planning layer.
  * Expanded error handling documentation to include rate-limited error responses.

* **Refactor**
  * Internal improvements to answer processing and compilation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->