### PR TITLE
[codex] Report mock run resource metrics

### DIFF
--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -359,9 +360,11 @@ func runRun(args []string, stdout io.Writer) error {
 	if eventFormat != "" {
 		options.Events, finishEvents = startRunEventStream(stdout, eventFormat, runEventBufferSize(plan))
 	}
+	beforeRuntime := sampleRuntime()
 	startedAt := time.Now()
 	snapshot, err := runner.RunPlanSubmissions(contextBackground(), plan, options)
 	elapsed := time.Since(startedAt)
+	afterRuntime := sampleRuntime()
 	if finishEvents != nil {
 		eventCount, eventErr := finishEvents()
 		if err == nil && eventErr != nil {
@@ -374,7 +377,7 @@ func runRun(args []string, stdout io.Writer) error {
 	if err != nil {
 		return commandError(exitFailure, fmt.Sprintf("run mock failed: %v", err), "")
 	}
-	return printMockRunSummary(stdout, path, plan, snapshot, seed, elapsed, jsonOutput)
+	return printMockRunSummary(stdout, path, plan, snapshot, seed, elapsed, runtimeMetrics(beforeRuntime, afterRuntime), jsonOutput)
 }
 
 type runPlanOverrides struct {
@@ -444,6 +447,38 @@ func parseRunEventFormat(value string) (logging.Format, error) {
 type runEventStreamResult struct {
 	count int
 	err   error
+}
+
+type runtimeSample struct {
+	heapAlloc  uint64
+	totalAlloc uint64
+	goroutines int
+}
+
+func sampleRuntime() runtimeSample {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return runtimeSample{
+		heapAlloc:  stats.HeapAlloc,
+		totalAlloc: stats.TotalAlloc,
+		goroutines: runtime.NumGoroutine(),
+	}
+}
+
+func runtimeMetrics(before runtimeSample, after runtimeSample) runner.RunResourceMetrics {
+	return runner.RunResourceMetrics{
+		Goroutines:      after.goroutines,
+		HeapAllocBytes:  after.heapAlloc,
+		HeapAllocDelta:  int64(after.heapAlloc) - int64(before.heapAlloc),
+		TotalAllocDelta: subtractUint64(after.totalAlloc, before.totalAlloc),
+	}
+}
+
+func subtractUint64(after uint64, before uint64) uint64 {
+	if after < before {
+		return 0
+	}
+	return after - before
 }
 
 func startRunEventStream(stdout io.Writer, format logging.Format, bufferSize int) (chan<- logging.RunEvent, func() (int, error)) {
@@ -536,6 +571,10 @@ type mockRunSummary struct {
 	SuccessRate       float64 `json:"success_rate"`
 	DurationMS        int64   `json:"duration_ms"`
 	ThroughputPerSec  float64 `json:"throughput_per_second"`
+	Goroutines        int     `json:"goroutines"`
+	HeapAllocBytes    uint64  `json:"heap_alloc_bytes"`
+	HeapAllocDelta    int64   `json:"heap_alloc_delta_bytes"`
+	TotalAllocDelta   uint64  `json:"total_alloc_delta_bytes"`
 	StopRequested     bool    `json:"stop_requested"`
 	StopReason        string  `json:"stop_reason,omitempty"`
 	StopFailureReason string  `json:"stop_failure_reason,omitempty"`
@@ -581,8 +620,8 @@ func printDryRunPlan(stdout io.Writer, path string, plan runner.Plan, jsonOutput
 	return nil
 }
 
-func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapshot runner.StateSnapshot, seed int64, elapsed time.Duration, jsonOutput bool) error {
-	report := runner.NewTimedRunPlanReport(plan, snapshot, elapsed)
+func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapshot runner.StateSnapshot, seed int64, elapsed time.Duration, metrics runner.RunResourceMetrics, jsonOutput bool) error {
+	report := runner.NewTimedRunPlanReport(plan, snapshot, elapsed).WithResourceMetrics(metrics)
 	summary := mockRunSummary{
 		Path:              path,
 		Provider:          report.Provider,
@@ -598,6 +637,10 @@ func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapsh
 		SuccessRate:       report.SuccessRate,
 		DurationMS:        report.DurationMS,
 		ThroughputPerSec:  report.ThroughputPerSec,
+		Goroutines:        report.Goroutines,
+		HeapAllocBytes:    report.HeapAllocBytes,
+		HeapAllocDelta:    report.HeapAllocDelta,
+		TotalAllocDelta:   report.TotalAllocDelta,
 		StopRequested:     report.StopRequested,
 		StopReason:        report.StopReason,
 		StopFailureReason: report.StopFailureReason,
@@ -623,6 +666,10 @@ func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapsh
 	fmt.Fprintf(stdout, "  success_rate: %s\n", formatPercent(summary.SuccessRate))
 	fmt.Fprintf(stdout, "  duration_ms: %d\n", summary.DurationMS)
 	fmt.Fprintf(stdout, "  throughput_per_second: %.2f\n", summary.ThroughputPerSec)
+	fmt.Fprintf(stdout, "  goroutines: %d\n", summary.Goroutines)
+	fmt.Fprintf(stdout, "  heap_alloc_bytes: %d\n", summary.HeapAllocBytes)
+	fmt.Fprintf(stdout, "  heap_alloc_delta_bytes: %d\n", summary.HeapAllocDelta)
+	fmt.Fprintf(stdout, "  total_alloc_delta_bytes: %d\n", summary.TotalAllocDelta)
 	fmt.Fprintf(stdout, "  stop_requested: %t\n", summary.StopRequested)
 	fmt.Fprintf(stdout, "  workers: %d\n", summary.WorkerCount)
 	fmt.Fprintln(stdout, "  network: disabled (mock)")

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -328,7 +328,7 @@ questions:
 	if code != exitOK {
 		t.Fatalf("run(mock) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
 	}
-	for _, want := range []string{"mock run:", "provider: mock", "target: 3", "successes: 3", "failures: 0", "completed: 3", "completion_rate: 100.00%", "success_rate: 100.00%", "duration_ms:", "throughput_per_second:", "network: disabled"} {
+	for _, want := range []string{"mock run:", "provider: mock", "target: 3", "successes: 3", "failures: 0", "completed: 3", "completion_rate: 100.00%", "success_rate: 100.00%", "duration_ms:", "throughput_per_second:", "goroutines:", "heap_alloc_bytes:", "total_alloc_delta_bytes:", "network: disabled"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
@@ -408,6 +408,11 @@ questions:
 	}
 	if _, ok := summary["throughput_per_second"]; !ok {
 		t.Fatalf("summary = %+v, want throughput_per_second", summary)
+	}
+	for _, key := range []string{"goroutines", "heap_alloc_bytes", "heap_alloc_delta_bytes", "total_alloc_delta_bytes"} {
+		if _, ok := summary[key]; !ok {
+			t.Fatalf("summary = %+v, want %s", summary, key)
+		}
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())

--- a/internal/runner/run_report.go
+++ b/internal/runner/run_report.go
@@ -18,10 +18,21 @@ type RunPlanReport struct {
 	SuccessRate       float64 `json:"success_rate"`
 	DurationMS        int64   `json:"duration_ms,omitempty"`
 	ThroughputPerSec  float64 `json:"throughput_per_second,omitempty"`
+	Goroutines        int     `json:"goroutines,omitempty"`
+	HeapAllocBytes    uint64  `json:"heap_alloc_bytes,omitempty"`
+	HeapAllocDelta    int64   `json:"heap_alloc_delta_bytes,omitempty"`
+	TotalAllocDelta   uint64  `json:"total_alloc_delta_bytes,omitempty"`
 	StopRequested     bool    `json:"stop_requested"`
 	StopReason        string  `json:"stop_reason,omitempty"`
 	StopFailureReason string  `json:"stop_failure_reason,omitempty"`
 	WorkerCount       int     `json:"worker_count"`
+}
+
+type RunResourceMetrics struct {
+	Goroutines      int
+	HeapAllocBytes  uint64
+	HeapAllocDelta  int64
+	TotalAllocDelta uint64
 }
 
 func NewTimedRunPlanReport(plan Plan, snapshot StateSnapshot, elapsed time.Duration) RunPlanReport {
@@ -32,6 +43,14 @@ func NewTimedRunPlanReport(plan Plan, snapshot StateSnapshot, elapsed time.Durat
 	report.DurationMS = elapsed.Milliseconds()
 	report.ThroughputPerSec = ratioPerSecond(report.Completed, elapsed)
 	return report
+}
+
+func (r RunPlanReport) WithResourceMetrics(metrics RunResourceMetrics) RunPlanReport {
+	r.Goroutines = metrics.Goroutines
+	r.HeapAllocBytes = metrics.HeapAllocBytes
+	r.HeapAllocDelta = metrics.HeapAllocDelta
+	r.TotalAllocDelta = metrics.TotalAllocDelta
+	return r
 }
 
 func NewRunPlanReport(plan Plan, snapshot StateSnapshot) RunPlanReport {

--- a/internal/runner/run_report_test.go
+++ b/internal/runner/run_report_test.go
@@ -108,6 +108,22 @@ func TestNewTimedRunPlanReportIgnoresNonPositiveDuration(t *testing.T) {
 	}
 }
 
+func TestRunPlanReportWithResourceMetrics(t *testing.T) {
+	report := NewRunPlanReport(Plan{Target: 1}, StateSnapshot{Successes: 1}).WithResourceMetrics(RunResourceMetrics{
+		Goroutines:      8,
+		HeapAllocBytes:  1024,
+		HeapAllocDelta:  -128,
+		TotalAllocDelta: 2048,
+	})
+
+	if report.Goroutines != 8 {
+		t.Fatalf("Goroutines = %d, want 8", report.Goroutines)
+	}
+	if report.HeapAllocBytes != 1024 || report.HeapAllocDelta != -128 || report.TotalAllocDelta != 2048 {
+		t.Fatalf("resource metrics = %+v, want heap/current/delta/total", report)
+	}
+}
+
 func TestRunPlanReportAvoidsDivideByZero(t *testing.T) {
 	report := NewRunPlanReport(Plan{}, StateSnapshot{})
 


### PR DESCRIPTION
## Summary
- Add resource metrics to run plan reports.
- Surface goroutine count, heap allocation, heap allocation delta, and total allocation delta in `surveyctl run --mock` output.
- Keep the metrics available in both text and JSON summaries.

Closes #95

## Validation
- go test ./internal/runner -run "TestRunPlanReport|TestNewTimedRunPlanReport" -count=1
- go test ./cmd/surveyctl -run "TestRunMockRun(Prints|JSON)" -count=1
- go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --seed 7
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check