### PR TITLE
[codex] 在 runner 状态快照中暴露失败归因

### DIFF
--- a/internal/runner/state.go
+++ b/internal/runner/state.go
@@ -20,37 +20,42 @@ type StateOptions struct {
 }
 
 type RunState struct {
-	mu            sync.Mutex
-	target        int
-	threshold     int
-	success       int
-	failure       int
-	failureCode   apperr.Code
-	stopRequested bool
-	stopReason    string
-	stopCode      apperr.Code
-	workers       map[int]WorkerProgress
+	mu                sync.Mutex
+	target            int
+	threshold         int
+	success           int
+	failure           int
+	failureCode       apperr.Code
+	failureReason     string
+	stopRequested     bool
+	stopReason        string
+	stopCode          apperr.Code
+	stopFailureReason string
+	workers           map[int]WorkerProgress
 }
 
 type WorkerProgress struct {
-	ID        int
-	Status    WorkerStatus
-	Successes int
-	Failures  int
-	Message   string
-	ErrorCode apperr.Code
+	ID            int
+	Status        WorkerStatus
+	Successes     int
+	Failures      int
+	Message       string
+	ErrorCode     apperr.Code
+	FailureReason string
 }
 
 type StateSnapshot struct {
-	Target           int
-	FailureThreshold int
-	Successes        int
-	Failures         int
-	LastFailureCode  apperr.Code
-	StopRequested    bool
-	StopReason       string
-	StopCode         apperr.Code
-	Workers          map[int]WorkerProgress
+	Target            int
+	FailureThreshold  int
+	Successes         int
+	Failures          int
+	LastFailureCode   apperr.Code
+	LastFailureReason string
+	StopRequested     bool
+	StopReason        string
+	StopCode          apperr.Code
+	StopFailureReason string
+	Workers           map[int]WorkerProgress
 }
 
 func NewRunState(options StateOptions) *RunState {
@@ -82,11 +87,13 @@ func (s *RunState) RecordFailureWithCode(workerID int, message string, code appe
 
 	s.failure++
 	s.failureCode = code
+	s.failureReason = failureReasonFromCode(code)
 	progress := s.worker(workerID)
 	progress.Failures++
 	progress.Status = WorkerStatusRunning
 	progress.Message = message
 	progress.ErrorCode = code
+	progress.FailureReason = failureReasonFromCode(code)
 	s.workers[workerID] = progress
 }
 
@@ -111,6 +118,7 @@ func (s *RunState) RequestStopWithCode(reason string, code apperr.Code) {
 	s.stopRequested = true
 	s.stopReason = reason
 	s.stopCode = code
+	s.stopFailureReason = failureReasonFromCode(code)
 }
 
 func (s *RunState) Snapshot() StateSnapshot {
@@ -122,15 +130,17 @@ func (s *RunState) Snapshot() StateSnapshot {
 		workers[id] = progress
 	}
 	return StateSnapshot{
-		Target:           s.target,
-		FailureThreshold: s.threshold,
-		Successes:        s.success,
-		Failures:         s.failure,
-		LastFailureCode:  s.failureCode,
-		StopRequested:    s.stopRequested,
-		StopReason:       s.stopReason,
-		StopCode:         s.stopCode,
-		Workers:          workers,
+		Target:            s.target,
+		FailureThreshold:  s.threshold,
+		Successes:         s.success,
+		Failures:          s.failure,
+		LastFailureCode:   s.failureCode,
+		LastFailureReason: s.failureReason,
+		StopRequested:     s.stopRequested,
+		StopReason:        s.stopReason,
+		StopCode:          s.stopCode,
+		StopFailureReason: s.stopFailureReason,
+		Workers:           workers,
 	}
 }
 
@@ -156,4 +166,11 @@ func (s *RunState) worker(workerID int) WorkerProgress {
 		}
 	}
 	return progress
+}
+
+func failureReasonFromCode(code apperr.Code) string {
+	if code == "" {
+		return ""
+	}
+	return string(code)
 }

--- a/internal/runner/submission_test.go
+++ b/internal/runner/submission_test.go
@@ -48,6 +48,9 @@ func TestRecordSubmissionResultCountsFailure(t *testing.T) {
 	if snapshot.LastFailureCode != apperr.CodeSubmitFailed || snapshot.Workers[2].ErrorCode != apperr.CodeSubmitFailed {
 		t.Fatalf("failure codes = %q/%q, want %q", snapshot.LastFailureCode, snapshot.Workers[2].ErrorCode, apperr.CodeSubmitFailed)
 	}
+	if snapshot.LastFailureReason != string(apperr.CodeSubmitFailed) || snapshot.Workers[2].FailureReason != string(apperr.CodeSubmitFailed) {
+		t.Fatalf("failure reasons = %q/%q, want %q", snapshot.LastFailureReason, snapshot.Workers[2].FailureReason, apperr.CodeSubmitFailed)
+	}
 	if snapshot.StopRequested {
 		t.Fatalf("StopRequested = true, want false")
 	}
@@ -70,6 +73,9 @@ func TestRecordSubmissionResultRequestsStop(t *testing.T) {
 	}
 	if snapshot.LastFailureCode != apperr.CodeVerificationNeeded || snapshot.StopCode != apperr.CodeVerificationNeeded {
 		t.Fatalf("snapshot codes = %q/%q, want %q", snapshot.LastFailureCode, snapshot.StopCode, apperr.CodeVerificationNeeded)
+	}
+	if snapshot.LastFailureReason != string(apperr.CodeVerificationNeeded) || snapshot.StopFailureReason != string(apperr.CodeVerificationNeeded) {
+		t.Fatalf("snapshot failure reasons = %q/%q, want %q", snapshot.LastFailureReason, snapshot.StopFailureReason, apperr.CodeVerificationNeeded)
 	}
 	if !state.ShouldStop() {
 		t.Fatalf("ShouldStop() = false, want true")


### PR DESCRIPTION
## Summary

- expose stable failure reason fields on runner worker progress and state snapshots
- mirror app error codes into last-failure and stop-failure reason fields
- cover submission failure and explicit stop snapshots in runner tests

## Validation

- `go test ./internal/runner -run "TestRecordSubmissionResult|TestWorkerPoolRunSubmissions" -count=1`
- `go test ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `$env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...`
- `git diff --check`

Closes #61
