### PR TITLE
feat: 增加 WJX HTTP submission pipeline

### DIFF
--- a/internal/provider/wjx/http_submission_pipeline.go
+++ b/internal/provider/wjx/http_submission_pipeline.go
@@ -1,0 +1,36 @@
+package wjx
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
+	"github.com/LING71671/SurveyController-go/internal/engine"
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+type HTTPSubmissionPipeline struct {
+	Provider provider.Provider
+	Mode     provider.ModeValue
+	Schema   HTTPAnswerSchema
+	Executor HTTPSubmissionExecutor
+}
+
+func (p HTTPSubmissionPipeline) Submit(ctx context.Context, plan answerplan.Plan) (engine.SubmissionResult, error) {
+	if err := provider.RequireSubmitCapability(p.Provider, p.Mode); err != nil {
+		return engine.SubmissionResult{}, err
+	}
+	if p.Executor == nil {
+		return engine.SubmissionResult{}, fmt.Errorf("http submission executor is required")
+	}
+
+	draft, err := p.Schema.BuildSubmissionDraft(plan)
+	if err != nil {
+		return engine.SubmissionResult{}, err
+	}
+	response, err := ExecuteHTTPSubmission(ctx, p.Executor, draft)
+	if err != nil {
+		return engine.SubmissionResult{}, err
+	}
+	return engine.ResultFromDetection(DetectHTTPSubmissionResponse(response)), nil
+}

