### PR TITLE
feat: 增加批量 AnswerPlan 生成

### DIFF
--- a/internal/runner/answer_plan_builder.go
+++ b/internal/runner/answer_plan_builder.go
@@ -32,6 +32,21 @@ func BuildAnswerPlan(rng *rand.Rand, questions []QuestionPlan) (answerplan.Plan,
 	return plan, nil
 }
 
+func BuildAnswerPlans(rng *rand.Rand, questions []QuestionPlan, count int) ([]answerplan.Plan, error) {
+	if count <= 0 {
+		return nil, fmt.Errorf("answer plan count must be greater than 0")
+	}
+	plans := make([]answerplan.Plan, 0, count)
+	for i := 0; i < count; i++ {
+		plan, err := BuildAnswerPlan(rng, questions)
+		if err != nil {
+			return nil, fmt.Errorf("answer plan %d: %w", i+1, err)
+		}
+		plans = append(plans, answerplan.Clone(plan))
+	}
+	return plans, nil
+}
+
 func buildQuestionAnswer(rng *rand.Rand, question QuestionPlan) (answerplan.QuestionAnswer, error) {
 	questionID := strings.TrimSpace(question.ID)
 	if questionID == "" {

--- a/internal/runner/answer_plan_builder_test.go
+++ b/internal/runner/answer_plan_builder_test.go
@@ -87,6 +87,46 @@ func TestBuildAnswerPlanSupportsMinMaxAliases(t *testing.T) {
 	}
 }
 
+func TestBuildAnswerPlans(t *testing.T) {
+	questions := []QuestionPlan{
+		{
+			ID:   "q1",
+			Kind: "single",
+			Weights: []answer.OptionWeight{
+				{OptionID: "a", Weight: 1},
+				{OptionID: "b", Weight: 1},
+			},
+		},
+	}
+
+	plans, err := BuildAnswerPlans(rand.New(rand.NewSource(3)), questions, 3)
+	if err != nil {
+		t.Fatalf("BuildAnswerPlans() returned error: %v", err)
+	}
+	if len(plans) != 3 {
+		t.Fatalf("len(plans) = %d, want 3", len(plans))
+	}
+	plans[0].Answers[0].QuestionID = "mutated"
+	if plans[1].Answers[0].QuestionID != "q1" {
+		t.Fatalf("plans are not independent: %+v", plans)
+	}
+}
+
+func TestBuildAnswerPlansRejectsInvalidInput(t *testing.T) {
+	questions := []QuestionPlan{{
+		ID:      "q1",
+		Kind:    "single",
+		Weights: []answer.OptionWeight{{OptionID: "a", Weight: 1}},
+	}}
+
+	if _, err := BuildAnswerPlans(rand.New(rand.NewSource(1)), questions, 0); err == nil || !strings.Contains(err.Error(), "count") {
+		t.Fatalf("BuildAnswerPlans(count=0) error = %v, want count error", err)
+	}
+	if _, err := BuildAnswerPlans(nil, questions, 1); err == nil || !strings.Contains(err.Error(), "answer plan 1") || !strings.Contains(err.Error(), "rng") {
+		t.Fatalf("BuildAnswerPlans(nil rng) error = %v, want indexed rng error", err)
+	}
+}
+
 func TestBuildAnswerPlanRejectsInvalidInput(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary

- add runner.BuildAnswerPlans for generating multiple answerplan.Plan values from compiled QuestionPlan values
- reuse BuildAnswerPlan for per-plan sampling
- validate count and wrap per-plan generation errors with an index
- clone each generated plan so returned plans are independent

## Safety

- no live network executor is added
- no provider declares SubmitHTTP
- this only generates local answer plans for later runner submission tasks

## Validation

- go test ./internal/runner -run 'TestBuildAnswerPlan|TestBuildAnswerPlans' -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check
- CGO_ENABLED=1 go test -race ./...

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new operation to generate multiple answer plans in a single call, with input validation for plan count requirements and improved error handling for invalid inputs.

* **Tests**
  * Added unit tests verifying the new functionality produces the correct number of independent plans and properly validates input parameters with appropriate error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->