### PR TITLE
[codex] Allow run target concurrency overrides

### DIFF
--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -30,8 +30,8 @@ Usage:
   surveyctl version
   surveyctl config validate [path]
   surveyctl config generate --provider <id> --fixture <path> --url <url>
-  surveyctl run --dry-run [path] [--json]
-  surveyctl run --mock [path] [--json] [--seed <n>] [--events <text|jsonl>]
+  surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
+  surveyctl run --mock [path] [--json] [--seed <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>]
   surveyctl doctor [browser]
   surveyctl help
 
@@ -54,8 +54,8 @@ const doctorUsage = `Usage:
 `
 
 const runUsage = `Usage:
-  surveyctl run --dry-run [path] [--json]
-  surveyctl run --mock [path] [--json] [--seed <n>] [--events <text|jsonl>]
+  surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
+  surveyctl run --mock [path] [--json] [--seed <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>]
 `
 
 const (
@@ -251,6 +251,7 @@ func runRun(args []string, stdout io.Writer) error {
 	mockRun := false
 	jsonOutput := false
 	eventFormat := logging.Format("")
+	overrides := runPlanOverrides{}
 	seed := int64(1)
 	path := "survey.yaml"
 	pathSet := false
@@ -269,6 +270,28 @@ func runRun(args []string, stdout io.Writer) error {
 			mockRun = true
 		case "--json":
 			jsonOutput = true
+		case "--target":
+			value, next, err := readRunFlagValue(args, i, "--target")
+			if err != nil {
+				return err
+			}
+			target, err := parsePositiveRunInt(value, "--target")
+			if err != nil {
+				return err
+			}
+			overrides.Target = target
+			i = next
+		case "--concurrency":
+			value, next, err := readRunFlagValue(args, i, "--concurrency")
+			if err != nil {
+				return err
+			}
+			concurrency, err := parsePositiveRunInt(value, "--concurrency")
+			if err != nil {
+				return err
+			}
+			overrides.Concurrency = concurrency
+			i = next
 		case "--events":
 			value, next, err := readRunFlagValue(args, i, "--events")
 			if err != nil {
@@ -312,7 +335,7 @@ func runRun(args []string, stdout io.Writer) error {
 		return usageError("run --events cannot be combined with --json summary output", runUsage)
 	}
 
-	plan, err := compileRunPlanFromFile(path)
+	plan, err := compileRunPlanFromFile(path, overrides)
 	if err != nil {
 		action := "dry-run"
 		if mockRun {
@@ -351,7 +374,12 @@ func runRun(args []string, stdout io.Writer) error {
 	return printMockRunSummary(stdout, path, plan, snapshot, seed, jsonOutput)
 }
 
-func compileRunPlanFromFile(path string) (runner.Plan, error) {
+type runPlanOverrides struct {
+	Target      int
+	Concurrency int
+}
+
+func compileRunPlanFromFile(path string, overrides runPlanOverrides) (runner.Plan, error) {
 	cfg, err := config.LoadRunConfig(path)
 	if err != nil {
 		return runner.Plan{}, err
@@ -363,7 +391,24 @@ func compileRunPlanFromFile(path string) (runner.Plan, error) {
 		}
 		cfg.Survey.Provider = providerID.String()
 	}
-	return runner.CompilePlan(cfg)
+	plan, err := runner.CompilePlan(cfg)
+	if err != nil {
+		return runner.Plan{}, err
+	}
+	return applyRunPlanOverrides(plan, overrides)
+}
+
+func applyRunPlanOverrides(plan runner.Plan, overrides runPlanOverrides) (runner.Plan, error) {
+	if overrides.Target > 0 {
+		plan.Target = overrides.Target
+	}
+	if overrides.Concurrency > 0 {
+		plan.Concurrency = overrides.Concurrency
+	}
+	if err := runner.New().ValidatePlan(plan); err != nil {
+		return runner.Plan{}, err
+	}
+	return plan, nil
 }
 
 func readRunFlagValue(args []string, index int, flag string) (string, int, error) {
@@ -372,6 +417,14 @@ func readRunFlagValue(args []string, index int, flag string) (string, int, error
 		return "", index, usageError(fmt.Sprintf("%s requires a value", flag), runUsage)
 	}
 	return args[next], next, nil
+}
+
+func parsePositiveRunInt(value string, flag string) (int, error) {
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return 0, usageError(fmt.Sprintf("%s requires a positive integer", flag), runUsage)
+	}
+	return parsed, nil
 }
 
 func parseRunEventFormat(value string) (logging.Format, error) {

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -272,6 +272,34 @@ questions: []
 	}
 }
 
+func TestRunDryRunAppliesTargetConcurrencyOverrides(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: http
+questions: []
+`)
+
+	code := run([]string{"run", "--dry-run", "--target", "7", "--concurrency", "3", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(dry-run overrides) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	for _, want := range []string{"target: 7", "concurrency: 3"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestRunMockRunPrintsSummary(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -301,6 +329,40 @@ questions:
 		t.Fatalf("run(mock) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
 	}
 	for _, want := range []string{"mock run:", "provider: mock", "target: 3", "successes: 3", "failures: 0", "completed: 3", "completion_rate: 100.00%", "success_rate: 100.00%", "network: disabled"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunMockRunAppliesTargetConcurrencyOverrides(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: http
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+`)
+
+	code := run([]string{"run", "--mock", "--target", "4", "--concurrency", "2", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(mock overrides) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	for _, want := range []string{"target: 4", "concurrency: 2", "successes: 4", "workers: 2"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
@@ -343,6 +405,64 @@ questions:
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunRejectsInvalidTargetOverride(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "--mock", "--target", "0"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(invalid target override) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "--target requires a positive integer") {
+		t.Fatalf("stderr = %q, want target override error", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunRejectsInvalidConcurrencyOverride(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "--mock", "--concurrency", "nope"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(invalid concurrency override) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "--concurrency requires a positive integer") {
+		t.Fatalf("stderr = %q, want concurrency override error", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunRejectsConcurrencyOverrideAboveModeLimit(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: browser
+questions: []
+`)
+
+	code := run([]string{"run", "--dry-run", "--concurrency", "17", path}, &stdout, &stderr)
+	if code != exitFailure {
+		t.Fatalf("run(too high concurrency override) exit code = %d, want %d", code, exitFailure)
+	}
+	if !strings.Contains(stderr.String(), "browser mode concurrency") {
+		t.Fatalf("stderr = %q, want browser concurrency limit", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `surveyctl run --target <n>` and `--concurrency <n>` overrides.
- Revalidate overridden plans through runner mode limits.
- Cover dry-run, mock run, invalid values, and browser-mode concurrency limit handling.

Closes #91

## Validation
- go test ./cmd/surveyctl -run "TestRun.*Override|TestRunMockRunApplies|TestRunDryRunApplies" -count=1
- go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --seed 7
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check