### PR TITLE
[codex] Generate run plan submissions lazily

### DIFF
--- a/internal/runner/benchmark_test.go
+++ b/internal/runner/benchmark_test.go
@@ -48,6 +48,35 @@ func BenchmarkWorkerPoolRunSubmissionsLightTasks(b *testing.B) {
 	}
 }
 
+func BenchmarkRunPlanSubmissionsLazyTasks(b *testing.B) {
+	for _, target := range []int{1000, 5000} {
+		b.Run(fmt.Sprintf("target_%d", target), func(b *testing.B) {
+			benchmarkRunPlanSubmissionsLazyTasks(b, target)
+		})
+	}
+}
+
+func benchmarkRunPlanSubmissionsLazyTasks(b *testing.B, target int) {
+	b.Helper()
+	plan := benchmarkRunnerPlan(target)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		snapshot, err := RunPlanSubmissions(context.Background(), plan, RunPlanOptions{
+			RNG:       rand.New(rand.NewSource(int64(i + 1))),
+			Submitter: benchmarkAnswerPlanSubmitter{},
+		})
+		if err != nil {
+			b.Fatalf("RunPlanSubmissions() returned error: %v", err)
+		}
+		if snapshot.Successes != target || snapshot.Failures != 0 {
+			b.Fatalf("snapshot counts = %d/%d, want %d/0", snapshot.Successes, snapshot.Failures, target)
+		}
+		benchmarkRunnerSnapshot = snapshot
+	}
+}
+
 func benchmarkWorkerPoolRunSubmissionsLightTasks(b *testing.B, target int) {
 	b.Helper()
 	tasks, err := SubmissionTasksFromPlan(rand.New(rand.NewSource(1)), benchmarkRunnerPlan(target), benchmarkAnswerPlanSubmitter{})

--- a/internal/runner/pool.go
+++ b/internal/runner/pool.go
@@ -11,6 +11,7 @@ import (
 
 type Task func(ctx context.Context, workerID int) error
 type SubmissionTask func(ctx context.Context, workerID int) (engine.SubmissionResult, error)
+type SubmissionTaskGenerator func(index int) (SubmissionTask, error)
 
 const DefaultMaxWorkerConcurrency = engine.LightWorkerConcurrencyBaseline
 
@@ -83,11 +84,25 @@ enqueue:
 }
 
 func (p *WorkerPool) RunSubmissions(ctx context.Context, tasks []SubmissionTask) StateSnapshot {
+	snapshot, _ := p.RunGeneratedSubmissions(ctx, len(tasks), func(index int) (SubmissionTask, error) {
+		return tasks[index], nil
+	})
+	return snapshot
+}
+
+func (p *WorkerPool) RunGeneratedSubmissions(ctx context.Context, taskCount int, next SubmissionTaskGenerator) (StateSnapshot, error) {
+	if taskCount < 0 {
+		return p.state.Snapshot(), fmt.Errorf("task count must not be negative")
+	}
+	if taskCount > 0 && next == nil {
+		return p.state.Snapshot(), fmt.Errorf("submission task generator is required")
+	}
+
 	p.emit(logging.NewEvent(logging.EventRunStarted, "run started"))
 	taskCh := make(chan SubmissionTask)
 	var wg sync.WaitGroup
 
-	for workerID := 1; workerID <= p.workerCount(len(tasks)); workerID++ {
+	for workerID := 1; workerID <= p.workerCount(taskCount); workerID++ {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
@@ -95,9 +110,15 @@ func (p *WorkerPool) RunSubmissions(ctx context.Context, tasks []SubmissionTask)
 		}(workerID)
 	}
 
+	var generateErr error
 enqueue:
-	for _, task := range tasks {
+	for index := 0; index < taskCount; index++ {
 		if p.state.ShouldStop() {
+			break
+		}
+		task, err := next(index)
+		if err != nil {
+			generateErr = err
 			break
 		}
 		select {
@@ -109,7 +130,7 @@ enqueue:
 	close(taskCh)
 	wg.Wait()
 
-	return p.finishRun()
+	return p.finishRun(), generateErr
 }
 
 func (p *WorkerPool) worker(ctx context.Context, workerID int, tasks <-chan Task) {

--- a/internal/runner/pool_test.go
+++ b/internal/runner/pool_test.go
@@ -3,6 +3,8 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -227,6 +229,75 @@ func TestWorkerPoolRunSubmissionsRecordsResults(t *testing.T) {
 	}
 	if !hasEvent(events, logging.EventSubmissionFailure) {
 		t.Fatalf("events did not include submission failure")
+	}
+}
+
+func TestWorkerPoolRunGeneratedSubmissions(t *testing.T) {
+	events := make(chan logging.RunEvent, 16)
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 2, Target: 3, Events: events})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+	var generated int32
+
+	snapshot, err := pool.RunGeneratedSubmissions(context.Background(), 3, func(index int) (SubmissionTask, error) {
+		atomic.AddInt32(&generated, 1)
+		return submissionResultTask(engine.SubmissionResult{
+			State:    provider.SubmissionStateSuccess,
+			Message:  "ok",
+			Success:  true,
+			Terminal: true,
+		}), nil
+	})
+	if err != nil {
+		t.Fatalf("RunGeneratedSubmissions() returned error: %v", err)
+	}
+	if generated != 3 {
+		t.Fatalf("generated = %d, want 3", generated)
+	}
+	if snapshot.Successes != 3 || snapshot.Failures != 0 {
+		t.Fatalf("snapshot counts = %d/%d, want 3/0", snapshot.Successes, snapshot.Failures)
+	}
+	if !hasEvent(events, logging.EventRunStarted) || !hasEvent(events, logging.EventRunFinished) {
+		t.Fatalf("events did not include run start and finish")
+	}
+}
+
+func TestWorkerPoolRunGeneratedSubmissionsReturnsGeneratorError(t *testing.T) {
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 1, Target: 3})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+
+	snapshot, err := pool.RunGeneratedSubmissions(context.Background(), 3, func(index int) (SubmissionTask, error) {
+		if index == 1 {
+			return nil, fmt.Errorf("generate task %d", index)
+		}
+		return submissionResultTask(engine.SubmissionResult{
+			State:    provider.SubmissionStateSuccess,
+			Success:  true,
+			Terminal: true,
+		}), nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "generate task 1") {
+		t.Fatalf("RunGeneratedSubmissions() error = %v, want generator error", err)
+	}
+	if snapshot.Successes != 1 || snapshot.Failures != 0 {
+		t.Fatalf("snapshot counts = %d/%d, want completed generated task", snapshot.Successes, snapshot.Failures)
+	}
+}
+
+func TestWorkerPoolRunGeneratedSubmissionsRejectsInvalidInput(t *testing.T) {
+	pool, err := NewWorkerPool(PoolOptions{Concurrency: 1})
+	if err != nil {
+		t.Fatalf("NewWorkerPool() returned error: %v", err)
+	}
+
+	if _, err := pool.RunGeneratedSubmissions(context.Background(), -1, nil); err == nil || !strings.Contains(err.Error(), "task count") {
+		t.Fatalf("RunGeneratedSubmissions(negative) error = %v, want task count error", err)
+	}
+	if _, err := pool.RunGeneratedSubmissions(context.Background(), 1, nil); err == nil || !strings.Contains(err.Error(), "generator") {
+		t.Fatalf("RunGeneratedSubmissions(nil generator) error = %v, want generator error", err)
 	}
 }
 

--- a/internal/runner/run_plan.go
+++ b/internal/runner/run_plan.go
@@ -27,8 +27,10 @@ func RunPlanSubmissions(ctx context.Context, plan Plan, options RunPlanOptions) 
 	if options.Submitter == nil {
 		return StateSnapshot{}, fmt.Errorf("answer plan submitter is required")
 	}
-
-	tasks, err := SubmissionTasksFromPlan(options.RNG, plan, options.Submitter)
+	if err := New().ValidatePlan(plan); err != nil {
+		return StateSnapshot{}, err
+	}
+	builder, err := CompileAnswerPlanBuilder(plan.Questions)
 	if err != nil {
 		return StateSnapshot{}, err
 	}
@@ -41,7 +43,17 @@ func RunPlanSubmissions(ctx context.Context, plan Plan, options RunPlanOptions) 
 	if err != nil {
 		return StateSnapshot{}, err
 	}
-	return pool.RunSubmissions(ctx, tasks), nil
+	return pool.RunGeneratedSubmissions(ctx, plan.Target, func(index int) (SubmissionTask, error) {
+		answerPlan, err := builder.Build(options.RNG)
+		if err != nil {
+			return nil, fmt.Errorf("answer plan %d: %w", index+1, err)
+		}
+		taskPlan := answerPlan
+		return func(ctx context.Context, workerID int) (engine.SubmissionResult, error) {
+			_ = workerID
+			return options.Submitter.Submit(ctx, taskPlan)
+		}, nil
+	})
 }
 
 func runFailureThreshold(plan Plan) int {


### PR DESCRIPTION
## Summary
- Add generated submission task execution to the worker pool.
- Switch `RunPlanSubmissions` to build answer plans lazily instead of prebuilding all target tasks.
- Keep the existing `RunSubmissions([]SubmissionTask)` API for callers that already have explicit tasks.

Closes #89

## Validation
- go test ./internal/runner -run "TestWorkerPoolRunGenerated|TestRunPlanSubmissions" -count=1
- go test ./internal/runner -bench "Benchmark(SubmissionTasksFromPlan|RunPlanSubmissionsLazyTasks)/target_1000$" -benchmem -run ^$
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check