### PR TITLE
[codex] Add mock run failure injection

### DIFF
--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -33,7 +33,7 @@ Usage:
   surveyctl config validate [path]
   surveyctl config generate --provider <id> --fixture <path> --url <url>
   surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
-  surveyctl run --mock [path] [--json] [--seed <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>]
+  surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>]
   surveyctl doctor [browser]
   surveyctl help
 
@@ -57,7 +57,7 @@ const doctorUsage = `Usage:
 
 const runUsage = `Usage:
   surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
-  surveyctl run --mock [path] [--json] [--seed <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>]
+  surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>]
 `
 
 const (
@@ -254,6 +254,7 @@ func runRun(args []string, stdout io.Writer) error {
 	jsonOutput := false
 	eventFormat := logging.Format("")
 	overrides := runPlanOverrides{}
+	mockFailEvery := 0
 	seed := int64(1)
 	path := "survey.yaml"
 	pathSet := false
@@ -316,6 +317,17 @@ func runRun(args []string, stdout io.Writer) error {
 			}
 			seed = parsed
 			i = next
+		case "--mock-fail-every":
+			value, next, err := readRunFlagValue(args, i, "--mock-fail-every")
+			if err != nil {
+				return err
+			}
+			failEvery, err := parsePositiveRunInt(value, "--mock-fail-every")
+			if err != nil {
+				return err
+			}
+			mockFailEvery = failEvery
+			i = next
 		default:
 			if pathSet {
 				return usageError("run accepts at most one path", runUsage)
@@ -336,6 +348,9 @@ func runRun(args []string, stdout io.Writer) error {
 	if jsonOutput && eventFormat != "" {
 		return usageError("run --events cannot be combined with --json summary output", runUsage)
 	}
+	if dryRun && mockFailEvery > 0 {
+		return usageError("run --mock-fail-every requires --mock", runUsage)
+	}
 
 	plan, err := compileRunPlanFromFile(path, overrides)
 	if err != nil {
@@ -354,7 +369,7 @@ func runRun(args []string, stdout io.Writer) error {
 	}
 	options := runner.RunPlanOptions{
 		RNG:       rand.New(rand.NewSource(seed)),
-		Submitter: runner.MockAnswerPlanSubmitter{},
+		Submitter: mockSubmitter(mockFailEvery),
 	}
 	var finishEvents func() (int, error)
 	if eventFormat != "" {
@@ -378,6 +393,13 @@ func runRun(args []string, stdout io.Writer) error {
 		return commandError(exitFailure, fmt.Sprintf("run mock failed: %v", err), "")
 	}
 	return printMockRunSummary(stdout, path, plan, snapshot, seed, elapsed, runtimeMetrics(beforeRuntime, afterRuntime), jsonOutput)
+}
+
+func mockSubmitter(failEvery int) runner.AnswerPlanSubmitter {
+	if failEvery > 0 {
+		return &runner.FailureInjectingMockSubmitter{FailEvery: failEvery}
+	}
+	return runner.MockAnswerPlanSubmitter{}
 }
 
 type runPlanOverrides struct {
@@ -576,6 +598,7 @@ type mockRunSummary struct {
 	HeapAllocDelta    int64   `json:"heap_alloc_delta_bytes"`
 	TotalAllocDelta   uint64  `json:"total_alloc_delta_bytes"`
 	StopRequested     bool    `json:"stop_requested"`
+	FailureThreshold  bool    `json:"failure_threshold_reached"`
 	StopReason        string  `json:"stop_reason,omitempty"`
 	StopFailureReason string  `json:"stop_failure_reason,omitempty"`
 	WorkerCount       int     `json:"worker_count"`
@@ -642,6 +665,7 @@ func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapsh
 		HeapAllocDelta:    report.HeapAllocDelta,
 		TotalAllocDelta:   report.TotalAllocDelta,
 		StopRequested:     report.StopRequested,
+		FailureThreshold:  report.FailureThreshold,
 		StopReason:        report.StopReason,
 		StopFailureReason: report.StopFailureReason,
 		WorkerCount:       report.WorkerCount,
@@ -671,6 +695,7 @@ func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapsh
 	fmt.Fprintf(stdout, "  heap_alloc_delta_bytes: %d\n", summary.HeapAllocDelta)
 	fmt.Fprintf(stdout, "  total_alloc_delta_bytes: %d\n", summary.TotalAllocDelta)
 	fmt.Fprintf(stdout, "  stop_requested: %t\n", summary.StopRequested)
+	fmt.Fprintf(stdout, "  failure_threshold_reached: %t\n", summary.FailureThreshold)
 	fmt.Fprintf(stdout, "  workers: %d\n", summary.WorkerCount)
 	fmt.Fprintln(stdout, "  network: disabled (mock)")
 	return nil

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -328,7 +328,7 @@ questions:
 	if code != exitOK {
 		t.Fatalf("run(mock) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
 	}
-	for _, want := range []string{"mock run:", "provider: mock", "target: 3", "successes: 3", "failures: 0", "completed: 3", "completion_rate: 100.00%", "success_rate: 100.00%", "duration_ms:", "throughput_per_second:", "goroutines:", "heap_alloc_bytes:", "total_alloc_delta_bytes:", "network: disabled"} {
+	for _, want := range []string{"mock run:", "provider: mock", "target: 3", "successes: 3", "failures: 0", "completed: 3", "completion_rate: 100.00%", "success_rate: 100.00%", "duration_ms:", "throughput_per_second:", "goroutines:", "heap_alloc_bytes:", "total_alloc_delta_bytes:", "failure_threshold_reached: false", "network: disabled"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
@@ -409,6 +409,9 @@ questions:
 	if _, ok := summary["throughput_per_second"]; !ok {
 		t.Fatalf("summary = %+v, want throughput_per_second", summary)
 	}
+	if summary["failure_threshold_reached"] != false {
+		t.Fatalf("summary = %+v, want failure threshold false", summary)
+	}
 	for _, key := range []string{"goroutines", "heap_alloc_bytes", "heap_alloc_delta_bytes", "total_alloc_delta_bytes"} {
 		if _, ok := summary[key]; !ok {
 			t.Fatalf("summary = %+v, want %s", summary, key)
@@ -471,6 +474,74 @@ questions: []
 	}
 	if !strings.Contains(stderr.String(), "browser mode concurrency") {
 		t.Fatalf("stderr = %q, want browser concurrency limit", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunMockRunFailureInjection(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 5
+  concurrency: 1
+  mode: http
+  failure_threshold: 1
+  fail_stop_enabled: true
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+`)
+
+	code := run([]string{"run", "--mock", "--mock-fail-every", "2", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(mock fail every) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	for _, want := range []string{"successes: 1", "failures: 1", "failure_threshold_reached: true"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunMockRejectsInvalidFailEvery(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "--mock", "--mock-fail-every", "0"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(invalid fail every) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "--mock-fail-every requires a positive integer") {
+		t.Fatalf("stderr = %q, want fail every error", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunDryRunRejectsFailEvery(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "--dry-run", "--mock-fail-every", "2"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(dry-run fail every) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "requires --mock") {
+		t.Fatalf("stderr = %q, want mock-only error", stderr.String())
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty", stdout.String())

--- a/internal/runner/pool.go
+++ b/internal/runner/pool.go
@@ -48,10 +48,11 @@ func NewWorkerPool(options PoolOptions) (*WorkerPool, error) {
 
 func (p *WorkerPool) Run(ctx context.Context, tasks []Task) StateSnapshot {
 	p.emit(logging.NewEvent(logging.EventRunStarted, "run started"))
-	taskCh := make(chan Task)
+	workerCount := p.workerCount(len(tasks))
+	taskCh := make(chan Task, workerCount)
 	var wg sync.WaitGroup
 
-	for workerID := 1; workerID <= p.workerCount(len(tasks)); workerID++ {
+	for workerID := 1; workerID <= workerCount; workerID++ {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
@@ -99,14 +100,22 @@ func (p *WorkerPool) RunGeneratedSubmissions(ctx context.Context, taskCount int,
 	}
 
 	p.emit(logging.NewEvent(logging.EventRunStarted, "run started"))
-	taskCh := make(chan SubmissionTask)
+	workerCount := p.workerCount(taskCount)
+	taskCh := make(chan SubmissionTask, workerCount)
+	stopCh := make(chan struct{})
+	var stopOnce sync.Once
+	signalStop := func() {
+		stopOnce.Do(func() {
+			close(stopCh)
+		})
+	}
 	var wg sync.WaitGroup
 
-	for workerID := 1; workerID <= p.workerCount(taskCount); workerID++ {
+	for workerID := 1; workerID <= workerCount; workerID++ {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			p.submissionWorker(ctx, id, taskCh)
+			p.submissionWorker(ctx, id, taskCh, signalStop)
 		}(workerID)
 	}
 
@@ -123,6 +132,8 @@ enqueue:
 		}
 		select {
 		case <-ctx.Done():
+			break enqueue
+		case <-stopCh:
 			break enqueue
 		case taskCh <- task:
 		}
@@ -169,7 +180,7 @@ func (p *WorkerPool) worker(ctx context.Context, workerID int, tasks <-chan Task
 	}
 }
 
-func (p *WorkerPool) submissionWorker(ctx context.Context, workerID int, tasks <-chan SubmissionTask) {
+func (p *WorkerPool) submissionWorker(ctx context.Context, workerID int, tasks <-chan SubmissionTask, signalStop func()) {
 	p.startWorker(workerID)
 	defer p.state.SetWorkerStatus(workerID, WorkerStatusStopped, "worker stopped")
 
@@ -179,6 +190,9 @@ func (p *WorkerPool) submissionWorker(ctx context.Context, workerID int, tasks <
 			return
 		case task, ok := <-tasks:
 			if !ok || p.state.ShouldStop() {
+				if p.state.ShouldStop() && signalStop != nil {
+					signalStop()
+				}
 				return
 			}
 			result, err := task(ctx, workerID)
@@ -191,11 +205,19 @@ func (p *WorkerPool) submissionWorker(ctx context.Context, workerID int, tasks <
 					addErrorFields(&event, err)
 					p.emit(event)
 				}
+				if p.state.ShouldStop() && signalStop != nil {
+					signalStop()
+					return
+				}
 				continue
 			}
 			p.state.RecordSubmissionResult(workerID, result)
 			if p.eventsEnabled() {
 				p.emit(EventForSubmissionResult(workerID, result))
+			}
+			if p.state.ShouldStop() && signalStop != nil {
+				signalStop()
+				return
 			}
 		}
 	}

--- a/internal/runner/pool.go
+++ b/internal/runner/pool.go
@@ -49,7 +49,7 @@ func NewWorkerPool(options PoolOptions) (*WorkerPool, error) {
 func (p *WorkerPool) Run(ctx context.Context, tasks []Task) StateSnapshot {
 	p.emit(logging.NewEvent(logging.EventRunStarted, "run started"))
 	workerCount := p.workerCount(len(tasks))
-	taskCh := make(chan Task, workerCount)
+	taskCh := make(chan Task)
 	var wg sync.WaitGroup
 
 	for workerID := 1; workerID <= workerCount; workerID++ {

--- a/internal/runner/run_plan.go
+++ b/internal/runner/run_plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sync/atomic"
 
 	"github.com/LING71671/SurveyController-go/internal/answerplan"
 	"github.com/LING71671/SurveyController-go/internal/engine"
@@ -75,6 +76,45 @@ func (MockAnswerPlanSubmitter) Submit(ctx context.Context, plan answerplan.Plan)
 			Message:  "answer plan is empty",
 			Terminal: true,
 			Error:    fmt.Errorf("answer plan is empty"),
+		}, nil
+	}
+	return engine.SubmissionResult{
+		State:              provider.SubmissionStateSuccess,
+		Message:            "mock submission succeeded",
+		Success:            true,
+		Terminal:           true,
+		CompletionDetected: true,
+	}, nil
+}
+
+type FailureInjectingMockSubmitter struct {
+	FailEvery int
+	counter   atomic.Uint64
+}
+
+func (s *FailureInjectingMockSubmitter) Submit(ctx context.Context, plan answerplan.Plan) (engine.SubmissionResult, error) {
+	if s == nil {
+		return engine.SubmissionResult{}, fmt.Errorf("failure injecting mock submitter is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return engine.SubmissionResult{}, err
+	}
+	if plan.Empty() {
+		return engine.SubmissionResult{
+			State:    provider.SubmissionStateFailure,
+			Message:  "answer plan is empty",
+			Terminal: true,
+			Error:    fmt.Errorf("answer plan is empty"),
+		}, nil
+	}
+
+	attempt := s.counter.Add(1)
+	if s.FailEvery > 0 && attempt%uint64(s.FailEvery) == 0 {
+		return engine.SubmissionResult{
+			State:    provider.SubmissionStateFailure,
+			Message:  fmt.Sprintf("mock submission failed at attempt %d", attempt),
+			Terminal: true,
+			Error:    fmt.Errorf("mock submission failed"),
 		}, nil
 	}
 	return engine.SubmissionResult{

--- a/internal/runner/run_plan_test.go
+++ b/internal/runner/run_plan_test.go
@@ -49,6 +49,48 @@ func TestRunPlanSubmissionsHonorsFailStopFlag(t *testing.T) {
 	}
 }
 
+func TestFailureInjectingMockSubmitter(t *testing.T) {
+	submitter := &FailureInjectingMockSubmitter{FailEvery: 2}
+	plan := answerplan.Plan{Answers: []answerplan.QuestionAnswer{{QuestionID: "q1", OptionIDs: []string{"a"}}}}
+
+	first, err := submitter.Submit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("first Submit() returned error: %v", err)
+	}
+	if !first.Success || first.State != provider.SubmissionStateSuccess {
+		t.Fatalf("first result = %+v, want success", first)
+	}
+
+	second, err := submitter.Submit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("second Submit() returned error: %v", err)
+	}
+	if second.Success || second.State != provider.SubmissionStateFailure || second.Error == nil {
+		t.Fatalf("second result = %+v, want injected failure", second)
+	}
+}
+
+func TestRunPlanSubmissionsWithFailureInjectingMockSubmitter(t *testing.T) {
+	plan := runnableTestPlan(5)
+	plan.Concurrency = 1
+	plan.FailureThreshold = 1
+	plan.FailStopEnabled = true
+
+	snapshot, err := RunPlanSubmissions(context.Background(), plan, RunPlanOptions{
+		RNG:       rand.New(rand.NewSource(1)),
+		Submitter: &FailureInjectingMockSubmitter{FailEvery: 2},
+	})
+	if err != nil {
+		t.Fatalf("RunPlanSubmissions() returned error: %v", err)
+	}
+	if snapshot.Successes != 1 || snapshot.Failures != 1 {
+		t.Fatalf("snapshot counts = %d/%d, want 1/1", snapshot.Successes, snapshot.Failures)
+	}
+	if !snapshot.FailureThresholdReached() {
+		t.Fatalf("FailureThresholdReached() = false, want true")
+	}
+}
+
 func TestRunPlanSubmissionsRejectsInvalidInput(t *testing.T) {
 	validPlan := runnableTestPlan(1)
 	tests := []struct {

--- a/internal/runner/run_report.go
+++ b/internal/runner/run_report.go
@@ -23,6 +23,7 @@ type RunPlanReport struct {
 	HeapAllocDelta    int64   `json:"heap_alloc_delta_bytes,omitempty"`
 	TotalAllocDelta   uint64  `json:"total_alloc_delta_bytes,omitempty"`
 	StopRequested     bool    `json:"stop_requested"`
+	FailureThreshold  bool    `json:"failure_threshold_reached"`
 	StopReason        string  `json:"stop_reason,omitempty"`
 	StopFailureReason string  `json:"stop_failure_reason,omitempty"`
 	WorkerCount       int     `json:"worker_count"`
@@ -67,6 +68,7 @@ func NewRunPlanReport(plan Plan, snapshot StateSnapshot) RunPlanReport {
 		CompletionRate:    ratio(completed, plan.Target),
 		SuccessRate:       ratio(snapshot.Successes, completed),
 		StopRequested:     snapshot.StopRequested,
+		FailureThreshold:  snapshot.FailureThresholdReached(),
 		StopReason:        snapshot.StopReason,
 		StopFailureReason: snapshot.StopFailureReason,
 		WorkerCount:       len(snapshot.Workers),

--- a/internal/runner/run_report_test.go
+++ b/internal/runner/run_report_test.go
@@ -16,6 +16,7 @@ func TestNewRunPlanReportSummarizesSnapshot(t *testing.T) {
 		Concurrency: 3,
 	}
 	snapshot := StateSnapshot{
+		FailureThreshold:  1,
 		Successes:         3,
 		Failures:          1,
 		StopRequested:     true,
@@ -44,6 +45,9 @@ func TestNewRunPlanReportSummarizesSnapshot(t *testing.T) {
 	}
 	if !report.StopRequested || report.StopReason != "failure_threshold" || report.StopFailureReason != "validation required" {
 		t.Fatalf("report stop = %+v, want stop details copied", report)
+	}
+	if !report.FailureThreshold {
+		t.Fatalf("FailureThreshold = false, want true")
 	}
 	if !report.HasFailures() {
 		t.Fatalf("HasFailures() = false, want true")


### PR DESCRIPTION
## Summary
- Add `FailureInjectingMockSubmitter` for local mock failure simulation.
- Add `surveyctl run --mock-fail-every <n>` to inject predictable mock failures.
- Surface `failure_threshold_reached` in mock run summaries.
- Avoid producer blocking when generated submission workers stop on threshold.

Closes #97

## Validation
- go test ./internal/runner -run "TestFailureInjecting|TestRunPlanSubmissionsWithFailure|TestWorkerPoolRunGeneratedSubmissionsReturnsGeneratorError|TestNewRunPlanReport" -count=1
- go test ./cmd/surveyctl -run "TestRunMockRunFailureInjection|TestRunMockRejectsInvalidFailEvery|TestRunDryRunRejectsFailEvery|TestRunMockRun(Prints|JSON)" -count=1
- go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 5 --concurrency 1 --mock-fail-every 2 --seed 7
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check