### PR TITLE
[codex] 无事件订阅时跳过 runner 事件构造

### DIFF
--- a/internal/runner/pool.go
+++ b/internal/runner/pool.go
@@ -135,23 +135,27 @@ func (p *WorkerPool) worker(ctx context.Context, workerID int, tasks <-chan Task
 			}
 			if err := task(ctx, workerID); err != nil {
 				p.state.RecordFailureWithCode(workerID, err.Error(), errorCode(err))
-				event := logging.RunEvent{
-					Type:     logging.EventSubmissionFailure,
-					Level:    logging.LevelError,
-					WorkerID: workerID,
-					Message:  err.Error(),
+				if p.eventsEnabled() {
+					event := logging.RunEvent{
+						Type:     logging.EventSubmissionFailure,
+						Level:    logging.LevelError,
+						WorkerID: workerID,
+						Message:  err.Error(),
+					}
+					addErrorFields(&event, err)
+					p.emit(event)
 				}
-				addErrorFields(&event, err)
-				p.emit(event)
 				continue
 			}
 			p.state.RecordSuccess(workerID)
-			p.emit(logging.RunEvent{
-				Type:     logging.EventSubmissionSuccess,
-				Level:    logging.LevelInfo,
-				WorkerID: workerID,
-				Message:  "submission succeeded",
-			})
+			if p.eventsEnabled() {
+				p.emit(logging.RunEvent{
+					Type:     logging.EventSubmissionSuccess,
+					Level:    logging.LevelInfo,
+					WorkerID: workerID,
+					Message:  "submission succeeded",
+				})
+			}
 		}
 	}
 }
@@ -171,18 +175,22 @@ func (p *WorkerPool) submissionWorker(ctx context.Context, workerID int, tasks <
 			result, err := task(ctx, workerID)
 			if err != nil {
 				p.state.RecordFailureWithCode(workerID, err.Error(), errorCode(err))
-				event := logging.RunEvent{
-					Type:     logging.EventSubmissionFailure,
-					Level:    logging.LevelError,
-					WorkerID: workerID,
-					Message:  err.Error(),
+				if p.eventsEnabled() {
+					event := logging.RunEvent{
+						Type:     logging.EventSubmissionFailure,
+						Level:    logging.LevelError,
+						WorkerID: workerID,
+						Message:  err.Error(),
+					}
+					addErrorFields(&event, err)
+					p.emit(event)
 				}
-				addErrorFields(&event, err)
-				p.emit(event)
 				continue
 			}
 			p.state.RecordSubmissionResult(workerID, result)
-			p.emit(EventForSubmissionResult(workerID, result))
+			if p.eventsEnabled() {
+				p.emit(EventForSubmissionResult(workerID, result))
+			}
 		}
 	}
 }
@@ -220,4 +228,8 @@ func (p *WorkerPool) emit(event logging.RunEvent) {
 	case p.options.Events <- event:
 	default:
 	}
+}
+
+func (p *WorkerPool) eventsEnabled() bool {
+	return p.options.Events != nil
 }


### PR DESCRIPTION
## Summary

- skip per-task runner event construction when no event channel is configured
- preserve event behavior when subscribers are present
- reduce hot-path allocations for high-volume submission runs

## Benchmark Signal

Short local benchmark (`-benchtime=10x`):

- `BenchmarkWorkerPoolRunSubmissionsLightTasks/target_1000`: about `1.14MB / 6257 allocs` before, about `787KB / 2267 allocs` after
- `BenchmarkWorkerPoolRunSubmissionsLightTasks/target_5000`: about `2.52MB / 22112 allocs` before, about `725KB / 2108 allocs` after

## Validation

- `go test ./internal/runner -run "TestWorkerPoolRunSubmissions|TestWorkerPoolRecordsSuccessAndFailure" -count=1`
- `go test ./internal/runner -run '^$' -bench 'BenchmarkWorkerPoolRunSubmissionsLightTasks' -benchtime=10x -count=1`
- `go test ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `$env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...`
- `git diff --check`

Closes #69
