### PR TITLE
[codex] Report mock run throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ surveyctl v0.1.0
 - `--dry-run`：只编译配置和运行计划，不生成提交任务，不访问网络。
 - `--mock`：使用本地 mock submitter 执行 runner/worker pool/答案计划链路，不访问网络。
 
-mock run 默认输出汇总信息，包括目标数、并发数、成功数、失败数、完成率、成功率和 worker 数。需要观察运行事件时可加：
+mock run 默认输出汇总信息，包括目标数、并发数、成功数、失败数、完成率、成功率、耗时、吞吐和 worker 数。需要临时压测不同规模时，可以不用修改 YAML，直接覆盖目标数和并发数：
+
+```powershell
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --seed 7
+```
+
+需要观察运行事件时可加：
 
 ```powershell
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events text

--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/LING71671/SurveyController-go/internal/config"
 	"github.com/LING71671/SurveyController-go/internal/doctor"
@@ -358,7 +359,9 @@ func runRun(args []string, stdout io.Writer) error {
 	if eventFormat != "" {
 		options.Events, finishEvents = startRunEventStream(stdout, eventFormat, runEventBufferSize(plan))
 	}
+	startedAt := time.Now()
 	snapshot, err := runner.RunPlanSubmissions(contextBackground(), plan, options)
+	elapsed := time.Since(startedAt)
 	if finishEvents != nil {
 		eventCount, eventErr := finishEvents()
 		if err == nil && eventErr != nil {
@@ -371,7 +374,7 @@ func runRun(args []string, stdout io.Writer) error {
 	if err != nil {
 		return commandError(exitFailure, fmt.Sprintf("run mock failed: %v", err), "")
 	}
-	return printMockRunSummary(stdout, path, plan, snapshot, seed, jsonOutput)
+	return printMockRunSummary(stdout, path, plan, snapshot, seed, elapsed, jsonOutput)
 }
 
 type runPlanOverrides struct {
@@ -531,6 +534,8 @@ type mockRunSummary struct {
 	Completed         int     `json:"completed"`
 	CompletionRate    float64 `json:"completion_rate"`
 	SuccessRate       float64 `json:"success_rate"`
+	DurationMS        int64   `json:"duration_ms"`
+	ThroughputPerSec  float64 `json:"throughput_per_second"`
 	StopRequested     bool    `json:"stop_requested"`
 	StopReason        string  `json:"stop_reason,omitempty"`
 	StopFailureReason string  `json:"stop_failure_reason,omitempty"`
@@ -576,8 +581,8 @@ func printDryRunPlan(stdout io.Writer, path string, plan runner.Plan, jsonOutput
 	return nil
 }
 
-func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapshot runner.StateSnapshot, seed int64, jsonOutput bool) error {
-	report := runner.NewRunPlanReport(plan, snapshot)
+func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapshot runner.StateSnapshot, seed int64, elapsed time.Duration, jsonOutput bool) error {
+	report := runner.NewTimedRunPlanReport(plan, snapshot, elapsed)
 	summary := mockRunSummary{
 		Path:              path,
 		Provider:          report.Provider,
@@ -591,6 +596,8 @@ func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapsh
 		Completed:         report.Completed,
 		CompletionRate:    report.CompletionRate,
 		SuccessRate:       report.SuccessRate,
+		DurationMS:        report.DurationMS,
+		ThroughputPerSec:  report.ThroughputPerSec,
 		StopRequested:     report.StopRequested,
 		StopReason:        report.StopReason,
 		StopFailureReason: report.StopFailureReason,
@@ -614,6 +621,8 @@ func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapsh
 	fmt.Fprintf(stdout, "  completed: %d\n", summary.Completed)
 	fmt.Fprintf(stdout, "  completion_rate: %s\n", formatPercent(summary.CompletionRate))
 	fmt.Fprintf(stdout, "  success_rate: %s\n", formatPercent(summary.SuccessRate))
+	fmt.Fprintf(stdout, "  duration_ms: %d\n", summary.DurationMS)
+	fmt.Fprintf(stdout, "  throughput_per_second: %.2f\n", summary.ThroughputPerSec)
 	fmt.Fprintf(stdout, "  stop_requested: %t\n", summary.StopRequested)
 	fmt.Fprintf(stdout, "  workers: %d\n", summary.WorkerCount)
 	fmt.Fprintln(stdout, "  network: disabled (mock)")

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -328,7 +328,7 @@ questions:
 	if code != exitOK {
 		t.Fatalf("run(mock) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
 	}
-	for _, want := range []string{"mock run:", "provider: mock", "target: 3", "successes: 3", "failures: 0", "completed: 3", "completion_rate: 100.00%", "success_rate: 100.00%", "network: disabled"} {
+	for _, want := range []string{"mock run:", "provider: mock", "target: 3", "successes: 3", "failures: 0", "completed: 3", "completion_rate: 100.00%", "success_rate: 100.00%", "duration_ms:", "throughput_per_second:", "network: disabled"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
@@ -402,6 +402,12 @@ questions:
 	}
 	if summary["successes"] != float64(2) || summary["failures"] != float64(0) || summary["completed"] != float64(2) || summary["completion_rate"] != float64(1) || summary["success_rate"] != float64(1) || summary["seed"] != float64(1) {
 		t.Fatalf("summary = %+v, want mock success summary", summary)
+	}
+	if _, ok := summary["duration_ms"]; !ok {
+		t.Fatalf("summary = %+v, want duration_ms", summary)
+	}
+	if _, ok := summary["throughput_per_second"]; !ok {
+		t.Fatalf("summary = %+v, want throughput_per_second", summary)
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,11 +26,14 @@ gofmt -w (git ls-files '*.go')
 ```powershell
 go run ./cmd/surveyctl run --dry-run examples/run.yaml
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --seed 7
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events text
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 ```
 
 `--dry-run` 用于验证配置能否编译成运行计划；`--mock` 会实际经过答案计划生成、worker pool、运行状态和事件输出，但 submitter 是本地 mock，不访问任何平台。
+
+`--target` 和 `--concurrency` 可以覆盖配置中的运行规模，用于本地压测和验证资源上限。覆盖后的计划仍会重新走 runner 校验，因此 `browser` 模式不会被临时参数放大到超过小池限制。
 
 事件流和汇总输出的边界要保持清晰：
 

--- a/internal/runner/run_report.go
+++ b/internal/runner/run_report.go
@@ -1,6 +1,9 @@
 package runner
 
-import "math"
+import (
+	"math"
+	"time"
+)
 
 type RunPlanReport struct {
 	Provider          string  `json:"provider"`
@@ -13,10 +16,22 @@ type RunPlanReport struct {
 	Completed         int     `json:"completed"`
 	CompletionRate    float64 `json:"completion_rate"`
 	SuccessRate       float64 `json:"success_rate"`
+	DurationMS        int64   `json:"duration_ms,omitempty"`
+	ThroughputPerSec  float64 `json:"throughput_per_second,omitempty"`
 	StopRequested     bool    `json:"stop_requested"`
 	StopReason        string  `json:"stop_reason,omitempty"`
 	StopFailureReason string  `json:"stop_failure_reason,omitempty"`
 	WorkerCount       int     `json:"worker_count"`
+}
+
+func NewTimedRunPlanReport(plan Plan, snapshot StateSnapshot, elapsed time.Duration) RunPlanReport {
+	report := NewRunPlanReport(plan, snapshot)
+	if elapsed <= 0 {
+		return report
+	}
+	report.DurationMS = elapsed.Milliseconds()
+	report.ThroughputPerSec = ratioPerSecond(report.Completed, elapsed)
+	return report
 }
 
 func NewRunPlanReport(plan Plan, snapshot StateSnapshot) RunPlanReport {
@@ -56,4 +71,11 @@ func ratio(value int, total int) float64 {
 
 func roundRatio(value float64) float64 {
 	return math.Round(value*10000) / 10000
+}
+
+func ratioPerSecond(value int, elapsed time.Duration) float64 {
+	if value <= 0 || elapsed <= 0 {
+		return 0
+	}
+	return roundRatio(float64(value) / elapsed.Seconds())
 }

--- a/internal/runner/run_report_test.go
+++ b/internal/runner/run_report_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"testing"
+	"time"
 
 	"github.com/LING71671/SurveyController-go/internal/engine"
 )
@@ -74,6 +75,36 @@ func TestRunPlanReportTargetReached(t *testing.T) {
 	}
 	if report.HasFailures() {
 		t.Fatalf("HasFailures() = true, want false")
+	}
+}
+
+func TestNewTimedRunPlanReportAddsDurationAndThroughput(t *testing.T) {
+	report := NewTimedRunPlanReport(
+		Plan{Target: 10},
+		StateSnapshot{Successes: 6, Failures: 4},
+		2*time.Second,
+	)
+
+	if report.Completed != 10 {
+		t.Fatalf("Completed = %d, want 10", report.Completed)
+	}
+	if report.DurationMS != 2000 {
+		t.Fatalf("DurationMS = %d, want 2000", report.DurationMS)
+	}
+	if report.ThroughputPerSec != 5 {
+		t.Fatalf("ThroughputPerSec = %.4f, want 5", report.ThroughputPerSec)
+	}
+}
+
+func TestNewTimedRunPlanReportIgnoresNonPositiveDuration(t *testing.T) {
+	report := NewTimedRunPlanReport(
+		Plan{Target: 1},
+		StateSnapshot{Successes: 1},
+		0,
+	)
+
+	if report.DurationMS != 0 || report.ThroughputPerSec != 0 {
+		t.Fatalf("timing = %d/%.4f, want zeros", report.DurationMS, report.ThroughputPerSec)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add timed run plan reports with duration and throughput fields.
- Surface `duration_ms` and `throughput_per_second` in `surveyctl run --mock` text and JSON output.
- Document 1000-concurrency mock preview commands in README and development docs.

Closes #93

## Validation
- go test ./internal/runner -run "TestNewTimedRunPlanReport|TestNewRunPlanReport" -count=1
- go test ./cmd/surveyctl -run "TestRunMockRun(Prints|JSON)" -count=1
- go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --seed 7
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check