### PR TITLE
[codex] runner 使用预编译 answer plan builder

### DIFF
--- a/internal/runner/answer_plan_builder.go
+++ b/internal/runner/answer_plan_builder.go
@@ -11,19 +11,58 @@ import (
 	"github.com/LING71671/SurveyController-go/internal/domain"
 )
 
+type AnswerPlanBuilder struct {
+	questions []compiledQuestionPlan
+}
+
+type compiledQuestionPlan struct {
+	id      string
+	kind    domain.QuestionKind
+	picker  answer.WeightedPicker
+	weights []answer.OptionWeight
+	rule    answer.SelectionRule
+}
+
 func BuildAnswerPlan(rng *rand.Rand, questions []QuestionPlan) (answerplan.Plan, error) {
 	if rng == nil {
 		return answerplan.Plan{}, fmt.Errorf("rng is required")
 	}
-	if len(questions) == 0 {
-		return answerplan.Plan{}, fmt.Errorf("questions are required")
+	builder, err := CompileAnswerPlanBuilder(questions)
+	if err != nil {
+		return answerplan.Plan{}, err
 	}
+	return builder.Build(rng)
+}
 
-	plan := answerplan.Plan{
-		Answers: make([]answerplan.QuestionAnswer, 0, len(questions)),
+func CompileAnswerPlanBuilder(questions []QuestionPlan) (AnswerPlanBuilder, error) {
+	if len(questions) == 0 {
+		return AnswerPlanBuilder{}, fmt.Errorf("questions are required")
+	}
+	builder := AnswerPlanBuilder{
+		questions: make([]compiledQuestionPlan, 0, len(questions)),
 	}
 	for _, question := range questions {
-		answer, err := buildQuestionAnswer(rng, question)
+		compiled, err := compileQuestionPlan(question)
+		if err != nil {
+			return AnswerPlanBuilder{}, err
+		}
+		builder.questions = append(builder.questions, compiled)
+	}
+	return builder, nil
+}
+
+func (b AnswerPlanBuilder) Build(rng *rand.Rand) (answerplan.Plan, error) {
+	if rng == nil {
+		return answerplan.Plan{}, fmt.Errorf("rng is required")
+	}
+	if len(b.questions) == 0 {
+		return answerplan.Plan{}, fmt.Errorf("questions are required")
+	}
+	plan := answerplan.Plan{
+		Answers: make([]answerplan.QuestionAnswer, 0, len(b.questions)),
+	}
+	for _, question := range b.questions {
+		answer, err := question.buildAnswer(rng)
 		if err != nil {
 			return answerplan.Plan{}, err
 		}
@@ -32,13 +71,13 @@ func BuildAnswerPlan(rng *rand.Rand, questions []QuestionPlan) (answerplan.Plan,
 	return plan, nil
 }
 
-func BuildAnswerPlans(rng *rand.Rand, questions []QuestionPlan, count int) ([]answerplan.Plan, error) {
+func (b AnswerPlanBuilder) BuildMany(rng *rand.Rand, count int) ([]answerplan.Plan, error) {
 	if count <= 0 {
 		return nil, fmt.Errorf("answer plan count must be greater than 0")
 	}
 	plans := make([]answerplan.Plan, 0, count)
 	for i := 0; i < count; i++ {
-		plan, err := BuildAnswerPlan(rng, questions)
+		plan, err := b.Build(rng)
 		if err != nil {
 			return nil, fmt.Errorf("answer plan %d: %w", i+1, err)
 		}
@@ -47,32 +86,63 @@ func BuildAnswerPlans(rng *rand.Rand, questions []QuestionPlan, count int) ([]an
 	return plans, nil
 }
 
-func buildQuestionAnswer(rng *rand.Rand, question QuestionPlan) (answerplan.QuestionAnswer, error) {
+func BuildAnswerPlans(rng *rand.Rand, questions []QuestionPlan, count int) ([]answerplan.Plan, error) {
+	if count <= 0 {
+		return nil, fmt.Errorf("answer plan count must be greater than 0")
+	}
+	builder, err := CompileAnswerPlanBuilder(questions)
+	if err != nil {
+		return nil, err
+	}
+	return builder.BuildMany(rng, count)
+}
+
+func compileQuestionPlan(question QuestionPlan) (compiledQuestionPlan, error) {
 	questionID := strings.TrimSpace(question.ID)
 	if questionID == "" {
-		return answerplan.QuestionAnswer{}, fmt.Errorf("question id is required")
+		return compiledQuestionPlan{}, fmt.Errorf("question id is required")
 	}
 
 	kind, err := domain.ParseQuestionKind(question.Kind)
 	if err != nil {
-		return answerplan.QuestionAnswer{}, fmt.Errorf("question %q kind: %w", questionID, err)
+		return compiledQuestionPlan{}, fmt.Errorf("question %q kind: %w", questionID, err)
 	}
 
 	switch kind {
 	case domain.QuestionKindSingle, domain.QuestionKindDropdown, domain.QuestionKindRating:
-		optionID, err := answer.PickOne(rng, question.Weights)
+		picker, err := answer.NewWeightedPicker(question.Weights)
 		if err != nil {
-			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q pick one: %w", questionID, err)
+			return compiledQuestionPlan{}, fmt.Errorf("question %q weights: %w", questionID, err)
 		}
-		return answerplan.QuestionAnswer{QuestionID: questionID, OptionIDs: []string{optionID}}, nil
+		return compiledQuestionPlan{id: questionID, kind: kind, picker: picker}, nil
 	case domain.QuestionKindMultiple:
-		selected, err := answer.PickMany(rng, question.Weights, selectionRuleFromOptions(question.Options))
-		if err != nil {
-			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q pick many: %w", questionID, err)
+		weights := append([]answer.OptionWeight(nil), question.Weights...)
+		rule := selectionRuleFromOptions(question.Options)
+		if _, err := answer.PickMany(rand.New(rand.NewSource(1)), weights, rule); err != nil {
+			return compiledQuestionPlan{}, fmt.Errorf("question %q weights: %w", questionID, err)
 		}
-		return answerplan.QuestionAnswer{QuestionID: questionID, OptionIDs: selected.OptionIDs}, nil
+		return compiledQuestionPlan{id: questionID, kind: kind, weights: weights, rule: rule}, nil
 	default:
-		return answerplan.QuestionAnswer{}, fmt.Errorf("question %q kind %q is not supported for answer plan builder", questionID, kind)
+		return compiledQuestionPlan{}, fmt.Errorf("question %q kind %q is not supported for answer plan builder", questionID, kind)
+	}
+}
+
+func (q compiledQuestionPlan) buildAnswer(rng *rand.Rand) (answerplan.QuestionAnswer, error) {
+	switch q.kind {
+	case domain.QuestionKindSingle, domain.QuestionKindDropdown, domain.QuestionKindRating:
+		optionID, err := q.picker.Pick(rng)
+		if err != nil {
+			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q pick one: %w", q.id, err)
+		}
+		return answerplan.QuestionAnswer{QuestionID: q.id, OptionIDs: []string{optionID}}, nil
+	case domain.QuestionKindMultiple:
+		selected, err := answer.PickMany(rng, q.weights, q.rule)
+		if err != nil {
+			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q pick many: %w", q.id, err)
+		}
+		return answerplan.QuestionAnswer{QuestionID: q.id, OptionIDs: selected.OptionIDs}, nil
+	default:
+		return answerplan.QuestionAnswer{}, fmt.Errorf("question %q kind %q is not supported for answer plan builder", q.id, q.kind)
 	}
 }
 

--- a/internal/runner/answer_plan_builder_test.go
+++ b/internal/runner/answer_plan_builder_test.go
@@ -112,6 +112,108 @@ func TestBuildAnswerPlans(t *testing.T) {
 	}
 }
 
+func TestCompileAnswerPlanBuilder(t *testing.T) {
+	questions := []QuestionPlan{
+		{
+			ID:   "q1",
+			Kind: "single",
+			Weights: []answer.OptionWeight{
+				{OptionID: "a", Weight: 0},
+				{OptionID: "b", Weight: 1},
+			},
+		},
+		{
+			ID:   "q2",
+			Kind: "multiple",
+			Options: map[string]any{
+				"min": 2,
+				"max": 2,
+			},
+			Weights: []answer.OptionWeight{
+				{OptionID: "a", Weight: 1},
+				{OptionID: "b", Weight: 1},
+				{OptionID: "c", Weight: 1},
+			},
+		},
+	}
+
+	builder, err := CompileAnswerPlanBuilder(questions)
+	if err != nil {
+		t.Fatalf("CompileAnswerPlanBuilder() returned error: %v", err)
+	}
+	questions[0].Weights[1].OptionID = "mutated"
+	questions[1].Weights[0].OptionID = "mutated"
+
+	plan, err := builder.Build(rand.New(rand.NewSource(4)))
+	if err != nil {
+		t.Fatalf("Build() returned error: %v", err)
+	}
+	if len(plan.Answers) != 2 {
+		t.Fatalf("len(Answers) = %d, want 2", len(plan.Answers))
+	}
+	if plan.Answers[0].QuestionID != "q1" || plan.Answers[0].OptionIDs[0] != "b" {
+		t.Fatalf("first answer = %+v, want copied q1=b", plan.Answers[0])
+	}
+	if plan.Answers[1].QuestionID != "q2" || len(plan.Answers[1].OptionIDs) != 2 {
+		t.Fatalf("second answer = %+v, want copied two-option multiple answer", plan.Answers[1])
+	}
+}
+
+func TestAnswerPlanBuilderBuildMany(t *testing.T) {
+	builder, err := CompileAnswerPlanBuilder([]QuestionPlan{{
+		ID:      "q1",
+		Kind:    "single",
+		Weights: []answer.OptionWeight{{OptionID: "a", Weight: 1}},
+	}})
+	if err != nil {
+		t.Fatalf("CompileAnswerPlanBuilder() returned error: %v", err)
+	}
+
+	plans, err := builder.BuildMany(rand.New(rand.NewSource(5)), 2)
+	if err != nil {
+		t.Fatalf("BuildMany() returned error: %v", err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("len(plans) = %d, want 2", len(plans))
+	}
+	plans[0].Answers[0].QuestionID = "mutated"
+	if plans[1].Answers[0].QuestionID != "q1" {
+		t.Fatalf("plans are not independent: %+v", plans)
+	}
+}
+
+func TestCompileAnswerPlanBuilderRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		questions []QuestionPlan
+		want      string
+	}{
+		{name: "questions", want: "questions"},
+		{name: "question id", questions: []QuestionPlan{{Kind: "single"}}, want: "question id"},
+		{name: "kind", questions: []QuestionPlan{{ID: "q1", Kind: "text"}}, want: "not supported"},
+		{name: "weights", questions: []QuestionPlan{{ID: "q1", Kind: "single"}}, want: "weights"},
+		{
+			name: "multiple rule",
+			questions: []QuestionPlan{{
+				ID:      "q1",
+				Kind:    "multiple",
+				Options: map[string]any{"min": 2, "max": 1},
+				Weights: []answer.OptionWeight{{OptionID: "a", Weight: 1}},
+			}},
+			want: "min must not be greater",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := CompileAnswerPlanBuilder(tt.questions)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("CompileAnswerPlanBuilder() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildAnswerPlansRejectsInvalidInput(t *testing.T) {
 	questions := []QuestionPlan{{
 		ID:      "q1",

--- a/internal/runner/submission_tasks.go
+++ b/internal/runner/submission_tasks.go
@@ -39,10 +39,14 @@ func SubmissionTasksFromPlan(rng *rand.Rand, plan Plan, submitter AnswerPlanSubm
 	if submitter == nil {
 		return nil, fmt.Errorf("answer plan submitter is required")
 	}
+	builder, err := CompileAnswerPlanBuilder(plan.Questions)
+	if err != nil {
+		return nil, err
+	}
 
 	tasks := make([]SubmissionTask, 0, plan.Target)
 	for i := 0; i < plan.Target; i++ {
-		answerPlan, err := BuildAnswerPlan(rng, plan.Questions)
+		answerPlan, err := builder.Build(rng)
 		if err != nil {
 			return nil, fmt.Errorf("answer plan %d: %w", i+1, err)
 		}


### PR DESCRIPTION
## Summary

- add `runner.CompileAnswerPlanBuilder` and reusable `AnswerPlanBuilder`
- precompile question kind, single/dropdown/rating weighted pickers, and multiple selection rules
- make `SubmissionTasksFromPlan` compile once and build target answer plans from the compiled builder
- keep existing `BuildAnswerPlan` / `BuildAnswerPlans` APIs intact

## Benchmark Signal

Short local benchmark:

- `BenchmarkSubmissionTasksFromPlan/target_5000`: about `3.67ms`, `1.84MB`, `30198 allocs`

The main value is not only raw speed; it moves the runner toward the V1.0 startup-compile / worker-read-only architecture.

## Validation

- `go test ./internal/runner -run "TestCompileAnswerPlanBuilder|TestAnswerPlanBuilder|TestBuildAnswerPlan|TestSubmissionTasksFromPlan" -count=1`
- `go test ./internal/runner -run '^$' -bench 'BenchmarkSubmissionTasksFromPlan' -benchtime=10x -count=1`
- `go test ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `$env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...`
- `git diff --check`

Closes #77
