### PR TITLE
[codex] Document mock run events

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ go run ./cmd/surveyctl version
 go run ./cmd/surveyctl config validate examples/run.yaml
 go run ./cmd/surveyctl config generate --provider wjx --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx
 go run ./cmd/surveyctl run --dry-run examples/run.yaml
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 go run ./cmd/surveyctl doctor
 go run ./cmd/surveyctl doctor browser
 ```
@@ -62,6 +64,20 @@ surveyctl v0.1.0
 运行事件会同时支持人类可读文本和 JSON Lines。默认文本用于终端查看，JSON Lines 用于后续脚本、CI 和 UI 订阅。
 
 结构化事件会优先携带机器可读字段，例如提交状态、错误码、失败归因、是否停止、是否需要轮换代理。高并发运行时不能依赖解析人类文案做决策。
+
+当前 `surveyctl run` 已经支持两个本地预览入口：
+
+- `--dry-run`：只编译配置和运行计划，不生成提交任务，不访问网络。
+- `--mock`：使用本地 mock submitter 执行 runner/worker pool/答案计划链路，不访问网络。
+
+mock run 默认输出汇总信息，包括目标数、并发数、成功数、失败数、完成率、成功率和 worker 数。需要观察运行事件时可加：
+
+```powershell
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events text
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
+```
+
+`--events jsonl` 面向后续脚本、CI 和轻量 GUI 外壳；`v1.0` 前不会把 GUI 放进核心，但事件流会保持足够稳定，让 UI 只做薄订阅层。
 
 ## 开发节奏
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,41 @@ gofmt -w (git ls-files '*.go')
 
 在 Windows 上，`go test -race` 需要 CGO 和 `gcc` 之类的 C 编译器。如果本地竞态检查失败并提示 `C compiler "gcc" not found`，可以先运行普通测试，并依赖 Ubuntu CI 中的竞态检查，直到本地安装好 C 工具链。
 
+## 运行预览
+
+`surveyctl run` 当前只开放不会访问网络的预览能力：
+
+```powershell
+go run ./cmd/surveyctl run --dry-run examples/run.yaml
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events text
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
+```
+
+`--dry-run` 用于验证配置能否编译成运行计划；`--mock` 会实际经过答案计划生成、worker pool、运行状态和事件输出，但 submitter 是本地 mock，不访问任何平台。
+
+事件流和汇总输出的边界要保持清晰：
+
+- `--json` 只输出最终汇总 JSON。
+- `--events text` 输出人类可读事件，再输出最终汇总。
+- `--events jsonl` 输出 JSON Lines 事件，再输出最终汇总。
+- `--events` 不和 `--json` 同时使用，避免把事件流和单个 JSON 汇总混成不稳定协议。
+
+新增真实运行能力时，优先复用 runner 层的 `RunPlanReport` 和 logging 事件类型。CLI、CI、脚本和后续轻量 GUI 都应订阅同一套 core 事件，不要为 UI 单独分叉业务状态。
+
+## 性能习惯
+
+热路径优先做编译型结构，例如 `WeightedPicker`、`SelectionPicker`、`AnswerPlanBuilder`。配置解析、规则校验、权重归一化这类稳定工作应尽量在编译阶段完成，运行阶段只做必要的随机抽样和提交调度。
+
+性能相关 PR 至少说明以下内容：
+
+- 是否减少每次提交或每题的分配。
+- 是否改变并发上限或 worker 生命周期。
+- 是否增加 benchmark 或保留可复测的 benchmark 命令。
+- 是否影响 browser 小池兜底路径。
+
+本地 benchmark 不作为绝对性能承诺，但要写清机器上的相对变化，例如 `PickMany` 与编译后 picker 的 ns/op、B/op、allocs/op 对比。
+
 ## 先有议题
 
 修改行为前先创建或认领议题：

--- a/examples/mock-run.yaml
+++ b/examples/mock-run.yaml
@@ -1,0 +1,57 @@
+schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 3
+  concurrency: 2
+  mode: http
+  failure_threshold: 1
+  fail_stop_enabled: true
+  headless: true
+  submit_interval:
+    min_seconds: 0
+    max_seconds: 0
+  answer_duration:
+    min_seconds: 0
+    max_seconds: 0
+  timed_mode:
+    enabled: false
+    refresh_interval_seconds: 3
+proxy:
+  enabled: false
+  source: default
+  occupy_minutes: 1
+reverse_fill:
+  enabled: false
+  format: auto
+  start_row: 1
+random_ua:
+  enabled: false
+  ratios:
+    wechat: 33
+    mobile: 33
+    pc: 34
+questions:
+  - id: q1
+    kind: single
+    required: true
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+        - option_id: b
+          weight: 2
+  - id: q2
+    kind: multiple
+    required: true
+    options:
+      min_selected: 1
+      max_selected: 2
+      weights:
+        - option_id: x
+          weight: 1
+        - option_id: y
+          weight: 1
+        - option_id: z
+          weight: 1

--- a/internal/runner/pool.go
+++ b/internal/runner/pool.go
@@ -73,15 +73,12 @@ enqueue:
 	wg.Wait()
 
 	snapshot := p.state.Snapshot()
-	p.emit(logging.RunEvent{
-		Type:    logging.EventRunFinished,
-		Level:   logging.LevelInfo,
-		Message: "run finished",
-		Fields: map[string]any{
-			"successes": snapshot.Successes,
-			"failures":  snapshot.Failures,
-		},
-	})
+	event := logging.NewEvent(logging.EventRunFinished, "run finished")
+	event.Fields = map[string]any{
+		"successes": snapshot.Successes,
+		"failures":  snapshot.Failures,
+	}
+	p.emit(event)
 	return snapshot
 }
 
@@ -117,12 +114,9 @@ enqueue:
 
 func (p *WorkerPool) worker(ctx context.Context, workerID int, tasks <-chan Task) {
 	p.state.SetWorkerStatus(workerID, WorkerStatusRunning, "worker started")
-	p.emit(logging.RunEvent{
-		Type:     logging.EventWorkerStarted,
-		Level:    logging.LevelInfo,
-		WorkerID: workerID,
-		Message:  "worker started",
-	})
+	event := logging.NewEvent(logging.EventWorkerStarted, "worker started")
+	event.WorkerID = workerID
+	p.emit(event)
 	defer p.state.SetWorkerStatus(workerID, WorkerStatusStopped, "worker stopped")
 
 	for {
@@ -136,12 +130,9 @@ func (p *WorkerPool) worker(ctx context.Context, workerID int, tasks <-chan Task
 			if err := task(ctx, workerID); err != nil {
 				p.state.RecordFailureWithCode(workerID, err.Error(), errorCode(err))
 				if p.eventsEnabled() {
-					event := logging.RunEvent{
-						Type:     logging.EventSubmissionFailure,
-						Level:    logging.LevelError,
-						WorkerID: workerID,
-						Message:  err.Error(),
-					}
+					event := logging.NewEvent(logging.EventSubmissionFailure, err.Error())
+					event.Level = logging.LevelError
+					event.WorkerID = workerID
 					addErrorFields(&event, err)
 					p.emit(event)
 				}
@@ -149,12 +140,9 @@ func (p *WorkerPool) worker(ctx context.Context, workerID int, tasks <-chan Task
 			}
 			p.state.RecordSuccess(workerID)
 			if p.eventsEnabled() {
-				p.emit(logging.RunEvent{
-					Type:     logging.EventSubmissionSuccess,
-					Level:    logging.LevelInfo,
-					WorkerID: workerID,
-					Message:  "submission succeeded",
-				})
+				event := logging.NewEvent(logging.EventSubmissionSuccess, "submission succeeded")
+				event.WorkerID = workerID
+				p.emit(event)
 			}
 		}
 	}
@@ -176,12 +164,9 @@ func (p *WorkerPool) submissionWorker(ctx context.Context, workerID int, tasks <
 			if err != nil {
 				p.state.RecordFailureWithCode(workerID, err.Error(), errorCode(err))
 				if p.eventsEnabled() {
-					event := logging.RunEvent{
-						Type:     logging.EventSubmissionFailure,
-						Level:    logging.LevelError,
-						WorkerID: workerID,
-						Message:  err.Error(),
-					}
+					event := logging.NewEvent(logging.EventSubmissionFailure, err.Error())
+					event.Level = logging.LevelError
+					event.WorkerID = workerID
 					addErrorFields(&event, err)
 					p.emit(event)
 				}
@@ -197,26 +182,20 @@ func (p *WorkerPool) submissionWorker(ctx context.Context, workerID int, tasks <
 
 func (p *WorkerPool) startWorker(workerID int) {
 	p.state.SetWorkerStatus(workerID, WorkerStatusRunning, "worker started")
-	p.emit(logging.RunEvent{
-		Type:     logging.EventWorkerStarted,
-		Level:    logging.LevelInfo,
-		WorkerID: workerID,
-		Message:  "worker started",
-	})
+	event := logging.NewEvent(logging.EventWorkerStarted, "worker started")
+	event.WorkerID = workerID
+	p.emit(event)
 }
 
 func (p *WorkerPool) finishRun() StateSnapshot {
 	snapshot := p.state.Snapshot()
-	p.emit(logging.RunEvent{
-		Type:    logging.EventRunFinished,
-		Level:   logging.LevelInfo,
-		Message: "run finished",
-		Fields: map[string]any{
-			"successes":      snapshot.Successes,
-			"failures":       snapshot.Failures,
-			"stop_requested": snapshot.StopRequested,
-		},
-	})
+	event := logging.NewEvent(logging.EventRunFinished, "run finished")
+	event.Fields = map[string]any{
+		"successes":      snapshot.Successes,
+		"failures":       snapshot.Failures,
+		"stop_requested": snapshot.StopRequested,
+	}
+	p.emit(event)
 	return snapshot
 }
 

--- a/internal/runner/pool_test.go
+++ b/internal/runner/pool_test.go
@@ -37,6 +37,34 @@ func TestWorkerPoolRecordsSuccessAndFailure(t *testing.T) {
 	}
 }
 
+func TestWorkerPoolEventsIncludeTimestamps(t *testing.T) {
+	events := make(chan logging.RunEvent, 16)
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 1, Target: 1, Events: events})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+
+	pool.RunSubmissions(context.Background(), []SubmissionTask{
+		submissionResultTask(engine.SubmissionResult{
+			State:    provider.SubmissionStateSuccess,
+			Message:  "done",
+			Success:  true,
+			Terminal: true,
+		}),
+	})
+
+	for {
+		select {
+		case event := <-events:
+			if event.Time.IsZero() {
+				t.Fatalf("event %q has zero timestamp: %+v", event.Type, event)
+			}
+		default:
+			return
+		}
+	}
+}
+
 func TestWorkerPoolHonorsConcurrency(t *testing.T) {
 	pool, err := NewWorkerPool(PoolOptions{Concurrency: 2})
 	if err != nil {

--- a/internal/runner/submission.go
+++ b/internal/runner/submission.go
@@ -25,18 +25,14 @@ func (s *RunState) RecordSubmissionResult(workerID int, result engine.Submission
 }
 
 func EventForSubmissionResult(workerID int, result engine.SubmissionResult) logging.RunEvent {
-	event := logging.RunEvent{
-		Type:     logging.EventWorkerProgress,
-		Level:    logging.LevelInfo,
-		WorkerID: workerID,
-		Message:  result.Message,
-		Fields: map[string]any{
-			"state":               string(result.State),
-			"terminal":            result.Terminal,
-			"completion_detected": result.CompletionDetected,
-			"should_stop":         result.ShouldStop,
-			"should_rotate_proxy": result.ShouldRotateProxy,
-		},
+	event := logging.NewEvent(logging.EventWorkerProgress, result.Message)
+	event.WorkerID = workerID
+	event.Fields = map[string]any{
+		"state":               string(result.State),
+		"terminal":            result.Terminal,
+		"completion_detected": result.CompletionDetected,
+		"should_stop":         result.ShouldStop,
+		"should_rotate_proxy": result.ShouldRotateProxy,
 	}
 	if code, ok := apperr.CodeOf(result.Error); ok {
 		event.Fields["error_code"] = string(code)

--- a/internal/runner/submission_test.go
+++ b/internal/runner/submission_test.go
@@ -159,6 +159,9 @@ func TestEventForSubmissionResult(t *testing.T) {
 			if event.Type != tt.wantType || event.Level != tt.wantLevel || event.WorkerID != 7 {
 				t.Fatalf("event = %+v, want type %q level %q worker 7", event, tt.wantType, tt.wantLevel)
 			}
+			if event.Time.IsZero() {
+				t.Fatalf("event time is zero: %+v", event)
+			}
 			if event.Fields["state"] != string(tt.result.State) {
 				t.Fatalf("state field = %v, want %q", event.Fields["state"], tt.result.State)
 			}


### PR DESCRIPTION
## Summary
- Document `surveyctl run --mock` and event streaming in README and development docs.
- Add `examples/mock-run.yaml` as a runnable local mock configuration.
- Ensure runner events emitted by worker pool/submission helpers always include UTC timestamps.

Closes #87

## Validation
- go run ./cmd/surveyctl config validate examples/mock-run.yaml
- go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
- go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
- go test ./internal/runner -run "TestWorkerPoolEventsIncludeTimestamps|TestEventForSubmissionResult" -count=1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check