### PR TITLE
[codex] 从 runner.Plan 构建 submission tasks

### DIFF
--- a/internal/runner/submission_tasks.go
+++ b/internal/runner/submission_tasks.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"math/rand"
 
 	"github.com/LING71671/SurveyController-go/internal/answerplan"
 	"github.com/LING71671/SurveyController-go/internal/engine"
@@ -29,4 +30,15 @@ func SubmissionTasksFromAnswerPlans(submitter AnswerPlanSubmitter, plans []answe
 		})
 	}
 	return tasks, nil
+}
+
+func SubmissionTasksFromPlan(rng *rand.Rand, plan Plan, submitter AnswerPlanSubmitter) ([]SubmissionTask, error) {
+	if err := New().ValidatePlan(plan); err != nil {
+		return nil, err
+	}
+	answerPlans, err := BuildAnswerPlans(rng, plan.Questions, plan.Target)
+	if err != nil {
+		return nil, err
+	}
+	return SubmissionTasksFromAnswerPlans(submitter, answerPlans)
 }

--- a/internal/runner/submission_tasks_test.go
+++ b/internal/runner/submission_tasks_test.go
@@ -3,9 +3,12 @@ package runner
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/LING71671/SurveyController-go/internal/answer"
 	"github.com/LING71671/SurveyController-go/internal/answerplan"
 	"github.com/LING71671/SurveyController-go/internal/engine"
 	"github.com/LING71671/SurveyController-go/internal/provider"
@@ -34,10 +37,11 @@ func TestSubmissionTasksFromAnswerPlans(t *testing.T) {
 		}
 	}
 
-	if got := submitter.plans[0].Answers[0].QuestionID; got != "q1" {
+	submittedPlans := submitter.submittedPlans()
+	if got := submittedPlans[0].Answers[0].QuestionID; got != "q1" {
 		t.Fatalf("first submitted plan id = %q, want q1", got)
 	}
-	if got := submitter.plans[1].Answers[0].QuestionID; got != "q2" {
+	if got := submittedPlans[1].Answers[0].QuestionID; got != "q2" {
 		t.Fatalf("second submitted plan id = %q, want q2", got)
 	}
 }
@@ -58,6 +62,60 @@ func TestWorkerPoolRunSubmissionsWithAnswerPlanTasks(t *testing.T) {
 	snapshot := pool.RunSubmissions(context.Background(), tasks)
 	if snapshot.Successes != 2 || snapshot.Failures != 0 {
 		t.Fatalf("snapshot counts = %d/%d, want 2/0", snapshot.Successes, snapshot.Failures)
+	}
+}
+
+func TestSubmissionTasksFromPlan(t *testing.T) {
+	submitter := &recordingAnswerPlanSubmitter{}
+	tasks, err := SubmissionTasksFromPlan(rand.New(rand.NewSource(11)), validSubmissionTaskPlan(3), submitter)
+	if err != nil {
+		t.Fatalf("SubmissionTasksFromPlan() returned error: %v", err)
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("len(tasks) = %d, want 3", len(tasks))
+	}
+
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 2, Target: 3})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+	snapshot := pool.RunSubmissions(context.Background(), tasks)
+	if snapshot.Successes != 3 || snapshot.Failures != 0 {
+		t.Fatalf("snapshot counts = %d/%d, want 3/0", snapshot.Successes, snapshot.Failures)
+	}
+	submittedPlans := submitter.submittedPlans()
+	if len(submittedPlans) != 3 {
+		t.Fatalf("submitted plans = %d, want 3", len(submittedPlans))
+	}
+	for _, submitted := range submittedPlans {
+		if len(submitted.Answers) != 1 || submitted.Answers[0].QuestionID != "q1" {
+			t.Fatalf("submitted plan = %+v, want q1 answer", submitted)
+		}
+	}
+}
+
+func TestSubmissionTasksFromPlanRejectsInvalidInput(t *testing.T) {
+	validPlan := validSubmissionTaskPlan(1)
+	tests := []struct {
+		name      string
+		rng       *rand.Rand
+		plan      Plan
+		submitter AnswerPlanSubmitter
+		want      string
+	}{
+		{name: "invalid plan", rng: rand.New(rand.NewSource(1)), plan: Plan{}, submitter: &recordingAnswerPlanSubmitter{}, want: "provider"},
+		{name: "rng", plan: validPlan, submitter: &recordingAnswerPlanSubmitter{}, want: "rng"},
+		{name: "questions", rng: rand.New(rand.NewSource(1)), plan: planWithoutQuestions(validPlan), submitter: &recordingAnswerPlanSubmitter{}, want: "questions"},
+		{name: "submitter", rng: rand.New(rand.NewSource(1)), plan: validPlan, want: "submitter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := SubmissionTasksFromPlan(tt.rng, tt.plan, tt.submitter)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("SubmissionTasksFromPlan() error = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }
 
@@ -95,7 +153,33 @@ func TestSubmissionTasksFromAnswerPlansReturnsSubmitterError(t *testing.T) {
 	}
 }
 
+func validSubmissionTaskPlan(target int) Plan {
+	return Plan{
+		Mode:        engine.ModeHTTP,
+		Provider:    "mock",
+		URL:         "https://example.com/survey",
+		Target:      target,
+		Concurrency: 2,
+		Questions: []QuestionPlan{
+			{
+				ID:   "q1",
+				Kind: "single",
+				Weights: []answer.OptionWeight{
+					{OptionID: "a", Weight: 1},
+					{OptionID: "b", Weight: 1},
+				},
+			},
+		},
+	}
+}
+
+func planWithoutQuestions(plan Plan) Plan {
+	plan.Questions = nil
+	return plan
+}
+
 type recordingAnswerPlanSubmitter struct {
+	mu    sync.Mutex
 	err   error
 	plans []answerplan.Plan
 }
@@ -104,7 +188,9 @@ func (s *recordingAnswerPlanSubmitter) Submit(ctx context.Context, plan answerpl
 	if err := ctx.Err(); err != nil {
 		return engine.SubmissionResult{}, err
 	}
+	s.mu.Lock()
 	s.plans = append(s.plans, answerplan.Clone(plan))
+	s.mu.Unlock()
 	if s.err != nil {
 		return engine.SubmissionResult{}, s.err
 	}
@@ -114,4 +200,15 @@ func (s *recordingAnswerPlanSubmitter) Submit(ctx context.Context, plan answerpl
 		Success:  true,
 		Terminal: true,
 	}, nil
+}
+
+func (s *recordingAnswerPlanSubmitter) submittedPlans() []answerplan.Plan {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	plans := make([]answerplan.Plan, 0, len(s.plans))
+	for _, plan := range s.plans {
+		plans = append(plans, answerplan.Clone(plan))
+	}
+	return plans
 }


### PR DESCRIPTION
## Summary

- add `SubmissionTasksFromPlan` to validate a runner plan, generate target-sized answer plans, and adapt them into submission tasks
- cover the new runner pipeline with worker-pool execution tests and invalid-input checks

## Validation

- `go test ./internal/runner -run "TestSubmissionTasksFromPlan|TestWorkerPoolRunSubmissionsWithAnswerPlanTasks|TestSubmissionTasksFromAnswerPlans" -count=1`
- `go test ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `git diff --check`
- `$env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...`

Closes #59


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capability to process submission plans with automatic validation and answer plan generation.

* **Tests**
  * Comprehensive test coverage added for plan processing, including validation, error handling, and submitter behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->