### PR TITLE
[codex] Add mock stress budget assertions

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -39,12 +39,30 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 
 JSON 汇总不要和 `--events jsonl` 混用。前者是最终报告，后者是事件流。
 
+## 预算断言
+
+脚本支持轻量预算断言，适合本地提交前或后续 CI 使用：
+
+```powershell
+.\scripts\mock-stress.ps1 -Target 1000 -Concurrency 1000 -MinThroughput 1000 -MaxGoroutines 1
+```
+
+可用预算包括：
+
+- `-MinThroughput`：要求 `throughput_per_second` 不低于指定值。
+- `-MaxHeapDelta`：要求 `heap_alloc_delta_bytes` 不高于指定值。
+- `-MaxGoroutines`：要求运行结束后的 goroutine 数不高于指定值。
+- `-ExpectFailureThreshold`：要求 `failure_threshold_reached` 等于指定布尔值。
+
+这些预算应先设得保守，主要用于抓明显退化。严苛性能门槛必须先在 CI 机器上积累基线。
+
 ## 失败注入
 
 可以用失败注入验证失败阈值和停止行为：
 
 ```powershell
 .\scripts\mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2
+.\scripts\mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2 -ExpectFailureThreshold true
 ```
 
 预期会在第二次 mock submission 失败后触发 `failure_threshold_reached: true`。这仍然是本地 mock，不访问网络。

--- a/scripts/mock-stress.ps1
+++ b/scripts/mock-stress.ps1
@@ -4,6 +4,11 @@ param(
     [int]$Concurrency = 1000,
     [int]$Seed = 7,
     [int]$FailEvery = 0,
+    [double]$MinThroughput = 0,
+    [UInt64]$MaxHeapDelta = 0,
+    [int]$MaxGoroutines = 0,
+    [ValidateSet("", "true", "false")]
+    [string]$ExpectFailureThreshold = "",
     [switch]$Json
 )
 
@@ -17,6 +22,16 @@ if ($Concurrency -le 0) {
 }
 if ($FailEvery -lt 0) {
     throw "FailEvery must not be negative."
+}
+if ($MinThroughput -lt 0) {
+    throw "MinThroughput must not be negative."
+}
+if ($MaxGoroutines -lt 0) {
+    throw "MaxGoroutines must not be negative."
+}
+$expectFailureThresholdValue = $null
+if ($ExpectFailureThreshold -ne "") {
+    $expectFailureThresholdValue = [bool]::Parse($ExpectFailureThreshold)
 }
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
@@ -37,12 +52,53 @@ try {
     if ($FailEvery -gt 0) {
         $surveyctlArgs += @("--mock-fail-every", $FailEvery)
     }
-    if ($Json) {
-        $surveyctlArgs += "--json"
+    $surveyctlArgs += "--json"
+
+    $raw = & go run ./cmd/surveyctl @surveyctlArgs
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
     }
 
-    & go run ./cmd/surveyctl @surveyctlArgs
-    exit $LASTEXITCODE
+    $summary = $raw | ConvertFrom-Json
+    $failures = @()
+
+    if ($MinThroughput -gt 0 -and [double]$summary.throughput_per_second -lt $MinThroughput) {
+        $failures += "throughput_per_second $($summary.throughput_per_second) is below $MinThroughput"
+    }
+    if ($MaxHeapDelta -gt 0 -and [UInt64]$summary.heap_alloc_delta_bytes -gt $MaxHeapDelta) {
+        $failures += "heap_alloc_delta_bytes $($summary.heap_alloc_delta_bytes) is above $MaxHeapDelta"
+    }
+    if ($MaxGoroutines -gt 0 -and [int]$summary.goroutines -gt $MaxGoroutines) {
+        $failures += "goroutines $($summary.goroutines) is above $MaxGoroutines"
+    }
+    if ($null -ne $expectFailureThresholdValue -and [bool]$summary.failure_threshold_reached -ne $expectFailureThresholdValue) {
+        $failures += "failure_threshold_reached $($summary.failure_threshold_reached) does not match $expectFailureThresholdValue"
+    }
+
+    if ($Json) {
+        $raw
+    }
+    else {
+        Write-Host "mock stress:"
+        Write-Host "  target: $($summary.target)"
+        Write-Host "  concurrency: $($summary.concurrency)"
+        Write-Host "  successes: $($summary.successes)"
+        Write-Host "  failures: $($summary.failures)"
+        Write-Host "  completed: $($summary.completed)"
+        Write-Host "  throughput_per_second: $($summary.throughput_per_second)"
+        Write-Host "  heap_alloc_delta_bytes: $($summary.heap_alloc_delta_bytes)"
+        Write-Host "  total_alloc_delta_bytes: $($summary.total_alloc_delta_bytes)"
+        Write-Host "  goroutines: $($summary.goroutines)"
+        Write-Host "  failure_threshold_reached: $($summary.failure_threshold_reached)"
+    }
+
+    if ($failures.Count -gt 0) {
+        foreach ($failure in $failures) {
+            Write-Error $failure
+        }
+        exit 1
+    }
+    exit 0
 }
 finally {
     Pop-Location


### PR DESCRIPTION
## Summary
- Add budget assertions to `scripts/mock-stress.ps1`.
- Support minimum throughput, maximum heap delta, maximum goroutines, and expected failure-threshold checks.
- Document budget usage in `docs/performance.md`.

Closes #101

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress.ps1 -Target 1000 -Concurrency 1000 -MinThroughput 1 -MaxGoroutines 1
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2 -ExpectFailureThreshold true
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress.ps1 -Target 3 -Concurrency 1 -Json
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added performance budget assertion checks documentation.

* **New Features**
  * Added performance budget validation with configurable thresholds for throughput, heap allocation, goroutine count, and failure state expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->