### PR TITLE
[codex] Add reusable run plan report

### DIFF
--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -384,19 +384,22 @@ type dryRunPlanSummary struct {
 }
 
 type mockRunSummary struct {
-	Path              string `json:"path"`
-	Provider          string `json:"provider"`
-	URL               string `json:"url"`
-	Mode              string `json:"mode"`
-	Target            int    `json:"target"`
-	Concurrency       int    `json:"concurrency"`
-	Seed              int64  `json:"seed"`
-	Successes         int    `json:"successes"`
-	Failures          int    `json:"failures"`
-	StopRequested     bool   `json:"stop_requested"`
-	StopReason        string `json:"stop_reason,omitempty"`
-	StopFailureReason string `json:"stop_failure_reason,omitempty"`
-	WorkerCount       int    `json:"worker_count"`
+	Path              string  `json:"path"`
+	Provider          string  `json:"provider"`
+	URL               string  `json:"url"`
+	Mode              string  `json:"mode"`
+	Target            int     `json:"target"`
+	Concurrency       int     `json:"concurrency"`
+	Seed              int64   `json:"seed"`
+	Successes         int     `json:"successes"`
+	Failures          int     `json:"failures"`
+	Completed         int     `json:"completed"`
+	CompletionRate    float64 `json:"completion_rate"`
+	SuccessRate       float64 `json:"success_rate"`
+	StopRequested     bool    `json:"stop_requested"`
+	StopReason        string  `json:"stop_reason,omitempty"`
+	StopFailureReason string  `json:"stop_failure_reason,omitempty"`
+	WorkerCount       int     `json:"worker_count"`
 }
 
 func printDryRunPlan(stdout io.Writer, path string, plan runner.Plan, jsonOutput bool) error {
@@ -439,20 +442,24 @@ func printDryRunPlan(stdout io.Writer, path string, plan runner.Plan, jsonOutput
 }
 
 func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapshot runner.StateSnapshot, seed int64, jsonOutput bool) error {
+	report := runner.NewRunPlanReport(plan, snapshot)
 	summary := mockRunSummary{
 		Path:              path,
-		Provider:          plan.Provider,
-		URL:               plan.URL,
-		Mode:              plan.Mode.String(),
-		Target:            plan.Target,
-		Concurrency:       plan.Concurrency,
+		Provider:          report.Provider,
+		URL:               report.URL,
+		Mode:              report.Mode,
+		Target:            report.Target,
+		Concurrency:       report.Concurrency,
 		Seed:              seed,
-		Successes:         snapshot.Successes,
-		Failures:          snapshot.Failures,
-		StopRequested:     snapshot.StopRequested,
-		StopReason:        snapshot.StopReason,
-		StopFailureReason: snapshot.StopFailureReason,
-		WorkerCount:       len(snapshot.Workers),
+		Successes:         report.Successes,
+		Failures:          report.Failures,
+		Completed:         report.Completed,
+		CompletionRate:    report.CompletionRate,
+		SuccessRate:       report.SuccessRate,
+		StopRequested:     report.StopRequested,
+		StopReason:        report.StopReason,
+		StopFailureReason: report.StopFailureReason,
+		WorkerCount:       report.WorkerCount,
 	}
 	if jsonOutput {
 		encoder := json.NewEncoder(stdout)
@@ -469,10 +476,17 @@ func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapsh
 	fmt.Fprintf(stdout, "  seed: %d\n", summary.Seed)
 	fmt.Fprintf(stdout, "  successes: %d\n", summary.Successes)
 	fmt.Fprintf(stdout, "  failures: %d\n", summary.Failures)
+	fmt.Fprintf(stdout, "  completed: %d\n", summary.Completed)
+	fmt.Fprintf(stdout, "  completion_rate: %s\n", formatPercent(summary.CompletionRate))
+	fmt.Fprintf(stdout, "  success_rate: %s\n", formatPercent(summary.SuccessRate))
 	fmt.Fprintf(stdout, "  stop_requested: %t\n", summary.StopRequested)
 	fmt.Fprintf(stdout, "  workers: %d\n", summary.WorkerCount)
 	fmt.Fprintln(stdout, "  network: disabled (mock)")
 	return nil
+}
+
+func formatPercent(ratio float64) string {
+	return fmt.Sprintf("%.2f%%", ratio*100)
 }
 
 func parseDoctorBrowserArgs(args []string) (bool, error) {

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -300,7 +300,7 @@ questions:
 	if code != exitOK {
 		t.Fatalf("run(mock) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
 	}
-	for _, want := range []string{"mock run:", "provider: mock", "target: 3", "successes: 3", "failures: 0", "network: disabled"} {
+	for _, want := range []string{"mock run:", "provider: mock", "target: 3", "successes: 3", "failures: 0", "completed: 3", "completion_rate: 100.00%", "success_rate: 100.00%", "network: disabled"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
@@ -338,7 +338,7 @@ questions:
 	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
 		t.Fatalf("json output decode failed: %v; output=%q", err, stdout.String())
 	}
-	if summary["successes"] != float64(2) || summary["failures"] != float64(0) || summary["seed"] != float64(1) {
+	if summary["successes"] != float64(2) || summary["failures"] != float64(0) || summary["completed"] != float64(2) || summary["completion_rate"] != float64(1) || summary["success_rate"] != float64(1) || summary["seed"] != float64(1) {
 		t.Fatalf("summary = %+v, want mock success summary", summary)
 	}
 	if stderr.Len() != 0 {

--- a/internal/runner/run_report.go
+++ b/internal/runner/run_report.go
@@ -1,0 +1,59 @@
+package runner
+
+import "math"
+
+type RunPlanReport struct {
+	Provider          string  `json:"provider"`
+	URL               string  `json:"url"`
+	Mode              string  `json:"mode"`
+	Target            int     `json:"target"`
+	Concurrency       int     `json:"concurrency"`
+	Successes         int     `json:"successes"`
+	Failures          int     `json:"failures"`
+	Completed         int     `json:"completed"`
+	CompletionRate    float64 `json:"completion_rate"`
+	SuccessRate       float64 `json:"success_rate"`
+	StopRequested     bool    `json:"stop_requested"`
+	StopReason        string  `json:"stop_reason,omitempty"`
+	StopFailureReason string  `json:"stop_failure_reason,omitempty"`
+	WorkerCount       int     `json:"worker_count"`
+}
+
+func NewRunPlanReport(plan Plan, snapshot StateSnapshot) RunPlanReport {
+	completed := snapshot.Successes + snapshot.Failures
+	return RunPlanReport{
+		Provider:          plan.Provider,
+		URL:               plan.URL,
+		Mode:              plan.Mode.String(),
+		Target:            plan.Target,
+		Concurrency:       plan.Concurrency,
+		Successes:         snapshot.Successes,
+		Failures:          snapshot.Failures,
+		Completed:         completed,
+		CompletionRate:    ratio(completed, plan.Target),
+		SuccessRate:       ratio(snapshot.Successes, completed),
+		StopRequested:     snapshot.StopRequested,
+		StopReason:        snapshot.StopReason,
+		StopFailureReason: snapshot.StopFailureReason,
+		WorkerCount:       len(snapshot.Workers),
+	}
+}
+
+func (r RunPlanReport) TargetReached() bool {
+	return r.Target > 0 && r.Successes >= r.Target
+}
+
+func (r RunPlanReport) HasFailures() bool {
+	return r.Failures > 0
+}
+
+func ratio(value int, total int) float64 {
+	if total <= 0 {
+		return 0
+	}
+	return roundRatio(float64(value) / float64(total))
+}
+
+func roundRatio(value float64) float64 {
+	return math.Round(value*10000) / 10000
+}

--- a/internal/runner/run_report_test.go
+++ b/internal/runner/run_report_test.go
@@ -1,0 +1,86 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/engine"
+)
+
+func TestNewRunPlanReportSummarizesSnapshot(t *testing.T) {
+	plan := Plan{
+		Provider:    "mock",
+		URL:         "https://example.com/survey",
+		Mode:        engine.ModeHTTP,
+		Target:      4,
+		Concurrency: 3,
+	}
+	snapshot := StateSnapshot{
+		Successes:         3,
+		Failures:          1,
+		StopRequested:     true,
+		StopReason:        "failure_threshold",
+		StopFailureReason: "validation required",
+		Workers: map[int]WorkerProgress{
+			1: {ID: 1, Status: WorkerStatusStopped},
+			2: {ID: 2, Status: WorkerStatusStopped},
+			3: {ID: 3, Status: WorkerStatusStopped},
+		},
+	}
+
+	report := NewRunPlanReport(plan, snapshot)
+
+	if report.Provider != "mock" || report.URL != "https://example.com/survey" || report.Mode != "http" {
+		t.Fatalf("report identity = %+v, want provider/url/mode copied", report)
+	}
+	if report.Target != 4 || report.Concurrency != 3 || report.WorkerCount != 3 {
+		t.Fatalf("report sizing = %+v, want target/concurrency/workers", report)
+	}
+	if report.Successes != 3 || report.Failures != 1 || report.Completed != 4 {
+		t.Fatalf("report totals = %+v, want successes/failures/completed", report)
+	}
+	if report.CompletionRate != 1 || report.SuccessRate != 0.75 {
+		t.Fatalf("report rates = completion %.4f success %.4f, want 1 and 0.75", report.CompletionRate, report.SuccessRate)
+	}
+	if !report.StopRequested || report.StopReason != "failure_threshold" || report.StopFailureReason != "validation required" {
+		t.Fatalf("report stop = %+v, want stop details copied", report)
+	}
+	if !report.HasFailures() {
+		t.Fatalf("HasFailures() = false, want true")
+	}
+	if report.TargetReached() {
+		t.Fatalf("TargetReached() = true, want false when successes < target")
+	}
+}
+
+func TestNewRunPlanReportHandlesPartialRun(t *testing.T) {
+	report := NewRunPlanReport(Plan{Target: 10}, StateSnapshot{Successes: 2, Failures: 1})
+
+	if report.Completed != 3 {
+		t.Fatalf("Completed = %d, want 3", report.Completed)
+	}
+	if report.CompletionRate != 0.3 {
+		t.Fatalf("CompletionRate = %.4f, want 0.3", report.CompletionRate)
+	}
+	if report.SuccessRate != 0.6667 {
+		t.Fatalf("SuccessRate = %.4f, want rounded 0.6667", report.SuccessRate)
+	}
+}
+
+func TestRunPlanReportTargetReached(t *testing.T) {
+	report := NewRunPlanReport(Plan{Target: 2}, StateSnapshot{Successes: 2})
+
+	if !report.TargetReached() {
+		t.Fatalf("TargetReached() = false, want true")
+	}
+	if report.HasFailures() {
+		t.Fatalf("HasFailures() = true, want false")
+	}
+}
+
+func TestRunPlanReportAvoidsDivideByZero(t *testing.T) {
+	report := NewRunPlanReport(Plan{}, StateSnapshot{})
+
+	if report.CompletionRate != 0 || report.SuccessRate != 0 {
+		t.Fatalf("rates = %.4f/%.4f, want zeros", report.CompletionRate, report.SuccessRate)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `runner.RunPlanReport` for reusable run result summaries.
- Use the report in `surveyctl run --mock` output.
- Add completion and success rates to text and JSON mock summaries.

Closes #81

## Validation
- go test ./internal/runner -run "TestNewRunPlanReport|TestRunPlanReport" -count=1
- go test ./cmd/surveyctl -run "TestRunMock" -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added completion rate and success rate metrics to survey run reports.
  * Enhanced run summary reporting with additional execution statistics including completed count.

* **Tests**
  * Updated test coverage for run reporting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->