### PR TITLE
[codex] 增加预编译单选权重抽样器

### DIFF
--- a/internal/answer/probability_benchmark_test.go
+++ b/internal/answer/probability_benchmark_test.go
@@ -46,3 +46,49 @@ func BenchmarkPickOneEvenWeights(b *testing.B) {
 		benchmarkPickedOption = optionID
 	}
 }
+
+func BenchmarkWeightedPickerPick(b *testing.B) {
+	picker, err := NewWeightedPicker([]OptionWeight{
+		{OptionID: "a", Weight: 1},
+		{OptionID: "b", Weight: 2},
+		{OptionID: "c", Weight: 3},
+		{OptionID: "d", Weight: 4},
+	})
+	if err != nil {
+		b.Fatalf("NewWeightedPicker() returned error: %v", err)
+	}
+	rng := rand.New(rand.NewSource(1))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		optionID, err := picker.Pick(rng)
+		if err != nil {
+			b.Fatalf("Pick() returned error: %v", err)
+		}
+		benchmarkPickedOption = optionID
+	}
+}
+
+func BenchmarkWeightedPickerPickEvenWeights(b *testing.B) {
+	picker, err := NewWeightedPicker([]OptionWeight{
+		{OptionID: "a"},
+		{OptionID: "b"},
+		{OptionID: "c"},
+		{OptionID: "d"},
+	})
+	if err != nil {
+		b.Fatalf("NewWeightedPicker() returned error: %v", err)
+	}
+	rng := rand.New(rand.NewSource(1))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		optionID, err := picker.Pick(rng)
+		if err != nil {
+			b.Fatalf("Pick() returned error: %v", err)
+		}
+		benchmarkPickedOption = optionID
+	}
+}

--- a/internal/answer/weighted_picker.go
+++ b/internal/answer/weighted_picker.go
@@ -1,0 +1,49 @@
+package answer
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+type WeightedPicker struct {
+	options []OptionWeight
+	total   float64
+}
+
+func NewWeightedPicker(weights []OptionWeight) (WeightedPicker, error) {
+	total, err := validateAndSumWeights(weights)
+	if err != nil {
+		return WeightedPicker{}, err
+	}
+
+	return WeightedPicker{
+		options: append([]OptionWeight(nil), weights...),
+		total:   total,
+	}, nil
+}
+
+func (p WeightedPicker) Pick(rng *rand.Rand) (string, error) {
+	if rng == nil {
+		return "", fmt.Errorf("rng is required")
+	}
+	if len(p.options) == 0 {
+		return "", fmt.Errorf("weighted picker is empty")
+	}
+	if p.total == 0 {
+		return pickEven(rng, p.options), nil
+	}
+
+	point := rng.Float64() * p.total
+	accumulated := 0.0
+	for _, item := range p.options {
+		accumulated += item.Weight
+		if point <= accumulated {
+			return item.OptionID, nil
+		}
+	}
+	return p.options[len(p.options)-1].OptionID, nil
+}
+
+func (p WeightedPicker) Len() int {
+	return len(p.options)
+}

--- a/internal/answer/weighted_picker_test.go
+++ b/internal/answer/weighted_picker_test.go
@@ -1,0 +1,100 @@
+package answer
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestWeightedPickerPick(t *testing.T) {
+	picker, err := NewWeightedPicker([]OptionWeight{
+		{OptionID: "a", Weight: 0},
+		{OptionID: "b", Weight: 1},
+	})
+	if err != nil {
+		t.Fatalf("NewWeightedPicker() returned error: %v", err)
+	}
+
+	got, err := picker.Pick(rand.New(rand.NewSource(1)))
+	if err != nil {
+		t.Fatalf("Pick() returned error: %v", err)
+	}
+	if got != "b" {
+		t.Fatalf("Pick() = %q, want b", got)
+	}
+	if picker.Len() != 2 {
+		t.Fatalf("Len() = %d, want 2", picker.Len())
+	}
+}
+
+func TestWeightedPickerEvenWeights(t *testing.T) {
+	picker, err := NewWeightedPicker([]OptionWeight{
+		{OptionID: "a"},
+		{OptionID: "b"},
+		{OptionID: "c"},
+	})
+	if err != nil {
+		t.Fatalf("NewWeightedPicker() returned error: %v", err)
+	}
+
+	got, err := picker.Pick(rand.New(rand.NewSource(2)))
+	if err != nil {
+		t.Fatalf("Pick() returned error: %v", err)
+	}
+	if got == "" {
+		t.Fatal("Pick() returned empty option id")
+	}
+}
+
+func TestWeightedPickerCopiesWeights(t *testing.T) {
+	weights := []OptionWeight{
+		{OptionID: "a", Weight: 0},
+		{OptionID: "b", Weight: 1},
+	}
+	picker, err := NewWeightedPicker(weights)
+	if err != nil {
+		t.Fatalf("NewWeightedPicker() returned error: %v", err)
+	}
+	weights[1].OptionID = "mutated"
+	weights[1].Weight = 0
+
+	got, err := picker.Pick(rand.New(rand.NewSource(1)))
+	if err != nil {
+		t.Fatalf("Pick() returned error: %v", err)
+	}
+	if got != "b" {
+		t.Fatalf("Pick() = %q, want copied b", got)
+	}
+}
+
+func TestWeightedPickerRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		weights []OptionWeight
+		want    string
+	}{
+		{name: "empty", want: "required"},
+		{name: "missing id", weights: []OptionWeight{{Weight: 1}}, want: "option id"},
+		{name: "negative", weights: []OptionWeight{{OptionID: "a", Weight: -1}}, want: "negative"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewWeightedPicker(tt.weights)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("NewWeightedPicker() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestWeightedPickerRejectsNilRNG(t *testing.T) {
+	picker, err := NewWeightedPicker([]OptionWeight{{OptionID: "a", Weight: 1}})
+	if err != nil {
+		t.Fatalf("NewWeightedPicker() returned error: %v", err)
+	}
+
+	if _, err := picker.Pick(nil); err == nil || !strings.Contains(err.Error(), "rng") {
+		t.Fatalf("Pick(nil) error = %v, want rng error", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add `answer.WeightedPicker` as a startup-time compiled weighted option picker
- preserve zero-total weights as even random selection
- add tests for weighted picks, even weights, copied inputs, invalid inputs, and nil RNG
- add benchmarks for raw `PickOne` and compiled picker paths

## Why

This is the first piece of the V1.0 precompiled answer strategy path: runner can compile and validate one-option questions once, then let workers sample from read-only picker state.

## Validation

- `go test ./internal/answer -count=1`
- `go test ./internal/answer -run '^$' -bench 'BenchmarkPickOne|BenchmarkWeightedPicker' -benchtime=100000x -count=1`
- `go test ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `$env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...`
- `git diff --check`

Closes #75
