### PR TITLE
[codex] Stream mock run events

### DIFF
--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LING71671/SurveyController-go/internal/config"
 	"github.com/LING71671/SurveyController-go/internal/doctor"
 	"github.com/LING71671/SurveyController-go/internal/domain"
+	"github.com/LING71671/SurveyController-go/internal/logging"
 	"github.com/LING71671/SurveyController-go/internal/provider/builtin"
 	"github.com/LING71671/SurveyController-go/internal/provider/credamo"
 	"github.com/LING71671/SurveyController-go/internal/provider/tencent"
@@ -30,7 +31,7 @@ Usage:
   surveyctl config validate [path]
   surveyctl config generate --provider <id> --fixture <path> --url <url>
   surveyctl run --dry-run [path] [--json]
-  surveyctl run --mock [path] [--json] [--seed <n>]
+  surveyctl run --mock [path] [--json] [--seed <n>] [--events <text|jsonl>]
   surveyctl doctor [browser]
   surveyctl help
 
@@ -54,7 +55,7 @@ const doctorUsage = `Usage:
 
 const runUsage = `Usage:
   surveyctl run --dry-run [path] [--json]
-  surveyctl run --mock [path] [--json] [--seed <n>]
+  surveyctl run --mock [path] [--json] [--seed <n>] [--events <text|jsonl>]
 `
 
 const (
@@ -249,6 +250,7 @@ func runRun(args []string, stdout io.Writer) error {
 	dryRun := false
 	mockRun := false
 	jsonOutput := false
+	eventFormat := logging.Format("")
 	seed := int64(1)
 	path := "survey.yaml"
 	pathSet := false
@@ -267,6 +269,17 @@ func runRun(args []string, stdout io.Writer) error {
 			mockRun = true
 		case "--json":
 			jsonOutput = true
+		case "--events":
+			value, next, err := readRunFlagValue(args, i, "--events")
+			if err != nil {
+				return err
+			}
+			format, err := parseRunEventFormat(value)
+			if err != nil {
+				return err
+			}
+			eventFormat = format
+			i = next
 		case "--seed":
 			value, next, err := readRunFlagValue(args, i, "--seed")
 			if err != nil {
@@ -292,6 +305,12 @@ func runRun(args []string, stdout io.Writer) error {
 	if !dryRun && !mockRun {
 		return usageError("run requires --dry-run or --mock", runUsage)
 	}
+	if dryRun && eventFormat != "" {
+		return usageError("run --events requires --mock", runUsage)
+	}
+	if jsonOutput && eventFormat != "" {
+		return usageError("run --events cannot be combined with --json summary output", runUsage)
+	}
 
 	plan, err := compileRunPlanFromFile(path)
 	if err != nil {
@@ -308,10 +327,24 @@ func runRun(args []string, stdout io.Writer) error {
 		}
 		return nil
 	}
-	snapshot, err := runner.RunPlanSubmissions(contextBackground(), plan, runner.RunPlanOptions{
+	options := runner.RunPlanOptions{
 		RNG:       rand.New(rand.NewSource(seed)),
 		Submitter: runner.MockAnswerPlanSubmitter{},
-	})
+	}
+	var finishEvents func() (int, error)
+	if eventFormat != "" {
+		options.Events, finishEvents = startRunEventStream(stdout, eventFormat, runEventBufferSize(plan))
+	}
+	snapshot, err := runner.RunPlanSubmissions(contextBackground(), plan, options)
+	if finishEvents != nil {
+		eventCount, eventErr := finishEvents()
+		if err == nil && eventErr != nil {
+			err = eventErr
+		}
+		if err == nil {
+			fmt.Fprintf(stdout, "events: %d\n", eventCount)
+		}
+	}
 	if err != nil {
 		return commandError(exitFailure, fmt.Sprintf("run mock failed: %v", err), "")
 	}
@@ -339,6 +372,55 @@ func readRunFlagValue(args []string, index int, flag string) (string, int, error
 		return "", index, usageError(fmt.Sprintf("%s requires a value", flag), runUsage)
 	}
 	return args[next], next, nil
+}
+
+func parseRunEventFormat(value string) (logging.Format, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(logging.FormatText):
+		return logging.FormatText, nil
+	case string(logging.FormatJSONLines):
+		return logging.FormatJSONLines, nil
+	default:
+		return "", usageError("--events must be text or jsonl", runUsage)
+	}
+}
+
+type runEventStreamResult struct {
+	count int
+	err   error
+}
+
+func startRunEventStream(stdout io.Writer, format logging.Format, bufferSize int) (chan<- logging.RunEvent, func() (int, error)) {
+	events := make(chan logging.RunEvent, bufferSize)
+	done := make(chan runEventStreamResult, 1)
+	go func() {
+		writer := logging.NewEventWriter(stdout, format)
+		count := 0
+		for event := range events {
+			if err := writer.WriteEvent(event); err != nil {
+				done <- runEventStreamResult{count: count, err: err}
+				return
+			}
+			count++
+		}
+		done <- runEventStreamResult{count: count}
+	}()
+	return events, func() (int, error) {
+		close(events)
+		result := <-done
+		return result.count, result.err
+	}
+}
+
+func runEventBufferSize(plan runner.Plan) int {
+	size := plan.Target + plan.Concurrency + 4
+	if size < 16 {
+		return 16
+	}
+	if size > 4096 {
+		return 4096
+	}
+	return size
 }
 
 func runDoctor(args []string, stdout io.Writer) error {

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -346,6 +346,131 @@ questions:
 	}
 }
 
+func TestRunMockRunEventsTextPrintsEventStream(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: http
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+`)
+
+	code := run([]string{"run", "--mock", "--events", "text", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(mock events text) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	for _, want := range []string{"run_started", "worker_started", "submission_success", "run_finished", "events: 4", "mock run:"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunMockRunEventsJSONLPrintsEventStream(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: http
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+`)
+
+	code := run([]string{"run", "--mock", "--events", "jsonl", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(mock events jsonl) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) < 6 {
+		t.Fatalf("stdout lines = %q, want event stream and summary", lines)
+	}
+	var firstEvent map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &firstEvent); err != nil {
+		t.Fatalf("first jsonl event decode failed: %v; line=%q", err, lines[0])
+	}
+	if firstEvent["type"] != "run_started" || firstEvent["level"] != "info" {
+		t.Fatalf("firstEvent = %+v, want run_started info", firstEvent)
+	}
+	if !strings.Contains(stdout.String(), "events: 4") || !strings.Contains(stdout.String(), "mock run:") {
+		t.Fatalf("stdout = %q, want event count and summary", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunMockRejectsEventsWithJSONSummary(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "--mock", "--json", "--events", "jsonl"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(mock json events) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "cannot be combined") {
+		t.Fatalf("stderr = %q, want json/events conflict", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunDryRunRejectsEvents(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "--dry-run", "--events", "text"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(dry-run events) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "requires --mock") {
+		t.Fatalf("stderr = %q, want dry-run events error", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunMockRejectsInvalidEventFormat(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "--mock", "--events", "xml"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(invalid events) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "--events must be text or jsonl") {
+		t.Fatalf("stderr = %q, want event format error", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
 func TestRunRejectsBothDryRunAndMock(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
## Summary
- Add `surveyctl run --mock --events text|jsonl` for local runner event streaming.
- Keep event output separate from JSON summary mode to preserve machine-readable output.
- Cover text, JSONL, and invalid flag combinations in CLI tests.

Closes #83

## Validation
- go test ./cmd/surveyctl -run "TestRunMock|TestRunDryRunRejectsEvents" -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check