### PR TITLE
feat: 增加 provider 提交能力 gate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,6 +132,7 @@ type ProviderRunner interface {
 - `http` 模式不能静默降级为浏览器。
 - `browser` 模式不能偷偷走 HTTP 提交，除非用户允许 hybrid。
 - `hybrid` 也必须由 provider 显式声明支持。
+- 真实提交路径必须先通过 `provider.RequireSubmitCapability`，`http` 模式只有 provider 显式声明 `SubmitHTTP` 才能进入提交。
 - provider 必须给出失败原因，例如“不支持 HTTP 提交”“需要登录”“命中验证”。
 
 ## 执行模式资源 Profile
@@ -218,6 +219,8 @@ HTTP 层围绕 Go `net/http` 设计：
 - HTTP transport、cookie jar 和缓存需要有生命周期边界，避免长时间运行时内存泄漏。
 
 HTTP 快速路径必须通过 provider 能力声明开启。
+
+HTTP 提交能力和 HTTP 解析能力分开声明：`ParseHTTP` 只能表示 provider 可以用 HTTP 获取或解析问卷结构，不能推导出提交能力；真实 HTTP 提交必须显式声明 `SubmitHTTP` 并通过提交能力 gate。命中登录、验证、设备限制、限流或其他风控信号时，只能停止并报告。
 
 ## 答案策略层
 

--- a/internal/provider/capability_gate.go
+++ b/internal/provider/capability_gate.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/LING71671/SurveyController-go/internal/apperr"
+)
+
+func RequireSubmitCapability(p Provider, mode ModeValue) error {
+	if p == nil {
+		return apperr.New(apperr.CodeProviderUnsupported, "provider is required")
+	}
+
+	normalized, ok := normalizeMode(mode)
+	if !ok {
+		return apperr.New(apperr.CodeProviderUnsupported, fmt.Sprintf("unsupported submit mode %q", modeString(mode)))
+	}
+
+	capabilities := p.Capabilities()
+	if capabilities.CanSubmit(modeStringValue(normalized)) {
+		return nil
+	}
+
+	return apperr.New(
+		apperr.CodeProviderUnsupported,
+		fmt.Sprintf("provider %q does not support %s submit capability", p.ID(), normalized),
+	)
+}
+
+type modeStringValue string
+
+func (m modeStringValue) String() string {
+	return string(m)
+}
+
+func modeString(mode ModeValue) string {
+	if mode == nil {
+		return ""
+	}
+	return strings.TrimSpace(mode.String())
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,8 +2,10 @@ package provider
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/LING71671/SurveyController-go/internal/apperr"
 	"github.com/LING71671/SurveyController-go/internal/domain"
 )
 
@@ -36,6 +38,100 @@ func TestCapabilitiesCanParseAndSubmit(t *testing.T) {
 	}
 	if !capabilities.CanSubmit(modeStub("hybrid")) {
 		t.Fatalf("CanSubmit(hybrid) = false, want true")
+	}
+}
+
+func TestRequireSubmitCapability(t *testing.T) {
+	tests := []struct {
+		name         string
+		provider     Provider
+		mode         ModeValue
+		wantErr      bool
+		wantContains string
+	}{
+		{
+			name: "http allowed",
+			provider: stubProvider{
+				id:           domain.ProviderWJX,
+				capabilities: Capabilities{SubmitHTTP: true},
+			},
+			mode: modeStub("http"),
+		},
+		{
+			name: "http requires submit http",
+			provider: stubProvider{
+				id:           domain.ProviderWJX,
+				capabilities: Capabilities{ParseHTTP: true},
+			},
+			mode:         modeStub("http"),
+			wantErr:      true,
+			wantContains: "http submit",
+		},
+		{
+			name: "browser requires submit browser",
+			provider: stubProvider{
+				id:           domain.ProviderWJX,
+				capabilities: Capabilities{RunBrowser: true},
+			},
+			mode:         modeStub("browser"),
+			wantErr:      true,
+			wantContains: "browser submit",
+		},
+		{
+			name: "hybrid allowed with submit http",
+			provider: stubProvider{
+				id:           domain.ProviderWJX,
+				capabilities: Capabilities{SupportsHybrid: true, SubmitHTTP: true},
+			},
+			mode: modeStub("hybrid"),
+		},
+		{
+			name: "hybrid requires supports hybrid",
+			provider: stubProvider{
+				id:           domain.ProviderWJX,
+				capabilities: Capabilities{SubmitHTTP: true},
+			},
+			mode:         modeStub("hybrid"),
+			wantErr:      true,
+			wantContains: "hybrid submit",
+		},
+		{
+			name:         "nil provider",
+			mode:         modeStub("http"),
+			wantErr:      true,
+			wantContains: "provider is required",
+		},
+		{
+			name: "invalid mode",
+			provider: stubProvider{
+				id:           domain.ProviderWJX,
+				capabilities: Capabilities{SubmitHTTP: true},
+			},
+			mode:         modeStub("magic"),
+			wantErr:      true,
+			wantContains: "unsupported submit mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RequireSubmitCapability(tt.provider, tt.mode)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("RequireSubmitCapability() returned nil error, want %q", tt.wantContains)
+				}
+				if !strings.Contains(err.Error(), tt.wantContains) {
+					t.Fatalf("RequireSubmitCapability() error = %v, want %q", err, tt.wantContains)
+				}
+				if !apperr.IsCode(err, apperr.CodeProviderUnsupported) {
+					t.Fatalf("RequireSubmitCapability() error = %v, want provider_unsupported", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("RequireSubmitCapability() returned error: %v", err)
+			}
+		})
 	}
 }
 
@@ -83,8 +179,9 @@ func TestMatchHostAndSuffix(t *testing.T) {
 }
 
 type stubProvider struct {
-	id   ProviderID
-	host string
+	id           ProviderID
+	host         string
+	capabilities Capabilities
 }
 
 type modeStub string
@@ -102,6 +199,9 @@ func (p stubProvider) MatchURL(rawURL string) bool {
 }
 
 func (p stubProvider) Capabilities() Capabilities {
+	if p.capabilities != (Capabilities{}) {
+		return p.capabilities
+	}
 	return Capabilities{ParseHTTP: true}
 }
 


### PR DESCRIPTION
## Summary

- add provider.RequireSubmitCapability for submit-mode capability checks
- enforce that http submit requires explicit SubmitHTTP, browser submit requires SubmitBrowser, and hybrid requires SupportsHybrid plus a submit path
- return provider_unsupported for blocked submit modes
- document the ParseHTTP vs SubmitHTTP boundary in architecture.md

## Safety

- no live network submission is added
- no provider enables SubmitHTTP in this PR
- verification, login, quota, rate-limit, and anti-abuse boundaries remain stop/report only

## Validation

- go test ./internal/provider -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- CGO_ENABLED=1 go test -race ./...

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Architecture documentation updated with enhanced details on provider submission capability requirements, validation enforcement, and explicit capability declaration for different submission modes.

* **Tests**
  * Test coverage expanded for submission capability validation, including scenarios for HTTP, browser, and hybrid submission modes with both allowed and rejected flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->