### PR TITLE
[codex] 优化 runner ShouldStop 热路径

### DIFF
--- a/internal/runner/state.go
+++ b/internal/runner/state.go
@@ -145,8 +145,12 @@ func (s *RunState) Snapshot() StateSnapshot {
 }
 
 func (s *RunState) ShouldStop() bool {
-	snapshot := s.Snapshot()
-	return snapshot.StopRequested || snapshot.TargetReached() || snapshot.FailureThresholdReached()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.stopRequested ||
+		(s.target > 0 && s.success >= s.target) ||
+		(s.threshold > 0 && s.failure >= s.threshold)
 }
 
 func (s StateSnapshot) TargetReached() bool {


### PR DESCRIPTION
## Summary

- optimize `RunState.ShouldStop` to check stop conditions directly under lock
- avoid calling `Snapshot()` on the worker-pool hot path
- preserve snapshot copy semantics and stop-condition behavior

## Benchmark Signal

Short local benchmark (`-benchtime=10x`):

- `BenchmarkWorkerPoolRunSubmissionsLightTasks/target_1000`: about `402ms / 426MB` before, about `9.7ms / 1.15MB` after
- `BenchmarkWorkerPoolRunSubmissionsLightTasks/target_5000`: about `2.1s / 2.13GB` before, about `15.8ms / 2.5MB` after

## Validation

- `go test ./internal/runner -run "TestWorkerPool|TestRecordSubmissionResult" -count=1`
- `go test ./internal/runner -run '^$' -bench 'BenchmarkWorkerPoolRunSubmissionsLightTasks' -benchtime=10x -count=1`
- `go test ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `$env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...`
- `git diff --check`

Closes #65
