### PR TITLE
[codex] Add mock stress matrix script

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -29,6 +29,22 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 
 这些数字用于观察趋势，不作为跨机器绝对承诺。比较不同实现时，优先在同一机器、同一配置、同一 seed 下重复运行。
 
+## 压测矩阵
+
+如果希望一次验证成功路径、失败阈值和 1000 并发路径，可以运行：
+
+```powershell
+.\scripts\mock-stress-matrix.ps1
+```
+
+快速 smoke 可以跳过完整 1000 并发 profile：
+
+```powershell
+.\scripts\mock-stress-matrix.ps1 -SkipFull
+```
+
+矩阵脚本会输出每个 profile 的 target、concurrency、成功/失败数、吞吐、heap delta、goroutine 和失败阈值状态。它内部仍然只调用本地 mock run，不访问网络。
+
 ## JSON 汇总
 
 脚本可输出单个 JSON 汇总，方便后续 CI 或轻量 GUI 读取：

--- a/scripts/mock-stress-matrix.ps1
+++ b/scripts/mock-stress-matrix.ps1
@@ -1,0 +1,54 @@
+param(
+    [string]$Config = "examples/mock-run.yaml",
+    [switch]$SkipFull
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$stressScript = Join-Path $PSScriptRoot "mock-stress.ps1"
+
+$profiles = @(
+    @{
+        Name = "smoke"
+        Args = @("-Config", $Config, "-Target", "10", "-Concurrency", "2", "-MaxGoroutines", "1", "-Json")
+    },
+    @{
+        Name = "failure-threshold"
+        Args = @("-Config", $Config, "-Target", "5", "-Concurrency", "1", "-FailEvery", "2", "-ExpectFailureThreshold", "true", "-Json")
+    }
+)
+
+if (-not $SkipFull) {
+    $profiles += @{
+        Name = "1000x1000"
+        Args = @("-Config", $Config, "-Target", "1000", "-Concurrency", "1000", "-MinThroughput", "1", "-MaxGoroutines", "1", "-Json")
+    }
+}
+
+Push-Location $repoRoot
+try {
+    $rows = @()
+    foreach ($profile in $profiles) {
+        $output = & powershell -ExecutionPolicy Bypass -File $stressScript @($profile.Args)
+        if ($LASTEXITCODE -ne 0) {
+            throw "profile $($profile.Name) failed with exit code $LASTEXITCODE"
+        }
+        $summary = $output | ConvertFrom-Json
+        $rows += [pscustomobject]@{
+            profile = $profile.Name
+            target = $summary.target
+            concurrency = $summary.concurrency
+            successes = $summary.successes
+            failures = $summary.failures
+            throughput_per_second = $summary.throughput_per_second
+            heap_alloc_delta_bytes = $summary.heap_alloc_delta_bytes
+            goroutines = $summary.goroutines
+            failure_threshold_reached = $summary.failure_threshold_reached
+        }
+    }
+    $rows | Format-Table -AutoSize
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- Add `scripts/mock-stress-matrix.ps1` to run smoke, failure-threshold, and 1000x1000 mock stress profiles.
- Add a `-SkipFull` mode for quick local verification.
- Document the matrix workflow in `docs/performance.md`.

Closes #103

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress-matrix.ps1 -SkipFull
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress-matrix.ps1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check