### PR TITLE
feat: 增加 runner AnswerPlan builder

### DIFF
--- a/internal/runner/answer_plan_builder.go
+++ b/internal/runner/answer_plan_builder.go
@@ -1,0 +1,117 @@
+package runner
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strings"
+
+	"github.com/LING71671/SurveyController-go/internal/answer"
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
+	"github.com/LING71671/SurveyController-go/internal/domain"
+)
+
+func BuildAnswerPlan(rng *rand.Rand, questions []QuestionPlan) (answerplan.Plan, error) {
+	if rng == nil {
+		return answerplan.Plan{}, fmt.Errorf("rng is required")
+	}
+	if len(questions) == 0 {
+		return answerplan.Plan{}, fmt.Errorf("questions are required")
+	}
+
+	plan := answerplan.Plan{
+		Answers: make([]answerplan.QuestionAnswer, 0, len(questions)),
+	}
+	for _, question := range questions {
+		answer, err := buildQuestionAnswer(rng, question)
+		if err != nil {
+			return answerplan.Plan{}, err
+		}
+		plan.Answers = append(plan.Answers, answer)
+	}
+	return plan, nil
+}
+
+func buildQuestionAnswer(rng *rand.Rand, question QuestionPlan) (answerplan.QuestionAnswer, error) {
+	questionID := strings.TrimSpace(question.ID)
+	if questionID == "" {
+		return answerplan.QuestionAnswer{}, fmt.Errorf("question id is required")
+	}
+
+	kind, err := domain.ParseQuestionKind(question.Kind)
+	if err != nil {
+		return answerplan.QuestionAnswer{}, fmt.Errorf("question %q kind: %w", questionID, err)
+	}
+
+	switch kind {
+	case domain.QuestionKindSingle, domain.QuestionKindDropdown, domain.QuestionKindRating:
+		optionID, err := answer.PickOne(rng, question.Weights)
+		if err != nil {
+			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q pick one: %w", questionID, err)
+		}
+		return answerplan.QuestionAnswer{QuestionID: questionID, OptionIDs: []string{optionID}}, nil
+	case domain.QuestionKindMultiple:
+		selected, err := answer.PickMany(rng, question.Weights, selectionRuleFromOptions(question.Options))
+		if err != nil {
+			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q pick many: %w", questionID, err)
+		}
+		return answerplan.QuestionAnswer{QuestionID: questionID, OptionIDs: selected.OptionIDs}, nil
+	default:
+		return answerplan.QuestionAnswer{}, fmt.Errorf("question %q kind %q is not supported for answer plan builder", questionID, kind)
+	}
+}
+
+func selectionRuleFromOptions(options map[string]any) answer.SelectionRule {
+	return answer.SelectionRule{
+		Min: intOption(options, "min_selected", "min"),
+		Max: intOption(options, "max_selected", "max"),
+	}
+}
+
+func intOption(options map[string]any, keys ...string) int {
+	for _, key := range keys {
+		raw, ok := options[key]
+		if !ok {
+			continue
+		}
+		value, ok := asNonNegativeInt(raw)
+		if ok {
+			return value
+		}
+	}
+	return 0
+}
+
+func asNonNegativeInt(raw any) (int, bool) {
+	switch value := raw.(type) {
+	case int:
+		return clampNonNegative(value), true
+	case int64:
+		return clampNonNegative64(value), true
+	case float64:
+		if math.Trunc(value) != value {
+			return 0, false
+		}
+		return clampNonNegative64(int64(value)), true
+	default:
+		return 0, false
+	}
+}
+
+func clampNonNegative(value int) int {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func clampNonNegative64(value int64) int {
+	if value < 0 {
+		return 0
+	}
+	maxInt := int64(int(^uint(0) >> 1))
+	if value > maxInt {
+		return int(maxInt)
+	}
+	return int(value)
+}

--- a/internal/runner/answer_plan_builder_test.go
+++ b/internal/runner/answer_plan_builder_test.go
@@ -1,0 +1,123 @@
+package runner
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/answer"
+)
+
+func TestBuildAnswerPlan(t *testing.T) {
+	got, err := BuildAnswerPlan(rand.New(rand.NewSource(1)), []QuestionPlan{
+		{
+			ID:   "q1",
+			Kind: "single",
+			Weights: []answer.OptionWeight{
+				{OptionID: "a", Weight: 0},
+				{OptionID: "b", Weight: 1},
+			},
+		},
+		{
+			ID:   "q2",
+			Kind: "multiple",
+			Options: map[string]any{
+				"min_selected": 2,
+				"max_selected": 2,
+			},
+			Weights: []answer.OptionWeight{
+				{OptionID: "a", Weight: 1},
+				{OptionID: "b", Weight: 1},
+				{OptionID: "c", Weight: 1},
+			},
+		},
+		{
+			ID:   "q3",
+			Kind: "rating",
+			Weights: []answer.OptionWeight{
+				{OptionID: "score5", Weight: 1},
+			},
+		},
+		{
+			ID:   "q4",
+			Kind: "dropdown",
+			Weights: []answer.OptionWeight{
+				{OptionID: "city2", Weight: 1},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildAnswerPlan() returned error: %v", err)
+	}
+
+	if len(got.Answers) != 4 {
+		t.Fatalf("len(Answers) = %d, want 4", len(got.Answers))
+	}
+	if got.Answers[0].QuestionID != "q1" || got.Answers[0].OptionIDs[0] != "b" {
+		t.Fatalf("first answer = %+v, want q1=b", got.Answers[0])
+	}
+	if got.Answers[1].QuestionID != "q2" || len(got.Answers[1].OptionIDs) != 2 {
+		t.Fatalf("second answer = %+v, want two selected options", got.Answers[1])
+	}
+	if got.Answers[2].OptionIDs[0] != "score5" || got.Answers[3].OptionIDs[0] != "city2" {
+		t.Fatalf("rating/dropdown answers = %+v/%+v, want score5/city2", got.Answers[2], got.Answers[3])
+	}
+}
+
+func TestBuildAnswerPlanSupportsMinMaxAliases(t *testing.T) {
+	got, err := BuildAnswerPlan(rand.New(rand.NewSource(2)), []QuestionPlan{
+		{
+			ID:   "q1",
+			Kind: "multiple",
+			Options: map[string]any{
+				"min": float64(1),
+				"max": int64(1),
+			},
+			Weights: []answer.OptionWeight{
+				{OptionID: "a", Weight: 1},
+				{OptionID: "b", Weight: 1},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildAnswerPlan() returned error: %v", err)
+	}
+	if len(got.Answers[0].OptionIDs) != 1 {
+		t.Fatalf("OptionIDs = %+v, want one selected option", got.Answers[0].OptionIDs)
+	}
+}
+
+func TestBuildAnswerPlanRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		rng       *rand.Rand
+		questions []QuestionPlan
+		want      string
+	}{
+		{name: "rng", questions: []QuestionPlan{{ID: "q1", Kind: "single"}}, want: "rng"},
+		{name: "questions", rng: rand.New(rand.NewSource(1)), want: "questions"},
+		{name: "question id", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{Kind: "single"}}, want: "question id"},
+		{name: "kind", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{ID: "q1", Kind: "text"}}, want: "not supported"},
+		{name: "weights", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{ID: "q1", Kind: "single"}}, want: "weights"},
+		{
+			name: "multiple rule",
+			rng:  rand.New(rand.NewSource(1)),
+			questions: []QuestionPlan{{
+				ID:      "q1",
+				Kind:    "multiple",
+				Options: map[string]any{"min": 2, "max": 1},
+				Weights: []answer.OptionWeight{{OptionID: "a", Weight: 1}},
+			}},
+			want: "min must not be greater",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := BuildAnswerPlan(tt.rng, tt.questions)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("BuildAnswerPlan() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add runner.BuildAnswerPlan to generate provider-neutral answerplan.Plan values from compiled QuestionPlan values
- support single, dropdown, rating, and multiple questions using existing answer probability helpers
- support multiple selection limits through min/max and min_selected/max_selected options
- cover success paths and invalid input/error wrapping

## Safety

- no live network executor is added
- no provider declares SubmitHTTP
- this only generates local answer plans from compiled config

## Validation

- go test ./internal/runner -run 'TestBuildAnswerPlan' -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- CGO_ENABLED=1 go test -race ./...

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added answer plan builder that validates survey inputs and generates answers for single choice, dropdown, rating, and multiple selection question types with proper selection constraints.

* **Tests**
  * Added comprehensive test suite covering answer plan generation for all question types and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->