### PR TITLE
feat: 增加 answer plan submission task 适配器

### DIFF
--- a/internal/answerplan/clone.go
+++ b/internal/answerplan/clone.go
@@ -1,0 +1,18 @@
+package answerplan
+
+func Clone(plan Plan) Plan {
+	if len(plan.Answers) == 0 {
+		return Plan{}
+	}
+	cloned := Plan{
+		Answers: make([]QuestionAnswer, len(plan.Answers)),
+	}
+	for i, answer := range plan.Answers {
+		cloned.Answers[i] = QuestionAnswer{
+			QuestionID: answer.QuestionID,
+			OptionIDs:  append([]string(nil), answer.OptionIDs...),
+			Value:      answer.Value,
+		}
+	}
+	return cloned
+}

--- a/internal/answerplan/clone_test.go
+++ b/internal/answerplan/clone_test.go
@@ -1,0 +1,20 @@
+package answerplan
+
+import "testing"
+
+func TestClone(t *testing.T) {
+	plan := Plan{
+		Answers: []QuestionAnswer{
+			{QuestionID: "q1", OptionIDs: []string{"a", "b"}, Value: "x"},
+		},
+	}
+
+	cloned := Clone(plan)
+	plan.Answers[0].QuestionID = "mutated"
+	plan.Answers[0].OptionIDs[0] = "mutated"
+	plan.Answers[0].Value = "mutated"
+
+	if cloned.Answers[0].QuestionID != "q1" || cloned.Answers[0].OptionIDs[0] != "a" || cloned.Answers[0].Value != "x" {
+		t.Fatalf("Clone() = %+v, want independent copy", cloned)
+	}
+}

--- a/internal/runner/submission_tasks.go
+++ b/internal/runner/submission_tasks.go
@@ -1,0 +1,32 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
+	"github.com/LING71671/SurveyController-go/internal/engine"
+)
+
+type AnswerPlanSubmitter interface {
+	Submit(ctx context.Context, plan answerplan.Plan) (engine.SubmissionResult, error)
+}
+
+func SubmissionTasksFromAnswerPlans(submitter AnswerPlanSubmitter, plans []answerplan.Plan) ([]SubmissionTask, error) {
+	if submitter == nil {
+		return nil, fmt.Errorf("answer plan submitter is required")
+	}
+	if len(plans) == 0 {
+		return nil, fmt.Errorf("answer plans are required")
+	}
+
+	tasks := make([]SubmissionTask, 0, len(plans))
+	for _, plan := range plans {
+		taskPlan := answerplan.Clone(plan)
+		tasks = append(tasks, func(ctx context.Context, workerID int) (engine.SubmissionResult, error) {
+			_ = workerID
+			return submitter.Submit(ctx, taskPlan)
+		})
+	}
+	return tasks, nil
+}

