### PR TITLE
[codex] Compile multiple choice selection picker

### DIFF
--- a/internal/answer/probability.go
+++ b/internal/answer/probability.go
@@ -3,7 +3,6 @@ package answer
 import (
 	"fmt"
 	"math/rand"
-	"sort"
 )
 
 type OptionWeight struct {
@@ -92,45 +91,11 @@ func pickEven(rng *rand.Rand, weights []OptionWeight) string {
 }
 
 func PickMany(rng *rand.Rand, weights []OptionWeight, rule SelectionRule) (SelectionResult, error) {
-	if rng == nil {
-		return SelectionResult{}, fmt.Errorf("rng is required")
-	}
-	normalized, err := NormalizeWeights(weights)
+	picker, err := NewSelectionPicker(weights, rule)
 	if err != nil {
 		return SelectionResult{}, err
 	}
-	min, max, err := normalizeRule(rule, len(normalized))
-	if err != nil {
-		return SelectionResult{}, err
-	}
-
-	selected := map[string]bool{}
-	for _, item := range normalized {
-		if rng.Float64() <= item.Weight {
-			selected[item.OptionID] = true
-		}
-	}
-
-	for len(selected) < min {
-		id, err := PickOne(rng, normalized)
-		if err != nil {
-			return SelectionResult{}, err
-		}
-		selected[id] = true
-	}
-
-	if len(selected) > max {
-		ids := keys(selected)
-		rng.Shuffle(len(ids), func(i, j int) {
-			ids[i], ids[j] = ids[j], ids[i]
-		})
-		selected = map[string]bool{}
-		for _, id := range ids[:max] {
-			selected[id] = true
-		}
-	}
-
-	return SelectionResult{OptionIDs: keys(selected)}, nil
+	return picker.Pick(rng)
 }
 
 func normalizeRule(rule SelectionRule, optionCount int) (int, int, error) {
@@ -152,13 +117,4 @@ func normalizeRule(rule SelectionRule, optionCount int) (int, int, error) {
 		return 0, 0, fmt.Errorf("max must not be greater than option count")
 	}
 	return min, max, nil
-}
-
-func keys(values map[string]bool) []string {
-	ids := make([]string, 0, len(values))
-	for id := range values {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	return ids
 }

--- a/internal/answer/probability_benchmark_test.go
+++ b/internal/answer/probability_benchmark_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 var benchmarkPickedOption string
+var benchmarkSelectionResult SelectionResult
 
 func BenchmarkPickOne(b *testing.B) {
 	weights := []OptionWeight{
@@ -90,5 +91,51 @@ func BenchmarkWeightedPickerPickEvenWeights(b *testing.B) {
 			b.Fatalf("Pick() returned error: %v", err)
 		}
 		benchmarkPickedOption = optionID
+	}
+}
+
+func BenchmarkPickMany(b *testing.B) {
+	weights := []OptionWeight{
+		{OptionID: "a", Weight: 1},
+		{OptionID: "b", Weight: 2},
+		{OptionID: "c", Weight: 3},
+		{OptionID: "d", Weight: 4},
+		{OptionID: "e", Weight: 5},
+	}
+	rng := rand.New(rand.NewSource(1))
+	rule := SelectionRule{Min: 2, Max: 3}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		selected, err := PickMany(rng, weights, rule)
+		if err != nil {
+			b.Fatalf("PickMany() returned error: %v", err)
+		}
+		benchmarkSelectionResult = selected
+	}
+}
+
+func BenchmarkSelectionPickerPick(b *testing.B) {
+	picker, err := NewSelectionPicker([]OptionWeight{
+		{OptionID: "a", Weight: 1},
+		{OptionID: "b", Weight: 2},
+		{OptionID: "c", Weight: 3},
+		{OptionID: "d", Weight: 4},
+		{OptionID: "e", Weight: 5},
+	}, SelectionRule{Min: 2, Max: 3})
+	if err != nil {
+		b.Fatalf("NewSelectionPicker() returned error: %v", err)
+	}
+	rng := rand.New(rand.NewSource(1))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		selected, err := picker.Pick(rng)
+		if err != nil {
+			b.Fatalf("Pick() returned error: %v", err)
+		}
+		benchmarkSelectionResult = selected
 	}
 }

