### PR TITLE
[codex] runner worker pool 按任务数限制 worker 数量

### DIFF
--- a/internal/runner/pool.go
+++ b/internal/runner/pool.go
@@ -50,7 +50,7 @@ func (p *WorkerPool) Run(ctx context.Context, tasks []Task) StateSnapshot {
 	taskCh := make(chan Task)
 	var wg sync.WaitGroup
 
-	for workerID := 1; workerID <= p.options.Concurrency; workerID++ {
+	for workerID := 1; workerID <= p.workerCount(len(tasks)); workerID++ {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
@@ -90,7 +90,7 @@ func (p *WorkerPool) RunSubmissions(ctx context.Context, tasks []SubmissionTask)
 	taskCh := make(chan SubmissionTask)
 	var wg sync.WaitGroup
 
-	for workerID := 1; workerID <= p.options.Concurrency; workerID++ {
+	for workerID := 1; workerID <= p.workerCount(len(tasks)); workerID++ {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
@@ -232,4 +232,11 @@ func (p *WorkerPool) emit(event logging.RunEvent) {
 
 func (p *WorkerPool) eventsEnabled() bool {
 	return p.options.Events != nil
+}
+
+func (p *WorkerPool) workerCount(taskCount int) int {
+	if taskCount < p.options.Concurrency {
+		return taskCount
+	}
+	return p.options.Concurrency
 }

--- a/internal/runner/pool_test.go
+++ b/internal/runner/pool_test.go
@@ -123,6 +123,42 @@ func TestWorkerPoolStopsOnContextCancel(t *testing.T) {
 	}
 }
 
+func TestWorkerPoolStartsNoMoreWorkersThanTasks(t *testing.T) {
+	events := make(chan logging.RunEvent, 16)
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 10, Target: 2, Events: events})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+
+	snapshot := pool.RunSubmissions(context.Background(), []SubmissionTask{
+		submissionResultTask(engine.SubmissionResult{State: provider.SubmissionStateSuccess, Success: true}),
+		submissionResultTask(engine.SubmissionResult{State: provider.SubmissionStateSuccess, Success: true}),
+	})
+
+	if snapshot.Successes != 2 || len(snapshot.Workers) != 2 {
+		t.Fatalf("snapshot = %+v, want two successes from two workers", snapshot)
+	}
+	if got := countEvents(events, logging.EventWorkerStarted); got != 2 {
+		t.Fatalf("worker started events = %d, want 2", got)
+	}
+}
+
+func TestWorkerPoolHandlesEmptyTaskListWithoutWorkers(t *testing.T) {
+	events := make(chan logging.RunEvent, 8)
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 10, Events: events})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+
+	snapshot := pool.RunSubmissions(context.Background(), nil)
+	if snapshot.Successes != 0 || snapshot.Failures != 0 || len(snapshot.Workers) != 0 {
+		t.Fatalf("snapshot = %+v, want no work recorded", snapshot)
+	}
+	if got := countEvents(events, logging.EventWorkerStarted); got != 0 {
+		t.Fatalf("worker started events = %d, want 0", got)
+	}
+}
+
 func TestWorkerPoolRunSubmissionsRecordsResults(t *testing.T) {
 	events := make(chan logging.RunEvent, 16)
 	pool, err := NewWorkerPool(PoolOptions{Concurrency: 1, Target: 3, Events: events})
@@ -262,6 +298,20 @@ func findEvent(events <-chan logging.RunEvent, eventType logging.EventType) (log
 			}
 		default:
 			return logging.RunEvent{}, false
+		}
+	}
+}
+
+func countEvents(events <-chan logging.RunEvent, eventType logging.EventType) int {
+	count := 0
+	for {
+		select {
+		case event := <-events:
+			if event.Type == eventType {
+				count++
+			}
+		default:
+			return count
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- cap started worker goroutines at `min(concurrency, len(tasks))`
- avoid worker startup and progress state for empty or tiny task batches
- add tests for small-task and empty-task worker behavior

## Validation

- `go test ./internal/runner -run "TestWorkerPoolStartsNoMoreWorkersThanTasks|TestWorkerPoolHandlesEmptyTaskListWithoutWorkers|TestWorkerPoolHonorsConcurrency|TestWorkerPoolSupportsThousandLightweightWorkers" -count=1`
- `go test ./internal/runner -count=1`
- `go test ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `$env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...`
- `git diff --check`

Closes #71


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized worker allocation to spawn only the required number of workers based on task count, preventing unnecessary resource overhead when task load is lower than the configured concurrency limit.

* **Tests**
  * Added test coverage for task-bounded worker creation behavior.
  * Added test coverage for empty submission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->