--- a/internal/runner/submission_tasks_test.go
+++ b/internal/runner/submission_tasks_test.go
@@ -1,0 +1,117 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
+	"github.com/LING71671/SurveyController-go/internal/engine"
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+func TestSubmissionTasksFromAnswerPlans(t *testing.T) {
+	submitter := &recordingAnswerPlanSubmitter{}
+	plans := []answerplan.Plan{
+		{Answers: []answerplan.QuestionAnswer{{QuestionID: "q1", Value: "1"}}},
+		{Answers: []answerplan.QuestionAnswer{{QuestionID: "q2", Value: "2"}}},
+	}
+
+	tasks, err := SubmissionTasksFromAnswerPlans(submitter, plans)
+	if err != nil {
+		t.Fatalf("SubmissionTasksFromAnswerPlans() returned error: %v", err)
+	}
+	plans[0].Answers[0].QuestionID = "mutated"
+
+	for _, task := range tasks {
+		result, err := task(context.Background(), 7)
+		if err != nil {
+			t.Fatalf("task returned error: %v", err)
+		}
+		if !result.Success {
+			t.Fatalf("task result = %+v, want success", result)
+		}
+	}
+
+	if got := submitter.plans[0].Answers[0].QuestionID; got != "q1" {
+		t.Fatalf("first submitted plan id = %q, want q1", got)
+	}
+	if got := submitter.plans[1].Answers[0].QuestionID; got != "q2" {
+		t.Fatalf("second submitted plan id = %q, want q2", got)
+	}
+}
+
+func TestWorkerPoolRunSubmissionsWithAnswerPlanTasks(t *testing.T) {
+	tasks, err := SubmissionTasksFromAnswerPlans(&recordingAnswerPlanSubmitter{}, []answerplan.Plan{
+		{Answers: []answerplan.QuestionAnswer{{QuestionID: "q1", Value: "1"}}},
+		{Answers: []answerplan.QuestionAnswer{{QuestionID: "q2", Value: "2"}}},
+	})
+	if err != nil {
+		t.Fatalf("SubmissionTasksFromAnswerPlans() returned error: %v", err)
+	}
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 2, Target: 2})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+
+	snapshot := pool.RunSubmissions(context.Background(), tasks)
+	if snapshot.Successes != 2 || snapshot.Failures != 0 {
+		t.Fatalf("snapshot counts = %d/%d, want 2/0", snapshot.Successes, snapshot.Failures)
+	}
+}
+
+func TestSubmissionTasksFromAnswerPlansRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		submitter AnswerPlanSubmitter
+		plans     []answerplan.Plan
+		want      string
+	}{
+		{name: "submitter", plans: []answerplan.Plan{{}}, want: "submitter"},
+		{name: "plans", submitter: &recordingAnswerPlanSubmitter{}, want: "plans"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := SubmissionTasksFromAnswerPlans(tt.submitter, tt.plans)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("SubmissionTasksFromAnswerPlans() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubmissionTasksFromAnswerPlansReturnsSubmitterError(t *testing.T) {
+	wantErr := errors.New("submit failed")
+	tasks, err := SubmissionTasksFromAnswerPlans(&recordingAnswerPlanSubmitter{err: wantErr}, []answerplan.Plan{{}})
+	if err != nil {
+		t.Fatalf("SubmissionTasksFromAnswerPlans() returned error: %v", err)
+	}
+
+	_, err = tasks[0](context.Background(), 1)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("task error = %v, want %v", err, wantErr)
+	}
+}
+
+type recordingAnswerPlanSubmitter struct {
+	err   error
+	plans []answerplan.Plan
+}
+
+func (s *recordingAnswerPlanSubmitter) Submit(ctx context.Context, plan answerplan.Plan) (engine.SubmissionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return engine.SubmissionResult{}, err
+	}
+	s.plans = append(s.plans, answerplan.Clone(plan))
+	if s.err != nil {
+		return engine.SubmissionResult{}, s.err
+	}
+	return engine.SubmissionResult{
+		State:    provider.SubmissionStateSuccess,
+		Message:  "ok",
+		Success:  true,
+		Terminal: true,
+	}, nil
+}


### PR DESCRIPTION
## Summary

- add answerplan.Clone for defensive plan copies
- add runner.AnswerPlanSubmitter interface
- add runner.SubmissionTasksFromAnswerPlans to compile answer plans into SubmissionTask values
- cover task execution, defensive cloning, submitter errors, invalid input, and WorkerPool.RunSubmissions integration

## Safety

- no live network executor is added
- no provider declares SubmitHTTP
- this only adapts prebuilt answer plans into existing runner submission tasks

## Validation

- go test ./internal/answerplan ./internal/runner -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- CGO_ENABLED=1 go test -race ./...

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved answer plan submission infrastructure enabling enhanced task execution with proper state isolation between concurrent submissions and better error handling.

* **Tests**
  * Added comprehensive test coverage for answer plan cloning and submission task conversion, including edge cases and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->