### PR TITLE
perf: 预编译 WJX HTTP submission pipeline

### DIFF
--- a/internal/provider/wjx/http_path_benchmark_test.go
+++ b/internal/provider/wjx/http_path_benchmark_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/LING71671/SurveyController-go/internal/provider"
 )
 
-var benchmarkHTTPPathDetection provider.SubmissionDetection
+var benchmarkHTTPPathState provider.SubmissionState
 
 func BenchmarkHTTPPathLightTasks(b *testing.B) {
 	for _, taskCount := range []int{1, 1000, 5000} {
@@ -24,38 +24,38 @@ func BenchmarkHTTPPathLightTasks(b *testing.B) {
 func benchmarkHTTPPathLightTasks(b *testing.B, taskCount int) {
 	b.Helper()
 	ctx := context.Background()
-	schema, err := CompileHTTPAnswerSchema(benchmarkSurvey())
-	if err != nil {
-		b.Fatalf("CompileHTTPAnswerSchema() returned error: %v", err)
-	}
 	plan := benchmarkAnswerPlan()
-	executor := staticHTTPSubmissionExecutor{
-		response: HTTPSubmissionResponse{
-			StatusCode: http.StatusOK,
-			Header:     http.Header{"Content-Type": []string{"text/plain"}},
-			Body:       "提交成功",
+	pipeline, err := NewHTTPSubmissionPipeline(
+		benchmarkProvider{capabilities: provider.Capabilities{SubmitHTTP: true}},
+		engineModeHTTP{},
+		benchmarkSurvey(),
+		staticHTTPSubmissionExecutor{
+			response: HTTPSubmissionResponse{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/plain"}},
+				Body:       "提交成功",
+			},
 		},
+	)
+	if err != nil {
+		b.Fatalf("NewHTTPSubmissionPipeline() returned error: %v", err)
 	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		var detection provider.SubmissionDetection
+		var state provider.SubmissionState
 		for j := 0; j < taskCount; j++ {
-			draft, err := schema.BuildSubmissionDraft(plan)
+			submissionResult, err := pipeline.Submit(ctx, plan)
 			if err != nil {
-				b.Fatalf("BuildSubmissionDraft() returned error: %v", err)
+				b.Fatalf("Submit() returned error: %v", err)
 			}
-			response, err := ExecuteHTTPSubmission(ctx, executor, draft)
-			if err != nil {
-				b.Fatalf("ExecuteHTTPSubmission() returned error: %v", err)
+			if submissionResult.State != provider.SubmissionStateSuccess {
+				b.Fatalf("state = %q, want success", submissionResult.State)
 			}
-			detection = DetectHTTPSubmissionResponse(response)
-			if detection.State != provider.SubmissionStateSuccess {
-				b.Fatalf("state = %q, want success", detection.State)
-			}
+			state = submissionResult.State
 		}
-		benchmarkHTTPPathDetection = detection
+		benchmarkHTTPPathState = state
 	}
 }
 
@@ -69,6 +69,32 @@ func (e staticHTTPSubmissionExecutor) ExecuteHTTPSubmission(ctx context.Context,
 	}
 	_ = draft
 	return e.response, nil
+}
+
+type benchmarkProvider struct {
+	capabilities provider.Capabilities
+}
+
+func (benchmarkProvider) ID() provider.ProviderID {
+	return domain.ProviderWJX
+}
+
+func (benchmarkProvider) MatchURL(rawURL string) bool {
+	return provider.MatchHostSuffix(rawURL, "wjx.cn")
+}
+
+func (p benchmarkProvider) Capabilities() provider.Capabilities {
+	return p.capabilities
+}
+
+func (benchmarkProvider) Parse(context.Context, string) (provider.SurveyDefinition, error) {
+	return provider.SurveyDefinition{}, nil
+}
+
+type engineModeHTTP struct{}
+
+func (engineModeHTTP) String() string {
+	return "http"
 }
 
 func benchmarkSurvey() domain.SurveyDefinition {

--- a/internal/provider/wjx/http_submission_pipeline.go
+++ b/internal/provider/wjx/http_submission_pipeline.go
@@ -10,25 +10,37 @@ import (
 )
 
 type HTTPSubmissionPipeline struct {
-	Provider provider.Provider
-	Mode     provider.ModeValue
-	Schema   HTTPAnswerSchema
-	Executor HTTPSubmissionExecutor
+	schema   HTTPAnswerSchema
+	executor HTTPSubmissionExecutor
+}
+
+func NewHTTPSubmissionPipeline(p provider.Provider, mode provider.ModeValue, survey provider.SurveyDefinition, executor HTTPSubmissionExecutor) (HTTPSubmissionPipeline, error) {
+	if err := provider.RequireSubmitCapability(p, mode); err != nil {
+		return HTTPSubmissionPipeline{}, err
+	}
+	if executor == nil {
+		return HTTPSubmissionPipeline{}, fmt.Errorf("http submission executor is required")
+	}
+	schema, err := CompileHTTPAnswerSchema(survey)
+	if err != nil {
+		return HTTPSubmissionPipeline{}, err
+	}
+	return HTTPSubmissionPipeline{
+		schema:   schema,
+		executor: executor,
+	}, nil
 }
 
 func (p HTTPSubmissionPipeline) Submit(ctx context.Context, plan answerplan.Plan) (engine.SubmissionResult, error) {
-	if err := provider.RequireSubmitCapability(p.Provider, p.Mode); err != nil {
-		return engine.SubmissionResult{}, err
-	}
-	if p.Executor == nil {
+	if p.executor == nil {
 		return engine.SubmissionResult{}, fmt.Errorf("http submission executor is required")
 	}
 
-	draft, err := p.Schema.BuildSubmissionDraft(plan)
+	draft, err := p.schema.BuildSubmissionDraft(plan)
 	if err != nil {
 		return engine.SubmissionResult{}, err
 	}
-	response, err := ExecuteHTTPSubmission(ctx, p.Executor, draft)
+	response, err := ExecuteHTTPSubmission(ctx, p.executor, draft)
 	if err != nil {
 		return engine.SubmissionResult{}, err
 	}

--- a/internal/provider/wjx/http_submission_pipeline_test.go
+++ b/internal/provider/wjx/http_submission_pipeline_test.go
@@ -21,7 +21,12 @@ func TestHTTPSubmissionPipelineSubmitSuccess(t *testing.T) {
 			Body:       "提交成功",
 		},
 	}
-	result, err := testHTTPSubmissionPipeline(executor, provider.Capabilities{SubmitHTTP: true}).Submit(context.Background(), testPipelineAnswerPlan())
+	pipeline, err := testHTTPSubmissionPipeline(executor, provider.Capabilities{SubmitHTTP: true})
+	if err != nil {
+		t.Fatalf("NewHTTPSubmissionPipeline() returned error: %v", err)
+	}
+
+	result, err := pipeline.Submit(context.Background(), testPipelineAnswerPlan())
 	if err != nil {
 		t.Fatalf("Submit() returned error: %v", err)
 	}
@@ -38,9 +43,9 @@ func TestHTTPSubmissionPipelineRequiresSubmitCapability(t *testing.T) {
 	executor := &pipelineRecordingExecutor{
 		response: HTTPSubmissionResponse{StatusCode: http.StatusOK, Body: "提交成功"},
 	}
-	_, err := testHTTPSubmissionPipeline(executor, provider.Capabilities{ParseHTTP: true}).Submit(context.Background(), testPipelineAnswerPlan())
+	_, err := testHTTPSubmissionPipeline(executor, provider.Capabilities{ParseHTTP: true})
 	if !apperr.IsCode(err, apperr.CodeProviderUnsupported) {
-		t.Fatalf("Submit() error = %v, want provider_unsupported", err)
+		t.Fatalf("NewHTTPSubmissionPipeline() error = %v, want provider_unsupported", err)
 	}
 	if len(executor.calls) != 0 {
 		t.Fatalf("executor was called despite capability gate failure: %+v", executor.calls)
@@ -48,15 +53,19 @@ func TestHTTPSubmissionPipelineRequiresSubmitCapability(t *testing.T) {
 }
 
 func TestHTTPSubmissionPipelineRejectsMissingExecutor(t *testing.T) {
-	_, err := testHTTPSubmissionPipeline(nil, provider.Capabilities{SubmitHTTP: true}).Submit(context.Background(), testPipelineAnswerPlan())
+	_, err := testHTTPSubmissionPipeline(nil, provider.Capabilities{SubmitHTTP: true})
 	if err == nil || !strings.Contains(err.Error(), "executor") {
-		t.Fatalf("Submit() error = %v, want executor error", err)
+		t.Fatalf("NewHTTPSubmissionPipeline() error = %v, want executor error", err)
 	}
 }
 
 func TestHTTPSubmissionPipelineReturnsExecutorError(t *testing.T) {
 	wantErr := errors.New("offline")
-	_, err := testHTTPSubmissionPipeline(&pipelineRecordingExecutor{err: wantErr}, provider.Capabilities{SubmitHTTP: true}).Submit(context.Background(), testPipelineAnswerPlan())
+	pipeline, err := testHTTPSubmissionPipeline(&pipelineRecordingExecutor{err: wantErr}, provider.Capabilities{SubmitHTTP: true})
+	if err != nil {
+		t.Fatalf("NewHTTPSubmissionPipeline() returned error: %v", err)
+	}
+	_, err = pipeline.Submit(context.Background(), testPipelineAnswerPlan())
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("Submit() error = %v, want %v", err, wantErr)
 	}
@@ -75,9 +84,13 @@ func TestHTTPSubmissionPipelineMapsStopDetections(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := testHTTPSubmissionPipeline(&pipelineRecordingExecutor{
+			pipeline, err := testHTTPSubmissionPipeline(&pipelineRecordingExecutor{
 				response: HTTPSubmissionResponse{StatusCode: http.StatusOK, Body: tt.body},
-			}, provider.Capabilities{SubmitHTTP: true}).Submit(context.Background(), testPipelineAnswerPlan())
+			}, provider.Capabilities{SubmitHTTP: true})
+			if err != nil {
+				t.Fatalf("NewHTTPSubmissionPipeline() returned error: %v", err)
+			}
+			result, err := pipeline.Submit(context.Background(), testPipelineAnswerPlan())
 			if err != nil {
 				t.Fatalf("Submit() returned error: %v", err)
 			}
@@ -88,19 +101,35 @@ func TestHTTPSubmissionPipelineMapsStopDetections(t *testing.T) {
 	}
 }
 
-func testHTTPSubmissionPipeline(executor HTTPSubmissionExecutor, capabilities provider.Capabilities) HTTPSubmissionPipeline {
-	schema, err := CompileHTTPAnswerSchema(testPipelineSurvey())
-	if err != nil {
-		panic(err)
+func TestHTTPSubmissionPipelineRejectsInvalidSurvey(t *testing.T) {
+	_, err := NewHTTPSubmissionPipeline(
+		pipelineProvider{capabilities: provider.Capabilities{SubmitHTTP: true}},
+		engine.ModeHTTP,
+		domain.SurveyDefinition{
+			Provider: domain.ProviderWJX,
+			Title:    "invalid",
+			URL:      "https://www.wjx.cn/vm/invalid.aspx",
+			Questions: []domain.QuestionDefinition{
+				{ID: "q1", Title: "One", Kind: domain.QuestionKindSingle},
+				{ID: "q1", Title: "Duplicate", Kind: domain.QuestionKindSingle},
+			},
+		},
+		&pipelineRecordingExecutor{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "defined more than once") {
+		t.Fatalf("NewHTTPSubmissionPipeline() error = %v, want schema error", err)
 	}
-	return HTTPSubmissionPipeline{
-		Provider: pipelineProvider{
+}
+
+func testHTTPSubmissionPipeline(executor HTTPSubmissionExecutor, capabilities provider.Capabilities) (HTTPSubmissionPipeline, error) {
+	return NewHTTPSubmissionPipeline(
+		pipelineProvider{
 			capabilities: capabilities,
 		},
-		Mode:     engine.ModeHTTP,
-		Schema:   schema,
-		Executor: executor,
-	}
+		engine.ModeHTTP,
+		testPipelineSurvey(),
+		executor,
+	)
 }
 
 type pipelineProvider struct {


### PR DESCRIPTION
## Summary

- add NewHTTPSubmissionPipeline so capability gate, executor validation, and HTTPAnswerSchema compilation happen once at construction
- keep Submit focused on the hot path: answer plan -> draft -> executor -> detector -> engine result
- make pipeline internals private to avoid zero-value/manual assembly misuse
- update WJX HTTP path benchmark to exercise the pipeline API

## Benchmark snapshot

Command:

\\\powershell
go test ./internal/provider/wjx -bench BenchmarkHTTPPathLightTasks -benchmem -run '^$' -count=1
\\\

Local result on Windows amd64 / i7-14650HX:

\\\	ext
BenchmarkHTTPPathLightTasks/tasks_1-24       10183 ns/op     3544 B/op      39 allocs/op
BenchmarkHTTPPathLightTasks/tasks_1000-24    9593059 ns/op   3544023 B/op   39000 allocs/op
BenchmarkHTTPPathLightTasks/tasks_5000-24    49452700 ns/op  17720118 B/op  195000 allocs/op
\\\

## Safety

- no live network executor is added
- WJX still does not declare SubmitHTTP
- login, verification, quota, rate-limit, and anti-abuse signals remain stop/report states

## Validation

- go test ./internal/provider/wjx -run 'TestHTTPSubmissionPipeline|TestHTTPAnswerSchema' -count=1
- go test ./internal/provider/wjx -bench BenchmarkHTTPPathLightTasks -benchmem -run '^$' -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- CGO_ENABLED=1 go test -race ./...

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized benchmark performance by reusing pipeline setup across iterations rather than rebuilding per iteration.
  * Enhanced test coverage for error handling and validation.

* **Refactor**
  * Improved HTTP submission pipeline architecture with better separation of concerns and encapsulation.
  * Introduced constructor-based initialization with validation checks performed upfront rather than at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->