--- a/internal/provider/wjx/http_submission_pipeline_test.go
+++ b/internal/provider/wjx/http_submission_pipeline_test.go
@@ -1,0 +1,177 @@
+package wjx
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
+	"github.com/LING71671/SurveyController-go/internal/apperr"
+	"github.com/LING71671/SurveyController-go/internal/domain"
+	"github.com/LING71671/SurveyController-go/internal/engine"
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+func TestHTTPSubmissionPipelineSubmitSuccess(t *testing.T) {
+	executor := &pipelineRecordingExecutor{
+		response: HTTPSubmissionResponse{
+			StatusCode: http.StatusOK,
+			Body:       "提交成功",
+		},
+	}
+	result, err := testHTTPSubmissionPipeline(executor, provider.Capabilities{SubmitHTTP: true}).Submit(context.Background(), testPipelineAnswerPlan())
+	if err != nil {
+		t.Fatalf("Submit() returned error: %v", err)
+	}
+
+	if !result.Success || result.State != provider.SubmissionStateSuccess || !result.CompletionDetected {
+		t.Fatalf("Submit() = %+v, want successful result", result)
+	}
+	if len(executor.calls) != 1 || executor.calls[0].Form.Get("q1") != "2" {
+		t.Fatalf("executor calls = %+v, want mapped draft", executor.calls)
+	}
+}
+
+func TestHTTPSubmissionPipelineRequiresSubmitCapability(t *testing.T) {
+	executor := &pipelineRecordingExecutor{
+		response: HTTPSubmissionResponse{StatusCode: http.StatusOK, Body: "提交成功"},
+	}
+	_, err := testHTTPSubmissionPipeline(executor, provider.Capabilities{ParseHTTP: true}).Submit(context.Background(), testPipelineAnswerPlan())
+	if !apperr.IsCode(err, apperr.CodeProviderUnsupported) {
+		t.Fatalf("Submit() error = %v, want provider_unsupported", err)
+	}
+	if len(executor.calls) != 0 {
+		t.Fatalf("executor was called despite capability gate failure: %+v", executor.calls)
+	}
+}
+
+func TestHTTPSubmissionPipelineRejectsMissingExecutor(t *testing.T) {
+	_, err := testHTTPSubmissionPipeline(nil, provider.Capabilities{SubmitHTTP: true}).Submit(context.Background(), testPipelineAnswerPlan())
+	if err == nil || !strings.Contains(err.Error(), "executor") {
+		t.Fatalf("Submit() error = %v, want executor error", err)
+	}
+}
+
+func TestHTTPSubmissionPipelineReturnsExecutorError(t *testing.T) {
+	wantErr := errors.New("offline")
+	_, err := testHTTPSubmissionPipeline(&pipelineRecordingExecutor{err: wantErr}, provider.Capabilities{SubmitHTTP: true}).Submit(context.Background(), testPipelineAnswerPlan())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Submit() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestHTTPSubmissionPipelineMapsStopDetections(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		state   provider.SubmissionState
+		errCode apperr.Code
+	}{
+		{name: "verification", body: "请完成验证码", state: provider.SubmissionStateVerificationRequired, errCode: apperr.CodeVerificationNeeded},
+		{name: "rate limited", body: "操作频繁，请稍后再试", state: provider.SubmissionStateRateLimited, errCode: apperr.CodeRateLimited},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := testHTTPSubmissionPipeline(&pipelineRecordingExecutor{
+				response: HTTPSubmissionResponse{StatusCode: http.StatusOK, Body: tt.body},
+			}, provider.Capabilities{SubmitHTTP: true}).Submit(context.Background(), testPipelineAnswerPlan())
+			if err != nil {
+				t.Fatalf("Submit() returned error: %v", err)
+			}
+			if result.State != tt.state || !result.ShouldStop || !apperr.IsCode(result.Error, tt.errCode) {
+				t.Fatalf("Submit() = %+v, want state %q stop with %q", result, tt.state, tt.errCode)
+			}
+		})
+	}
+}
+
+func testHTTPSubmissionPipeline(executor HTTPSubmissionExecutor, capabilities provider.Capabilities) HTTPSubmissionPipeline {
+	schema, err := CompileHTTPAnswerSchema(testPipelineSurvey())
+	if err != nil {
+		panic(err)
+	}
+	return HTTPSubmissionPipeline{
+		Provider: pipelineProvider{
+			capabilities: capabilities,
+		},
+		Mode:     engine.ModeHTTP,
+		Schema:   schema,
+		Executor: executor,
+	}
+}
+
+type pipelineProvider struct {
+	capabilities provider.Capabilities
+}
+
+func (pipelineProvider) ID() provider.ProviderID {
+	return domain.ProviderWJX
+}
+
+func (pipelineProvider) MatchURL(rawURL string) bool {
+	return provider.MatchHostSuffix(rawURL, "wjx.cn")
+}
+
+func (p pipelineProvider) Capabilities() provider.Capabilities {
+	return p.capabilities
+}
+
+func (pipelineProvider) Parse(context.Context, string) (provider.SurveyDefinition, error) {
+	return provider.SurveyDefinition{}, nil
+}
+
+type pipelineRecordingExecutor struct {
+	response HTTPSubmissionResponse
+	err      error
+	calls    []HTTPSubmissionDraft
+}
+
+func (e *pipelineRecordingExecutor) ExecuteHTTPSubmission(ctx context.Context, draft HTTPSubmissionDraft) (HTTPSubmissionResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return HTTPSubmissionResponse{}, err
+	}
+	e.calls = append(e.calls, cloneHTTPSubmissionDraft(draft))
+	if e.err != nil {
+		return HTTPSubmissionResponse{}, e.err
+	}
+	return cloneHTTPSubmissionResponse(e.response), nil
+}
+
+func testPipelineSurvey() domain.SurveyDefinition {
+	return domain.SurveyDefinition{
+		Provider: domain.ProviderWJX,
+		Title:    "Pipeline",
+		URL:      "https://www.wjx.cn/vm/pipeline.aspx",
+		Questions: []domain.QuestionDefinition{
+			{
+				ID:    "q1",
+				Title: "Single",
+				Kind:  domain.QuestionKindSingle,
+				Options: []domain.OptionDefinition{
+					{ID: "a", Label: "A", Value: "1"},
+					{ID: "b", Label: "B", Value: "2"},
+				},
+			},
+			{
+				ID:    "q2",
+				Title: "Rating",
+				Kind:  domain.QuestionKindRating,
+				Options: []domain.OptionDefinition{
+					{ID: "score5", Label: "5", Value: "5"},
+				},
+			},
+		},
+	}
+}
+
+func testPipelineAnswerPlan() answerplan.Plan {
+	return answerplan.Plan{
+		Answers: []answerplan.QuestionAnswer{
+			{QuestionID: "q1", OptionIDs: []string{"b"}},
+			{QuestionID: "q2", OptionIDs: []string{"score5"}},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- add WJX HTTPSubmissionPipeline to compose submit capability gate, answer schema, executor, response detector, and engine.SubmissionResult mapping
- keep executor injectable and mock-only in tests
- verify the capability gate prevents executor calls when SubmitHTTP is not declared
- cover success, missing executor, executor error, verification stop, and rate-limit stop paths

## Safety

- no live network executor is added
- WJX still does not declare SubmitHTTP
- login, verification, quota, rate-limit, and anti-abuse signals remain stop/report states

## Validation

- go test ./internal/provider/wjx -run 'TestHTTPSubmissionPipeline' -count=1
- go test ./internal/provider/wjx -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- CGO_ENABLED=1 go test -race ./...

Closes #49