### PR TITLE
[codex] Add local mock stress profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ go run ./cmd/surveyctl config generate --provider wjx --fixture internal/provide
 go run ./cmd/surveyctl run --dry-run examples/run.yaml
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
+.\scripts\mock-stress.ps1
 go run ./cmd/surveyctl doctor
 go run ./cmd/surveyctl doctor browser
 ```
@@ -76,6 +77,14 @@ mock run 默认输出汇总信息，包括目标数、并发数、成功数、�
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --seed 7
 ```
 
+也可以使用脚本复现默认 1000 并发 mock 压测：
+
+```powershell
+.\scripts\mock-stress.ps1
+.\scripts\mock-stress.ps1 -Json
+.\scripts\mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2
+```
+
 需要观察运行事件时可加：
 
 ```powershell
@@ -104,5 +113,6 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 - [开发指南](docs/development.md)
 - [架构说明](docs/architecture.md)
 - [路线图](docs/roadmap.md)
+- [性能与压测](docs/performance.md)
 - [原项目分析](docs/discovery/original-project-analysis.md)
 - [运行闭环对齐复盘](docs/discovery/original-runtime-alignment-2026-04-30.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,6 +27,7 @@ gofmt -w (git ls-files '*.go')
 go run ./cmd/surveyctl run --dry-run examples/run.yaml
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --seed 7
+.\scripts\mock-stress.ps1
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events text
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 ```
@@ -34,6 +35,8 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 `--dry-run` 用于验证配置能否编译成运行计划；`--mock` 会实际经过答案计划生成、worker pool、运行状态和事件输出，但 submitter 是本地 mock，不访问任何平台。
 
 `--target` 和 `--concurrency` 可以覆盖配置中的运行规模，用于本地压测和验证资源上限。覆盖后的计划仍会重新走 runner 校验，因此 `browser` 模式不会被临时参数放大到超过小池限制。
+
+常用压测入口见 [性能与压测](performance.md)。默认脚本会运行 1000 target / 1000 concurrency 的本地 mock；`-Json` 输出最终 JSON 汇总，`-FailEvery` 可验证失败阈值和停止行为。
 
 事件流和汇总输出的边界要保持清晰：
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,57 @@
+# 性能与压测
+
+本项目的性能目标是高速、高效、轻量、高性能。`v1.0` 前的压测以本地 mock run 为主：它会经过配置编译、答案计划生成、worker pool、运行状态和报告输出，但不会访问任何问卷平台。
+
+## 本地 mock 压测
+
+推荐从 1000 并发开始验证：
+
+```powershell
+.\scripts\mock-stress.ps1
+```
+
+等价于：
+
+```powershell
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --seed 7
+```
+
+输出会包含：
+
+- `successes` / `failures` / `completed`
+- `duration_ms`
+- `throughput_per_second`
+- `goroutines`
+- `heap_alloc_bytes`
+- `heap_alloc_delta_bytes`
+- `total_alloc_delta_bytes`
+- `failure_threshold_reached`
+
+这些数字用于观察趋势，不作为跨机器绝对承诺。比较不同实现时，优先在同一机器、同一配置、同一 seed 下重复运行。
+
+## JSON 汇总
+
+脚本可输出单个 JSON 汇总，方便后续 CI 或轻量 GUI 读取：
+
+```powershell
+.\scripts\mock-stress.ps1 -Json
+```
+
+JSON 汇总不要和 `--events jsonl` 混用。前者是最终报告，后者是事件流。
+
+## 失败注入
+
+可以用失败注入验证失败阈值和停止行为：
+
+```powershell
+.\scripts\mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2
+```
+
+预期会在第二次 mock submission 失败后触发 `failure_threshold_reached: true`。这仍然是本地 mock，不访问网络。
+
+## 解释原则
+
+- `duration_ms` 和 `throughput_per_second` 主要用于对比同一台机器上的相对变化。
+- `heap_alloc_delta_bytes` 和 `total_alloc_delta_bytes` 用于观察运行期间新增分配。
+- `goroutines` 用于确认 worker 已回收，长期目标是运行后不留下额外 goroutine。
+- 真实平台运行加入后，仍要保持 provider 能力门控；登录、验证、风控、设备次数上限必须停止并报告。

--- a/scripts/mock-stress.ps1
+++ b/scripts/mock-stress.ps1
@@ -1,0 +1,49 @@
+param(
+    [string]$Config = "examples/mock-run.yaml",
+    [int]$Target = 1000,
+    [int]$Concurrency = 1000,
+    [int]$Seed = 7,
+    [int]$FailEvery = 0,
+    [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($Target -le 0) {
+    throw "Target must be greater than 0."
+}
+if ($Concurrency -le 0) {
+    throw "Concurrency must be greater than 0."
+}
+if ($FailEvery -lt 0) {
+    throw "FailEvery must not be negative."
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $repoRoot
+try {
+    $surveyctlArgs = @(
+        "run",
+        "--mock",
+        $Config,
+        "--target",
+        $Target,
+        "--concurrency",
+        $Concurrency,
+        "--seed",
+        $Seed
+    )
+
+    if ($FailEvery -gt 0) {
+        $surveyctlArgs += @("--mock-fail-every", $FailEvery)
+    }
+    if ($Json) {
+        $surveyctlArgs += "--json"
+    }
+
+    & go run ./cmd/surveyctl @surveyctlArgs
+    exit $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- Add `scripts/mock-stress.ps1` as a repeatable local mock stress profile.
- Add `docs/performance.md` with success, JSON, and failure-injection profiles.
- Link the stress profile from README and development docs.

Closes #99

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress.ps1 -Target 10 -Concurrency 2 -Seed 7
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress.ps1 -Target 3 -Concurrency 1 -Json
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress.ps1 -Target 1000 -Concurrency 1000 -Seed 7
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a stress-testing utility for local performance evaluation with configurable target concurrency, failure injection, and JSON output options.

* **Documentation**
  * Added comprehensive performance testing guide with instructions for running load tests, interpreting results, and analyzing key metrics.
  * Updated development guide with stress-testing commands and documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->