### PR TITLE
[codex] 减少 runner plan task 构建分配

### DIFF
--- a/internal/runner/submission_tasks.go
+++ b/internal/runner/submission_tasks.go
@@ -36,9 +36,21 @@ func SubmissionTasksFromPlan(rng *rand.Rand, plan Plan, submitter AnswerPlanSubm
 	if err := New().ValidatePlan(plan); err != nil {
 		return nil, err
 	}
-	answerPlans, err := BuildAnswerPlans(rng, plan.Questions, plan.Target)
-	if err != nil {
-		return nil, err
+	if submitter == nil {
+		return nil, fmt.Errorf("answer plan submitter is required")
 	}
-	return SubmissionTasksFromAnswerPlans(submitter, answerPlans)
+
+	tasks := make([]SubmissionTask, 0, plan.Target)
+	for i := 0; i < plan.Target; i++ {
+		answerPlan, err := BuildAnswerPlan(rng, plan.Questions)
+		if err != nil {
+			return nil, fmt.Errorf("answer plan %d: %w", i+1, err)
+		}
+		taskPlan := answerPlan
+		tasks = append(tasks, func(ctx context.Context, workerID int) (engine.SubmissionResult, error) {
+			_ = workerID
+			return submitter.Submit(ctx, taskPlan)
+		})
+	}
+	return tasks, nil
 }


### PR DESCRIPTION
## Summary

- build submission tasks directly from `runner.Plan` without retaining an intermediate answer-plan slice
- keep each generated task bound to its own locally generated answer plan
- preserve the external `SubmissionTasksFromAnswerPlans` clone behavior for caller-provided plans

## Benchmark Signal

Short local benchmark (`-benchtime=10x`):

- `BenchmarkSubmissionTasksFromPlan/target_5000`: about `4.84MB / 81681 allocs` before, about `2.44MB / 41679 allocs` after
- `BenchmarkSubmissionTasksFromPlan/target_1000`: about `972KB / 16333 allocs` before, about `492KB / 8333 allocs` after

## Validation

- `go test ./internal/runner -run "TestSubmissionTasksFromPlan|TestSubmissionTasksFromAnswerPlans" -count=1`
- `go test ./internal/runner -run '^$' -bench 'BenchmarkSubmissionTasksFromPlan' -benchtime=10x -count=1`
- `go test ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `$env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...`
- `git diff --check`

Closes #67
