### PR TITLE
[codex] surveyctl run 增加本地 mock 执行预览

### DIFF
--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/LING71671/SurveyController-go/internal/config"
@@ -28,6 +30,7 @@ Usage:
   surveyctl config validate [path]
   surveyctl config generate --provider <id> --fixture <path> --url <url>
   surveyctl run --dry-run [path] [--json]
+  surveyctl run --mock [path] [--json] [--seed <n>]
   surveyctl doctor [browser]
   surveyctl help
 
@@ -51,6 +54,7 @@ const doctorUsage = `Usage:
 
 const runUsage = `Usage:
   surveyctl run --dry-run [path] [--json]
+  surveyctl run --mock [path] [--json] [--seed <n>]
 `
 
 const (
@@ -240,13 +244,16 @@ func readFlagValue(args []string, index int, flag string) (string, int, error) {
 
 func runRun(args []string, stdout io.Writer) error {
 	if len(args) == 0 {
-		return usageError("run requires --dry-run until execution is implemented", runUsage)
+		return usageError("run requires --dry-run or --mock", runUsage)
 	}
 	dryRun := false
+	mockRun := false
 	jsonOutput := false
+	seed := int64(1)
 	path := "survey.yaml"
 	pathSet := false
-	for _, arg := range args {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
 		normalized := strings.ToLower(strings.TrimSpace(arg))
 		switch normalized {
 		case "":
@@ -256,8 +263,21 @@ func runRun(args []string, stdout io.Writer) error {
 			return nil
 		case "--dry-run":
 			dryRun = true
+		case "--mock":
+			mockRun = true
 		case "--json":
 			jsonOutput = true
+		case "--seed":
+			value, next, err := readRunFlagValue(args, i, "--seed")
+			if err != nil {
+				return err
+			}
+			parsed, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return usageError("--seed requires an integer", runUsage)
+			}
+			seed = parsed
+			i = next
 		default:
 			if pathSet {
 				return usageError("run accepts at most one path", runUsage)
@@ -266,29 +286,59 @@ func runRun(args []string, stdout io.Writer) error {
 			pathSet = true
 		}
 	}
-	if !dryRun {
-		return usageError("run requires --dry-run until execution is implemented", runUsage)
+	if dryRun && mockRun {
+		return usageError("run accepts only one of --dry-run or --mock", runUsage)
+	}
+	if !dryRun && !mockRun {
+		return usageError("run requires --dry-run or --mock", runUsage)
 	}
 
+	plan, err := compileRunPlanFromFile(path)
+	if err != nil {
+		action := "dry-run"
+		if mockRun {
+			action = "mock"
+		}
+		return commandError(exitFailure, fmt.Sprintf("run %s failed: %v", action, err), "")
+	}
+
+	if dryRun {
+		if err := printDryRunPlan(stdout, path, plan, jsonOutput); err != nil {
+			return err
+		}
+		return nil
+	}
+	snapshot, err := runner.RunPlanSubmissions(contextBackground(), plan, runner.RunPlanOptions{
+		RNG:       rand.New(rand.NewSource(seed)),
+		Submitter: runner.MockAnswerPlanSubmitter{},
+	})
+	if err != nil {
+		return commandError(exitFailure, fmt.Sprintf("run mock failed: %v", err), "")
+	}
+	return printMockRunSummary(stdout, path, plan, snapshot, seed, jsonOutput)
+}
+
+func compileRunPlanFromFile(path string) (runner.Plan, error) {
 	cfg, err := config.LoadRunConfig(path)
 	if err != nil {
-		return commandError(exitFailure, fmt.Sprintf("run dry-run failed: %v", err), "")
+		return runner.Plan{}, err
 	}
 	if strings.TrimSpace(cfg.Survey.Provider) == "" {
 		providerID, ok := builtin.DetectProvider(cfg.Survey.URL)
 		if !ok {
-			return commandError(exitFailure, fmt.Sprintf("run dry-run failed: provider is required or survey.url must match a built-in provider: %s", cfg.Survey.URL), "")
+			return runner.Plan{}, fmt.Errorf("provider is required or survey.url must match a built-in provider: %s", cfg.Survey.URL)
 		}
 		cfg.Survey.Provider = providerID.String()
 	}
-	plan, err := runner.CompilePlan(cfg)
-	if err != nil {
-		return commandError(exitFailure, fmt.Sprintf("run dry-run failed: %v", err), "")
+	return runner.CompilePlan(cfg)
+}
+
+func readRunFlagValue(args []string, index int, flag string) (string, int, error) {
+	next := index + 1
+	if next >= len(args) || strings.TrimSpace(args[next]) == "" {
+		return "", index, usageError(fmt.Sprintf("%s requires a value", flag), runUsage)
 	}
-	if err := printDryRunPlan(stdout, path, plan, jsonOutput); err != nil {
-		return err
-	}
-	return nil
+	return args[next], next, nil
 }
 
 func runDoctor(args []string, stdout io.Writer) error {
@@ -333,6 +383,22 @@ type dryRunPlanSummary struct {
 	RandomUA         bool   `json:"random_ua_enabled"`
 }
 
+type mockRunSummary struct {
+	Path              string `json:"path"`
+	Provider          string `json:"provider"`
+	URL               string `json:"url"`
+	Mode              string `json:"mode"`
+	Target            int    `json:"target"`
+	Concurrency       int    `json:"concurrency"`
+	Seed              int64  `json:"seed"`
+	Successes         int    `json:"successes"`
+	Failures          int    `json:"failures"`
+	StopRequested     bool   `json:"stop_requested"`
+	StopReason        string `json:"stop_reason,omitempty"`
+	StopFailureReason string `json:"stop_failure_reason,omitempty"`
+	WorkerCount       int    `json:"worker_count"`
+}
+
 func printDryRunPlan(stdout io.Writer, path string, plan runner.Plan, jsonOutput bool) error {
 	summary := dryRunPlanSummary{
 		Path:             path,
@@ -369,6 +435,43 @@ func printDryRunPlan(stdout io.Writer, path string, plan runner.Plan, jsonOutput
 	fmt.Fprintf(stdout, "  reverse_fill_enabled: %t\n", summary.ReverseFill)
 	fmt.Fprintf(stdout, "  random_ua_enabled: %t\n", summary.RandomUA)
 	fmt.Fprintln(stdout, "  submissions: 0 (dry run)")
+	return nil
+}
+
+func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapshot runner.StateSnapshot, seed int64, jsonOutput bool) error {
+	summary := mockRunSummary{
+		Path:              path,
+		Provider:          plan.Provider,
+		URL:               plan.URL,
+		Mode:              plan.Mode.String(),
+		Target:            plan.Target,
+		Concurrency:       plan.Concurrency,
+		Seed:              seed,
+		Successes:         snapshot.Successes,
+		Failures:          snapshot.Failures,
+		StopRequested:     snapshot.StopRequested,
+		StopReason:        snapshot.StopReason,
+		StopFailureReason: snapshot.StopFailureReason,
+		WorkerCount:       len(snapshot.Workers),
+	}
+	if jsonOutput {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		return encoder.Encode(summary)
+	}
+	fmt.Fprintln(stdout, "mock run:")
+	fmt.Fprintf(stdout, "  path: %s\n", summary.Path)
+	fmt.Fprintf(stdout, "  provider: %s\n", summary.Provider)
+	fmt.Fprintf(stdout, "  url: %s\n", summary.URL)
+	fmt.Fprintf(stdout, "  mode: %s\n", summary.Mode)
+	fmt.Fprintf(stdout, "  target: %d\n", summary.Target)
+	fmt.Fprintf(stdout, "  concurrency: %d\n", summary.Concurrency)
+	fmt.Fprintf(stdout, "  seed: %d\n", summary.Seed)
+	fmt.Fprintf(stdout, "  successes: %d\n", summary.Successes)
+	fmt.Fprintf(stdout, "  failures: %d\n", summary.Failures)
+	fmt.Fprintf(stdout, "  stop_requested: %t\n", summary.StopRequested)
+	fmt.Fprintf(stdout, "  workers: %d\n", summary.WorkerCount)
+	fmt.Fprintln(stdout, "  network: disabled (mock)")
 	return nil
 }
 

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -272,6 +272,112 @@ questions: []
 	}
 }
 
+func TestRunMockRunPrintsSummary(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 3
+  concurrency: 2
+  mode: http
+  failure_threshold: 1
+  fail_stop_enabled: true
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+        - option_id: b
+          weight: 1
+`)
+
+	code := run([]string{"run", "--mock", "--seed", "7", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(mock) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	for _, want := range []string{"mock run:", "provider: mock", "target: 3", "successes: 3", "failures: 0", "network: disabled"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunMockRunJSONPrintsSummary(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 2
+  concurrency: 2
+  mode: http
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+`)
+
+	code := run([]string{"run", "--mock", "--json", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(mock json) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	var summary map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("json output decode failed: %v; output=%q", err, stdout.String())
+	}
+	if summary["successes"] != float64(2) || summary["failures"] != float64(0) || summary["seed"] != float64(1) {
+		t.Fatalf("summary = %+v, want mock success summary", summary)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunRejectsBothDryRunAndMock(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "--dry-run", "--mock"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(conflicting modes) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "only one") {
+		t.Fatalf("stderr = %q, want conflict error", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunMockRejectsInvalidSeed(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "--mock", "--seed", "nope"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(invalid seed) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "--seed requires an integer") {
+		t.Fatalf("stderr = %q, want seed error", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
 func TestRunRequiresDryRun(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -280,8 +386,8 @@ func TestRunRequiresDryRun(t *testing.T) {
 	if code != exitUsage {
 		t.Fatalf("run(without dry-run) exit code = %d, want %d", code, exitUsage)
 	}
-	if !strings.Contains(stderr.String(), "requires --dry-run") {
-		t.Fatalf("stderr = %q, want dry-run requirement", stderr.String())
+	if !strings.Contains(stderr.String(), "requires --dry-run or --mock") {
+		t.Fatalf("stderr = %q, want run mode requirement", stderr.String())
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty", stdout.String())

--- a/internal/runner/run_plan.go
+++ b/internal/runner/run_plan.go
@@ -1,0 +1,75 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
+	"github.com/LING71671/SurveyController-go/internal/engine"
+	"github.com/LING71671/SurveyController-go/internal/logging"
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+type RunPlanOptions struct {
+	RNG       *rand.Rand
+	Submitter AnswerPlanSubmitter
+	Events    chan<- logging.RunEvent
+}
+
+func RunPlanSubmissions(ctx context.Context, plan Plan, options RunPlanOptions) (StateSnapshot, error) {
+	if ctx == nil {
+		return StateSnapshot{}, fmt.Errorf("context is required")
+	}
+	if options.RNG == nil {
+		return StateSnapshot{}, fmt.Errorf("rng is required")
+	}
+	if options.Submitter == nil {
+		return StateSnapshot{}, fmt.Errorf("answer plan submitter is required")
+	}
+
+	tasks, err := SubmissionTasksFromPlan(options.RNG, plan, options.Submitter)
+	if err != nil {
+		return StateSnapshot{}, err
+	}
+	pool, err := NewWorkerPool(PoolOptions{
+		Concurrency:      plan.Concurrency,
+		Target:           plan.Target,
+		FailureThreshold: runFailureThreshold(plan),
+		Events:           options.Events,
+	})
+	if err != nil {
+		return StateSnapshot{}, err
+	}
+	return pool.RunSubmissions(ctx, tasks), nil
+}
+
+func runFailureThreshold(plan Plan) int {
+	if !plan.FailStopEnabled {
+		return 0
+	}
+	return plan.FailureThreshold
+}
+
+type MockAnswerPlanSubmitter struct{}
+
+func (MockAnswerPlanSubmitter) Submit(ctx context.Context, plan answerplan.Plan) (engine.SubmissionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return engine.SubmissionResult{}, err
+	}
+	if plan.Empty() {
+		return engine.SubmissionResult{
+			State:    provider.SubmissionStateFailure,
+			Message:  "answer plan is empty",
+			Terminal: true,
+			Error:    fmt.Errorf("answer plan is empty"),
+		}, nil
+	}
+	return engine.SubmissionResult{
+		State:              provider.SubmissionStateSuccess,
+		Message:            "mock submission succeeded",
+		Success:            true,
+		Terminal:           true,
+		CompletionDetected: true,
+	}, nil
+}

--- a/internal/runner/run_plan_test.go
+++ b/internal/runner/run_plan_test.go
@@ -1,0 +1,112 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/answer"
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
+	"github.com/LING71671/SurveyController-go/internal/engine"
+	"github.com/LING71671/SurveyController-go/internal/logging"
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+func TestRunPlanSubmissionsWithMockSubmitter(t *testing.T) {
+	events := make(chan logging.RunEvent, 64)
+	snapshot, err := RunPlanSubmissions(context.Background(), runnableTestPlan(3), RunPlanOptions{
+		RNG:       rand.New(rand.NewSource(1)),
+		Submitter: MockAnswerPlanSubmitter{},
+		Events:    events,
+	})
+	if err != nil {
+		t.Fatalf("RunPlanSubmissions() returned error: %v", err)
+	}
+	if snapshot.Successes != 3 || snapshot.Failures != 0 {
+		t.Fatalf("snapshot counts = %d/%d, want 3/0", snapshot.Successes, snapshot.Failures)
+	}
+	if !hasEvent(events, logging.EventRunStarted) || !hasEvent(events, logging.EventSubmissionSuccess) || !hasEvent(events, logging.EventRunFinished) {
+		t.Fatalf("events did not include run start, success, and finish")
+	}
+}
+
+func TestRunPlanSubmissionsHonorsFailStopFlag(t *testing.T) {
+	plan := runnableTestPlan(3)
+	plan.FailStopEnabled = false
+	plan.FailureThreshold = 1
+
+	snapshot, err := RunPlanSubmissions(context.Background(), plan, RunPlanOptions{
+		RNG:       rand.New(rand.NewSource(1)),
+		Submitter: failingAnswerPlanSubmitter{},
+	})
+	if err != nil {
+		t.Fatalf("RunPlanSubmissions() returned error: %v", err)
+	}
+	if snapshot.Failures != 3 || snapshot.StopRequested {
+		t.Fatalf("snapshot = %+v, want all failures without stop request", snapshot)
+	}
+}
+
+func TestRunPlanSubmissionsRejectsInvalidInput(t *testing.T) {
+	validPlan := runnableTestPlan(1)
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		plan    Plan
+		options RunPlanOptions
+		want    string
+	}{
+		{name: "context", plan: validPlan, options: RunPlanOptions{RNG: rand.New(rand.NewSource(1)), Submitter: MockAnswerPlanSubmitter{}}, want: "context"},
+		{name: "rng", ctx: context.Background(), plan: validPlan, options: RunPlanOptions{Submitter: MockAnswerPlanSubmitter{}}, want: "rng"},
+		{name: "submitter", ctx: context.Background(), plan: validPlan, options: RunPlanOptions{RNG: rand.New(rand.NewSource(1))}, want: "submitter"},
+		{name: "plan", ctx: context.Background(), plan: Plan{}, options: RunPlanOptions{RNG: rand.New(rand.NewSource(1)), Submitter: MockAnswerPlanSubmitter{}}, want: "provider"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := RunPlanSubmissions(tt.ctx, tt.plan, tt.options)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("RunPlanSubmissions() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func runnableTestPlan(target int) Plan {
+	return Plan{
+		Mode:             engine.ModeHTTP,
+		Provider:         "mock",
+		URL:              "https://example.com/survey",
+		Target:           target,
+		Concurrency:      2,
+		FailureThreshold: 1,
+		FailStopEnabled:  true,
+		Questions: []QuestionPlan{
+			{
+				ID:   "q1",
+				Kind: "single",
+				Weights: []answer.OptionWeight{
+					{OptionID: "a", Weight: 1},
+					{OptionID: "b", Weight: 1},
+				},
+			},
+		},
+	}
+}
+
+type failingAnswerPlanSubmitter struct{}
+
+func (failingAnswerPlanSubmitter) Submit(ctx context.Context, plan answerplan.Plan) (engine.SubmissionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return engine.SubmissionResult{}, err
+	}
+	_ = plan
+	return engine.SubmissionResult{
+		State:    provider.SubmissionStateFailure,
+		Message:  "mock failure",
+		Terminal: true,
+		Error:    fmt.Errorf("mock failure"),
+	}, nil
+}


### PR DESCRIPTION
## Summary

- add `runner.RunPlanSubmissions` as a local execution helper over answer-plan tasks and worker pool
- add `runner.MockAnswerPlanSubmitter` for network-free execution previews
- add `surveyctl run --mock [path] [--json] [--seed <n>]`
- keep `--dry-run` intact and reject conflicting run modes

## Safety Boundary

`--mock` does not open the survey URL, does not use browser automation, and does not submit network requests. It only validates the local run pipeline: config -> plan -> answer generation -> worker pool -> summary.

## Validation

- `go test ./internal/runner -run "TestRunPlanSubmissions|TestSubmissionTasksFromPlan" -count=1`
- `go test ./cmd/surveyctl -run "TestRunMock|TestRunDryRun|TestRunRequiresDryRun|TestRunRejectsBoth" -count=1`
- `go test ./...`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `$env:Path = 'C:\msys64\ucrt64\bin;' + $env:Path; $env:CGO_ENABLED='1'; go test -race ./...`
- `git diff --check`

Closes #79