--- a/internal/answer/selection_picker.go
+++ b/internal/answer/selection_picker.go
@@ -1,0 +1,89 @@
+package answer
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+)
+
+type SelectionPicker struct {
+	options []OptionWeight
+	indexes map[string]int
+	picker  WeightedPicker
+	min     int
+	max     int
+}
+
+func NewSelectionPicker(weights []OptionWeight, rule SelectionRule) (SelectionPicker, error) {
+	normalized, err := NormalizeWeights(weights)
+	if err != nil {
+		return SelectionPicker{}, err
+	}
+	min, max, err := normalizeRule(rule, len(normalized))
+	if err != nil {
+		return SelectionPicker{}, err
+	}
+	picker, err := NewWeightedPicker(normalized)
+	if err != nil {
+		return SelectionPicker{}, err
+	}
+	indexes := make(map[string]int, len(normalized))
+	for index, item := range normalized {
+		indexes[item.OptionID] = index
+	}
+	return SelectionPicker{
+		options: normalized,
+		indexes: indexes,
+		picker:  picker,
+		min:     min,
+		max:     max,
+	}, nil
+}
+
+func (p SelectionPicker) Pick(rng *rand.Rand) (SelectionResult, error) {
+	if rng == nil {
+		return SelectionResult{}, fmt.Errorf("rng is required")
+	}
+	if len(p.options) == 0 {
+		return SelectionResult{}, fmt.Errorf("selection picker is empty")
+	}
+
+	selected := make([]bool, len(p.options))
+	ids := make([]string, 0, p.max)
+	for index, item := range p.options {
+		if rng.Float64() <= item.Weight {
+			selected[index] = true
+			ids = append(ids, item.OptionID)
+		}
+	}
+
+	for len(ids) < p.min {
+		id, err := p.picker.Pick(rng)
+		if err != nil {
+			return SelectionResult{}, err
+		}
+		index := p.indexes[id]
+		if selected[index] {
+			continue
+		}
+		selected[index] = true
+		ids = append(ids, id)
+	}
+
+	if len(ids) > p.max {
+		rng.Shuffle(len(ids), func(i, j int) {
+			ids[i], ids[j] = ids[j], ids[i]
+		})
+		ids = ids[:p.max]
+	}
+	sort.Strings(ids)
+	return SelectionResult{OptionIDs: ids}, nil
+}
+
+func (p SelectionPicker) Len() int {
+	return len(p.options)
+}
+
+func (p SelectionPicker) Rule() SelectionRule {
+	return SelectionRule{Min: p.min, Max: p.max}
+}

