### PR TITLE
perf: 增加 WJX HTTP path benchmark

### DIFF
--- a/internal/provider/wjx/http_answer_plan.go
+++ b/internal/provider/wjx/http_answer_plan.go
@@ -11,7 +11,8 @@ import (
 type HTTPAnswerPlan = answerplan.Plan
 type HTTPQuestionAnswer = answerplan.QuestionAnswer
 
-type httpAnswerSchema struct {
+type HTTPAnswerSchema struct {
+	surveyURL string
 	questions map[string]httpQuestionSpec
 }
 
@@ -22,21 +23,41 @@ type httpQuestionSpec struct {
 }
 
 func BuildHTTPSubmissionDraftFromAnswerPlan(survey domain.SurveyDefinition, plan answerplan.Plan) (HTTPSubmissionDraft, error) {
-	answers, err := BuildHTTPAnswers(survey, plan)
+	schema, err := CompileHTTPAnswerSchema(survey)
 	if err != nil {
 		return HTTPSubmissionDraft{}, err
 	}
-	return BuildHTTPSubmissionDraft(survey.URL, answers)
+	return schema.BuildSubmissionDraft(plan)
+}
+
+func (s HTTPAnswerSchema) BuildSubmissionDraft(plan answerplan.Plan) (HTTPSubmissionDraft, error) {
+	answers, err := s.BuildAnswers(plan)
+	if err != nil {
+		return HTTPSubmissionDraft{}, err
+	}
+	return BuildHTTPSubmissionDraft(s.surveyURL, answers)
 }
 
 func BuildHTTPAnswers(survey domain.SurveyDefinition, plan answerplan.Plan) (map[string]string, error) {
-	if plan.Empty() {
-		return nil, fmt.Errorf("answer plan is required")
-	}
-
-	schema, err := compileHTTPAnswerSchema(survey.Questions)
+	schema, err := CompileHTTPAnswerSchema(survey)
 	if err != nil {
 		return nil, err
+	}
+	return schema.BuildAnswers(plan)
+}
+
+func CompileHTTPAnswerSchema(survey domain.SurveyDefinition) (HTTPAnswerSchema, error) {
+	schema, err := compileHTTPAnswerSchema(survey.Questions)
+	if err != nil {
+		return HTTPAnswerSchema{}, err
+	}
+	schema.surveyURL = strings.TrimSpace(survey.URL)
+	return schema, nil
+}
+
+func (s HTTPAnswerSchema) BuildAnswers(plan answerplan.Plan) (map[string]string, error) {
+	if plan.Empty() {
+		return nil, fmt.Errorf("answer plan is required")
 	}
 
 	answers := make(map[string]string, len(plan.Answers))
@@ -46,7 +67,7 @@ func BuildHTTPAnswers(survey domain.SurveyDefinition, plan answerplan.Plan) (map
 			return nil, fmt.Errorf("question %q has duplicate answers", questionID)
 		}
 
-		value, err := schema.mapAnswer(planned)
+		value, err := s.mapAnswer(planned)
 		if err != nil {
 			return nil, fmt.Errorf("question %q: %w", questionID, err)
 		}
@@ -55,18 +76,18 @@ func BuildHTTPAnswers(survey domain.SurveyDefinition, plan answerplan.Plan) (map
 	return answers, nil
 }
 
-func compileHTTPAnswerSchema(questions []domain.QuestionDefinition) (httpAnswerSchema, error) {
-	schema := httpAnswerSchema{
+func compileHTTPAnswerSchema(questions []domain.QuestionDefinition) (HTTPAnswerSchema, error) {
+	schema := HTTPAnswerSchema{
 		questions: make(map[string]httpQuestionSpec, len(questions)),
 	}
 	for _, question := range questions {
 		spec, err := compileHTTPQuestionSpec(question)
 		if err != nil {
-			return httpAnswerSchema{}, err
+			return HTTPAnswerSchema{}, err
 		}
 		if spec.id != "" {
 			if _, exists := schema.questions[spec.id]; exists {
-				return httpAnswerSchema{}, fmt.Errorf("question %q is defined more than once", spec.id)
+				return HTTPAnswerSchema{}, fmt.Errorf("question %q is defined more than once", spec.id)
 			}
 			schema.questions[spec.id] = spec
 		}
@@ -107,7 +128,7 @@ func compileHTTPOptionValue(option domain.OptionDefinition) (string, string, err
 	return id, value, nil
 }
 
-func (s httpAnswerSchema) mapAnswer(planned answerplan.QuestionAnswer) (string, error) {
+func (s HTTPAnswerSchema) mapAnswer(planned answerplan.QuestionAnswer) (string, error) {
 	questionID := planned.NormalizedQuestionID()
 	if questionID == "" {
 		return "", fmt.Errorf("question id is required")

--- a/internal/provider/wjx/http_answer_plan_test.go
+++ b/internal/provider/wjx/http_answer_plan_test.go
@@ -59,6 +59,31 @@ func TestBuildHTTPSubmissionDraftFromAnswerPlan(t *testing.T) {
 	}
 }
 
+func TestHTTPAnswerSchemaBuildSubmissionDraft(t *testing.T) {
+	schema, err := CompileHTTPAnswerSchema(testAnswerPlanSurvey())
+	if err != nil {
+		t.Fatalf("CompileHTTPAnswerSchema() returned error: %v", err)
+	}
+
+	draft, err := schema.BuildSubmissionDraft(answerplan.Plan{
+		Answers: []answerplan.QuestionAnswer{
+			{QuestionID: "q1", OptionIDs: []string{"a"}},
+			{QuestionID: "q2", OptionIDs: []string{"b", "c"}},
+			{QuestionID: "q3", Value: "4"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSubmissionDraft() returned error: %v", err)
+	}
+
+	if draft.Endpoint != "https://www.wjx.cn/joinnew/processjq.ashx" {
+		t.Fatalf("Endpoint = %q, want process endpoint", draft.Endpoint)
+	}
+	if draft.Form.Get("q1") != "1" || draft.Form.Get("q2") != "B,C" || draft.Form.Get("q3") != "4" {
+		t.Fatalf("Form = %+v, want mapped answers", draft.Form)
+	}
+}
+
 func TestBuildHTTPAnswersSupportsDirectValues(t *testing.T) {
 	survey := testAnswerPlanSurvey()
 

--- a/internal/provider/wjx/http_path_benchmark_test.go
+++ b/internal/provider/wjx/http_path_benchmark_test.go
@@ -1,0 +1,130 @@
+package wjx
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
+	"github.com/LING71671/SurveyController-go/internal/domain"
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+var benchmarkHTTPPathDetection provider.SubmissionDetection
+
+func BenchmarkHTTPPathLightTasks(b *testing.B) {
+	for _, taskCount := range []int{1, 1000, 5000} {
+		b.Run(fmt.Sprintf("tasks_%d", taskCount), func(b *testing.B) {
+			benchmarkHTTPPathLightTasks(b, taskCount)
+		})
+	}
+}
+
+func benchmarkHTTPPathLightTasks(b *testing.B, taskCount int) {
+	b.Helper()
+	ctx := context.Background()
+	schema, err := CompileHTTPAnswerSchema(benchmarkSurvey())
+	if err != nil {
+		b.Fatalf("CompileHTTPAnswerSchema() returned error: %v", err)
+	}
+	plan := benchmarkAnswerPlan()
+	executor := staticHTTPSubmissionExecutor{
+		response: HTTPSubmissionResponse{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/plain"}},
+			Body:       "提交成功",
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var detection provider.SubmissionDetection
+		for j := 0; j < taskCount; j++ {
+			draft, err := schema.BuildSubmissionDraft(plan)
+			if err != nil {
+				b.Fatalf("BuildSubmissionDraft() returned error: %v", err)
+			}
+			response, err := ExecuteHTTPSubmission(ctx, executor, draft)
+			if err != nil {
+				b.Fatalf("ExecuteHTTPSubmission() returned error: %v", err)
+			}
+			detection = DetectHTTPSubmissionResponse(response)
+			if detection.State != provider.SubmissionStateSuccess {
+				b.Fatalf("state = %q, want success", detection.State)
+			}
+		}
+		benchmarkHTTPPathDetection = detection
+	}
+}
+
+type staticHTTPSubmissionExecutor struct {
+	response HTTPSubmissionResponse
+}
+
+func (e staticHTTPSubmissionExecutor) ExecuteHTTPSubmission(ctx context.Context, draft HTTPSubmissionDraft) (HTTPSubmissionResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return HTTPSubmissionResponse{}, err
+	}
+	_ = draft
+	return e.response, nil
+}
+
+func benchmarkSurvey() domain.SurveyDefinition {
+	return domain.SurveyDefinition{
+		Provider: domain.ProviderWJX,
+		Title:    "Benchmark",
+		URL:      "https://www.wjx.cn/vm/benchmark.aspx",
+		Questions: []domain.QuestionDefinition{
+			{
+				ID:    "q1",
+				Title: "Single",
+				Kind:  domain.QuestionKindSingle,
+				Options: []domain.OptionDefinition{
+					{ID: "a", Label: "A", Value: "1"},
+					{ID: "b", Label: "B", Value: "2"},
+				},
+			},
+			{
+				ID:    "q2",
+				Title: "Multiple",
+				Kind:  domain.QuestionKindMultiple,
+				Options: []domain.OptionDefinition{
+					{ID: "a", Label: "A", Value: "A"},
+					{ID: "b", Label: "B", Value: "B"},
+					{ID: "c", Label: "C", Value: "C"},
+				},
+			},
+			{
+				ID:    "q3",
+				Title: "Rating",
+				Kind:  domain.QuestionKindRating,
+				Options: []domain.OptionDefinition{
+					{ID: "score4", Label: "4", Value: "4"},
+					{ID: "score5", Label: "5", Value: "5"},
+				},
+			},
+			{
+				ID:    "q4",
+				Title: "Dropdown",
+				Kind:  domain.QuestionKindDropdown,
+				Options: []domain.OptionDefinition{
+					{ID: "city1", Label: "Beijing", Value: "beijing"},
+					{ID: "city2", Label: "Shanghai", Value: "shanghai"},
+				},
+			},
+		},
+	}
+}
+
+func benchmarkAnswerPlan() answerplan.Plan {
+	return answerplan.Plan{
+		Answers: []answerplan.QuestionAnswer{
+			{QuestionID: "q1", OptionIDs: []string{"b"}},
+			{QuestionID: "q2", OptionIDs: []string{"a", "c"}},
+			{QuestionID: "q3", OptionIDs: []string{"score5"}},
+			{QuestionID: "q4", OptionIDs: []string{"city2"}},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- add a local WJX HTTP path benchmark for 1, 1000, and 5000 light tasks
- benchmark the pure local path: answerplan -> HTTPSubmissionDraft -> mock executor -> response detector
- add a reusable compiled HTTPAnswerSchema so hot paths can reuse question/option indexes
- cover schema reuse through unit tests

## Benchmark snapshot

Command:

\\\powershell
go test ./internal/provider/wjx -bench BenchmarkHTTPPathLightTasks -benchmem -run '^$' -count=1
\\\

Local result on Windows amd64 / i7-14650HX:

\\\	ext
BenchmarkHTTPPathLightTasks/tasks_1-24       8828 ns/op      3576 B/op      40 allocs/op
BenchmarkHTTPPathLightTasks/tasks_1000-24    8818598 ns/op   3576023 B/op   40000 allocs/op
BenchmarkHTTPPathLightTasks/tasks_5000-24    43909689 ns/op  17880090 B/op  200000 allocs/op
\\\

## Safety

- no live network submission is added
- executor is static/mock only
- does not bypass login, verification, anti-abuse, quota, or rate-limit controls

## Validation

- go test ./internal/provider/wjx -run Test -count=1
- go test ./internal/provider/wjx -bench BenchmarkHTTPPathLightTasks -benchmem -run '^$' -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- CGO_ENABLED=1 go test -race ./...

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal refactoring for improved code maintainability and structure.
  * Added performance benchmarks for optimization validation.
  * Enhanced test coverage for core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->