### PR TITLE
[codex] 减少 answer PickOne 抽样分配

### DIFF
--- a/internal/answer/probability.go
+++ b/internal/answer/probability.go
@@ -21,22 +21,12 @@ type SelectionResult struct {
 }
 
 func NormalizeWeights(weights []OptionWeight) ([]OptionWeight, error) {
-	if len(weights) == 0 {
-		return nil, fmt.Errorf("weights are required")
+	total, err := validateAndSumWeights(weights)
+	if err != nil {
+		return nil, err
 	}
 
-	normalized := make([]OptionWeight, 0, len(weights))
-	total := 0.0
-	for _, item := range weights {
-		if item.OptionID == "" {
-			return nil, fmt.Errorf("option id is required")
-		}
-		if item.Weight < 0 {
-			return nil, fmt.Errorf("weight for option %q must not be negative", item.OptionID)
-		}
-		total += item.Weight
-		normalized = append(normalized, item)
-	}
+	normalized := append([]OptionWeight(nil), weights...)
 	if total == 0 {
 		even := 1.0 / float64(len(normalized))
 		for i := range normalized {
@@ -55,20 +45,50 @@ func PickOne(rng *rand.Rand, weights []OptionWeight) (string, error) {
 	if rng == nil {
 		return "", fmt.Errorf("rng is required")
 	}
-	normalized, err := NormalizeWeights(weights)
+	total, err := validateAndSumWeights(weights)
 	if err != nil {
 		return "", err
 	}
+	if total == 0 {
+		return pickEven(rng, weights), nil
+	}
 
-	point := rng.Float64()
+	point := rng.Float64() * total
 	accumulated := 0.0
-	for _, item := range normalized {
+	for _, item := range weights {
 		accumulated += item.Weight
 		if point <= accumulated {
 			return item.OptionID, nil
 		}
 	}
-	return normalized[len(normalized)-1].OptionID, nil
+	return weights[len(weights)-1].OptionID, nil
+}
+
+func validateAndSumWeights(weights []OptionWeight) (float64, error) {
+	if len(weights) == 0 {
+		return 0, fmt.Errorf("weights are required")
+	}
+
+	total := 0.0
+	for _, item := range weights {
+		if item.OptionID == "" {
+			return 0, fmt.Errorf("option id is required")
+		}
+		if item.Weight < 0 {
+			return 0, fmt.Errorf("weight for option %q must not be negative", item.OptionID)
+		}
+		total += item.Weight
+	}
+	return total, nil
+}
+
+func pickEven(rng *rand.Rand, weights []OptionWeight) string {
+	point := rng.Float64() * float64(len(weights))
+	index := int(point)
+	if index >= len(weights) {
+		index = len(weights) - 1
+	}
+	return weights[index].OptionID
 }
 
 func PickMany(rng *rand.Rand, weights []OptionWeight, rule SelectionRule) (SelectionResult, error) {

--- a/internal/answer/probability_benchmark_test.go
+++ b/internal/answer/probability_benchmark_test.go
@@ -1,0 +1,48 @@
+package answer
+
+import (
+	"math/rand"
+	"testing"
+)
+
+var benchmarkPickedOption string
+
+func BenchmarkPickOne(b *testing.B) {
+	weights := []OptionWeight{
+		{OptionID: "a", Weight: 1},
+		{OptionID: "b", Weight: 2},
+		{OptionID: "c", Weight: 3},
+		{OptionID: "d", Weight: 4},
+	}
+	rng := rand.New(rand.NewSource(1))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		optionID, err := PickOne(rng, weights)
+		if err != nil {
+			b.Fatalf("PickOne() returned error: %v", err)
+		}
+		benchmarkPickedOption = optionID
+	}
+}
+
+func BenchmarkPickOneEvenWeights(b *testing.B) {
+	weights := []OptionWeight{
+		{OptionID: "a"},
+		{OptionID: "b"},
+		{OptionID: "c"},
+		{OptionID: "d"},
+	}
+	rng := rand.New(rand.NewSource(1))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		optionID, err := PickOne(rng, weights)
+		if err != nil {
+			b.Fatalf("PickOne() returned error: %v", err)
+		}
+		benchmarkPickedOption = optionID
+	}
+}


### PR DESCRIPTION
## Summary

- make `answer.PickOne` sample directly from raw weights without allocating a normalized slice
- keep zero-total weights as even random selection
- add `PickOne` benchmarks for weighted and even-weight paths

## Benchmark Signal

Short local benchmark:

- `BenchmarkPickOne`: `32.64 ns/op`, `0 B/op`, `0 allocs/op`
- `BenchmarkPickOneEvenWeights`: `14.79 ns/op`, `0 B/op`, `0 allocs/op`
- `BenchmarkSubmissionTasksFromPlan/target_5000`: about `2.44MB / 41679 allocs` before, about `1.84MB / 30191 allocs` after

## Validation

- `go test ./internal/answer -count=1`
- `go test ./internal/answer -run '^$' -bench 'BenchmarkPickOne' -benchtime=100000x -count=1`
- `go test ./internal/runner -run '^$' -bench 'BenchmarkSubmissionTasksFromPlan' -benchtime=10x -count=1`
- `go test ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `$env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...`
- `git diff --check`

Closes #73