--- a/internal/answer/selection_picker_test.go
+++ b/internal/answer/selection_picker_test.go
@@ -1,0 +1,109 @@
+package answer
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestSelectionPickerPick(t *testing.T) {
+	picker, err := NewSelectionPicker([]OptionWeight{
+		{OptionID: "a", Weight: 1},
+		{OptionID: "b", Weight: 1},
+		{OptionID: "c", Weight: 1},
+	}, SelectionRule{Min: 2, Max: 2})
+	if err != nil {
+		t.Fatalf("NewSelectionPicker() returned error: %v", err)
+	}
+
+	got, err := picker.Pick(rand.New(rand.NewSource(1)))
+	if err != nil {
+		t.Fatalf("Pick() returned error: %v", err)
+	}
+	if len(got.OptionIDs) != 2 {
+		t.Fatalf("len(OptionIDs) = %d, want 2: %+v", len(got.OptionIDs), got.OptionIDs)
+	}
+	if got.OptionIDs[0] > got.OptionIDs[1] {
+		t.Fatalf("OptionIDs = %+v, want sorted IDs", got.OptionIDs)
+	}
+	if picker.Len() != 3 {
+		t.Fatalf("Len() = %d, want 3", picker.Len())
+	}
+	if picker.Rule() != (SelectionRule{Min: 2, Max: 2}) {
+		t.Fatalf("Rule() = %+v, want min/max 2", picker.Rule())
+	}
+}
+
+func TestSelectionPickerEvenWeights(t *testing.T) {
+	picker, err := NewSelectionPicker([]OptionWeight{
+		{OptionID: "a"},
+		{OptionID: "b"},
+		{OptionID: "c"},
+	}, SelectionRule{Min: 1, Max: 1})
+	if err != nil {
+		t.Fatalf("NewSelectionPicker() returned error: %v", err)
+	}
+
+	got, err := picker.Pick(rand.New(rand.NewSource(2)))
+	if err != nil {
+		t.Fatalf("Pick() returned error: %v", err)
+	}
+	if len(got.OptionIDs) != 1 || got.OptionIDs[0] == "" {
+		t.Fatalf("OptionIDs = %+v, want one non-empty option", got.OptionIDs)
+	}
+}
+
+func TestSelectionPickerCopiesWeights(t *testing.T) {
+	weights := []OptionWeight{
+		{OptionID: "a", Weight: 0},
+		{OptionID: "b", Weight: 1},
+	}
+	picker, err := NewSelectionPicker(weights, SelectionRule{Min: 1, Max: 1})
+	if err != nil {
+		t.Fatalf("NewSelectionPicker() returned error: %v", err)
+	}
+	weights[1].OptionID = "mutated"
+	weights[1].Weight = 0
+
+	got, err := picker.Pick(rand.New(rand.NewSource(1)))
+	if err != nil {
+		t.Fatalf("Pick() returned error: %v", err)
+	}
+	if len(got.OptionIDs) != 1 || got.OptionIDs[0] != "b" {
+		t.Fatalf("OptionIDs = %+v, want copied b", got.OptionIDs)
+	}
+}
+
+func TestSelectionPickerRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		weights []OptionWeight
+		rule    SelectionRule
+		want    string
+	}{
+		{name: "empty", want: "required"},
+		{name: "missing id", weights: []OptionWeight{{Weight: 1}}, want: "option id"},
+		{name: "negative", weights: []OptionWeight{{OptionID: "a", Weight: -1}}, want: "negative"},
+		{name: "invalid rule", weights: []OptionWeight{{OptionID: "a", Weight: 1}}, rule: SelectionRule{Min: 2, Max: 1}, want: "min must not be greater"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewSelectionPicker(tt.weights, tt.rule)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("NewSelectionPicker() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectionPickerRejectsNilRNG(t *testing.T) {
+	picker, err := NewSelectionPicker([]OptionWeight{{OptionID: "a", Weight: 1}}, SelectionRule{})
+	if err != nil {
+		t.Fatalf("NewSelectionPicker() returned error: %v", err)
+	}
+
+	if _, err := picker.Pick(nil); err == nil || !strings.Contains(err.Error(), "rng") {
+		t.Fatalf("Pick(nil) error = %v, want rng error", err)
+	}
+}

--- a/internal/runner/answer_plan_builder.go
+++ b/internal/runner/answer_plan_builder.go
@@ -16,11 +16,10 @@ type AnswerPlanBuilder struct {
 }
 
 type compiledQuestionPlan struct {
-	id      string
-	kind    domain.QuestionKind
-	picker  answer.WeightedPicker
-	weights []answer.OptionWeight
-	rule    answer.SelectionRule
+	id       string
+	kind     domain.QuestionKind
+	picker   answer.WeightedPicker
+	selector answer.SelectionPicker
 }
 
 func BuildAnswerPlan(rng *rand.Rand, questions []QuestionPlan) (answerplan.Plan, error) {
@@ -116,12 +115,12 @@ func compileQuestionPlan(question QuestionPlan) (compiledQuestionPlan, error) {
 		}
 		return compiledQuestionPlan{id: questionID, kind: kind, picker: picker}, nil
 	case domain.QuestionKindMultiple:
-		weights := append([]answer.OptionWeight(nil), question.Weights...)
 		rule := selectionRuleFromOptions(question.Options)
-		if _, err := answer.PickMany(rand.New(rand.NewSource(1)), weights, rule); err != nil {
+		selector, err := answer.NewSelectionPicker(question.Weights, rule)
+		if err != nil {
 			return compiledQuestionPlan{}, fmt.Errorf("question %q weights: %w", questionID, err)
 		}
-		return compiledQuestionPlan{id: questionID, kind: kind, weights: weights, rule: rule}, nil
+		return compiledQuestionPlan{id: questionID, kind: kind, selector: selector}, nil
 	default:
 		return compiledQuestionPlan{}, fmt.Errorf("question %q kind %q is not supported for answer plan builder", questionID, kind)
 	}
@@ -136,7 +135,7 @@ func (q compiledQuestionPlan) buildAnswer(rng *rand.Rand) (answerplan.QuestionAn
 		}
 		return answerplan.QuestionAnswer{QuestionID: q.id, OptionIDs: []string{optionID}}, nil
 	case domain.QuestionKindMultiple:
-		selected, err := answer.PickMany(rng, q.weights, q.rule)
+		selected, err := q.selector.Pick(rng)
 		if err != nil {
 			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q pick many: %w", q.id, err)
 		}


### PR DESCRIPTION
## Summary
- Add a compiled `answer.SelectionPicker` for multiple-choice answer selection.
- Wire `runner.AnswerPlanBuilder` to compile multiple-choice questions once.
- Add tests and benchmarks comparing legacy `PickMany` with compiled selection picking.

Closes #85

## Benchmark
- BenchmarkPickMany: about 690.7 ns/op, 560 B/op, 5 allocs/op
- BenchmarkSelectionPickerPick: about 185.9 ns/op, 48 B/op, 1 alloc/op

## Validation
- go test ./internal/answer -run "TestSelectionPicker|TestPickMany" -count=1
- go test ./internal/runner -run "TestBuildAnswerPlan|TestCompileAnswerPlanBuilder" -count=1
- go test ./internal/answer -bench "Benchmark(PickMany|SelectionPickerPick)$" -benchmem -run ^$
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check