### PR TITLE
[codex] Add local verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 .\scripts\mock-stress.ps1
 .\scripts\mock-stress.ps1 -Json
 .\scripts\mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2
+.\scripts\verify-local.ps1
 ```
 
 需要观察运行事件时可加：

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,24 @@ gofmt -w (git ls-files '*.go')
 
 在 Windows 上，`go test -race` 需要 CGO 和 `gcc` 之类的 C 编译器。如果本地竞态检查失败并提示 `C compiler "gcc" not found`，可以先运行普通测试，并依赖 Ubuntu CI 中的竞态检查，直到本地安装好 C 工具链。
 
+常用本地验证可以直接跑：
+
+```powershell
+.\scripts\verify-local.ps1
+```
+
+默认会执行 `go test ./...`、`go vet ./...`、`staticcheck` 和轻量 mock stress matrix。需要完整 1000 并发 profile 时：
+
+```powershell
+.\scripts\verify-local.ps1 -IncludeFullStress
+```
+
+如果只是快速检查 Go 代码、不跑压测：
+
+```powershell
+.\scripts\verify-local.ps1 -SkipStress
+```
+
 ## 运行预览
 
 `surveyctl run` 当前只开放不会访问网络的预览能力：

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -45,6 +45,20 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 
 矩阵脚本会输出每个 profile 的 target、concurrency、成功/失败数、吞吐、heap delta、goroutine 和失败阈值状态。它内部仍然只调用本地 mock run，不访问网络。
 
+## 本地验证入口
+
+提交 PR 前推荐跑：
+
+```powershell
+.\scripts\verify-local.ps1
+```
+
+默认会跑 Go 测试、`go vet`、`staticcheck` 和轻量 mock stress matrix。要包含完整 1000 并发 profile：
+
+```powershell
+.\scripts\verify-local.ps1 -IncludeFullStress
+```
+
 ## JSON 汇总
 
 脚本可输出单个 JSON 汇总，方便后续 CI 或轻量 GUI 读取：

--- a/scripts/verify-local.ps1
+++ b/scripts/verify-local.ps1
@@ -1,0 +1,48 @@
+param(
+    [switch]$IncludeFullStress,
+    [switch]$SkipStaticcheck,
+    [switch]$SkipStress
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $repoRoot
+try {
+    Write-Host "== go test ./... =="
+    & go test ./...
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    Write-Host "== go vet ./... =="
+    & go vet ./...
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (-not $SkipStaticcheck) {
+        Write-Host "== staticcheck ./... =="
+        & go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    }
+
+    if (-not $SkipStress) {
+        Write-Host "== mock stress matrix =="
+        $stressArgs = @()
+        if (-not $IncludeFullStress) {
+            $stressArgs += "-SkipFull"
+        }
+        & powershell -ExecutionPolicy Bypass -File scripts/mock-stress-matrix.ps1 @stressArgs
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    }
+
+    Write-Host "local verification passed"
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- Add `scripts/verify-local.ps1` as a one-command local validation entrypoint.
- Run go test, go vet, staticcheck, and the lightweight mock stress matrix by default.
- Document the verification entrypoint in README, development docs, and performance docs.

Closes #105

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/verify-local.ps1
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- git diff --check