### PR TITLE
[codex] Add run report budget validation

### DIFF
--- a/internal/runner/run_report_budget.go
+++ b/internal/runner/run_report_budget.go
@@ -1,0 +1,105 @@
+package runner
+
+import (
+	"fmt"
+	"strings"
+)
+
+type RunReportBudget struct {
+	MinThroughput          float64
+	MaxHeapAllocDelta      uint64
+	MaxGoroutines          int
+	ExpectFailureThreshold *bool
+}
+
+type RunReportBudgetViolation struct {
+	Field string
+	Got   string
+	Want  string
+}
+
+type RunReportBudgetError struct {
+	Violations []RunReportBudgetViolation
+}
+
+func (e RunReportBudgetError) Error() string {
+	if len(e.Violations) == 0 {
+		return "run report budget failed"
+	}
+	parts := make([]string, 0, len(e.Violations))
+	for _, violation := range e.Violations {
+		parts = append(parts, fmt.Sprintf("%s got %s, want %s", violation.Field, violation.Got, violation.Want))
+	}
+	return "run report budget failed: " + strings.Join(parts, "; ")
+}
+
+func (b RunReportBudget) Validate() error {
+	if b.MinThroughput < 0 {
+		return fmt.Errorf("minimum throughput must not be negative")
+	}
+	if b.MaxGoroutines < 0 {
+		return fmt.Errorf("maximum goroutines must not be negative")
+	}
+	return nil
+}
+
+func (b RunReportBudget) Check(report RunPlanReport) error {
+	if err := b.Validate(); err != nil {
+		return err
+	}
+
+	violations := make([]RunReportBudgetViolation, 0, 4)
+	if b.MinThroughput > 0 && report.ThroughputPerSec < b.MinThroughput {
+		violations = append(violations, budgetViolation(
+			"throughput_per_second",
+			formatFloat(report.ThroughputPerSec),
+			">= "+formatFloat(b.MinThroughput),
+		))
+	}
+	if b.MaxHeapAllocDelta > 0 {
+		if report.HeapAllocDelta < 0 {
+			violations = append(violations, budgetViolation(
+				"heap_alloc_delta_bytes",
+				fmt.Sprintf("%d", report.HeapAllocDelta),
+				">= 0",
+			))
+		} else if uint64(report.HeapAllocDelta) > b.MaxHeapAllocDelta {
+			violations = append(violations, budgetViolation(
+				"heap_alloc_delta_bytes",
+				fmt.Sprintf("%d", report.HeapAllocDelta),
+				"<= "+fmt.Sprintf("%d", b.MaxHeapAllocDelta),
+			))
+		}
+	}
+	if b.MaxGoroutines > 0 && report.Goroutines > b.MaxGoroutines {
+		violations = append(violations, budgetViolation(
+			"goroutines",
+			fmt.Sprintf("%d", report.Goroutines),
+			"<= "+fmt.Sprintf("%d", b.MaxGoroutines),
+		))
+	}
+	if b.ExpectFailureThreshold != nil && report.FailureThreshold != *b.ExpectFailureThreshold {
+		violations = append(violations, budgetViolation(
+			"failure_threshold_reached",
+			fmt.Sprintf("%t", report.FailureThreshold),
+			fmt.Sprintf("%t", *b.ExpectFailureThreshold),
+		))
+	}
+
+	if len(violations) > 0 {
+		return RunReportBudgetError{Violations: violations}
+	}
+	return nil
+}
+
+func budgetViolation(field string, got string, want string) RunReportBudgetViolation {
+	return RunReportBudgetViolation{Field: field, Got: got, Want: want}
+}
+
+func BoolBudget(value bool) *bool {
+	return &value
+}
+
+func formatFloat(value float64) string {
+	return fmt.Sprintf("%.4f", value)
+}

--- a/internal/runner/run_report_budget_test.go
+++ b/internal/runner/run_report_budget_test.go
@@ -1,0 +1,93 @@
+package runner
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRunReportBudgetCheckPasses(t *testing.T) {
+	budget := RunReportBudget{
+		MinThroughput:          100,
+		MaxHeapAllocDelta:      2048,
+		MaxGoroutines:          2,
+		ExpectFailureThreshold: BoolBudget(false),
+	}
+	report := RunPlanReport{
+		ThroughputPerSec: 150,
+		HeapAllocDelta:   1024,
+		Goroutines:       1,
+		FailureThreshold: false,
+	}
+
+	if err := budget.Check(report); err != nil {
+		t.Fatalf("Check() returned error: %v", err)
+	}
+}
+
+func TestRunReportBudgetCheckReportsViolations(t *testing.T) {
+	budget := RunReportBudget{
+		MinThroughput:          100,
+		MaxHeapAllocDelta:      500,
+		MaxGoroutines:          1,
+		ExpectFailureThreshold: BoolBudget(true),
+	}
+	report := RunPlanReport{
+		ThroughputPerSec: 25,
+		HeapAllocDelta:   700,
+		Goroutines:       3,
+		FailureThreshold: false,
+	}
+
+	err := budget.Check(report)
+	var budgetErr RunReportBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("Check() error = %T %[1]v, want RunReportBudgetError", err)
+	}
+	if len(budgetErr.Violations) != 4 {
+		t.Fatalf("violations = %+v, want 4 entries", budgetErr.Violations)
+	}
+	for _, want := range []string{"throughput_per_second", "heap_alloc_delta_bytes", "goroutines", "failure_threshold_reached"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want %q", err.Error(), want)
+		}
+	}
+}
+
+func TestRunReportBudgetRejectsInvalidBudget(t *testing.T) {
+	tests := []struct {
+		name   string
+		budget RunReportBudget
+		want   string
+	}{
+		{name: "throughput", budget: RunReportBudget{MinThroughput: -1}, want: "throughput"},
+		{name: "goroutines", budget: RunReportBudget{MaxGoroutines: -1}, want: "goroutines"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.budget.Check(RunPlanReport{})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Check() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunReportBudgetTreatsNegativeHeapDeltaAsViolation(t *testing.T) {
+	err := RunReportBudget{MaxHeapAllocDelta: 1}.Check(RunPlanReport{HeapAllocDelta: -1})
+	var budgetErr RunReportBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("Check() error = %T %[1]v, want RunReportBudgetError", err)
+	}
+	if budgetErr.Violations[0].Field != "heap_alloc_delta_bytes" {
+		t.Fatalf("violations = %+v, want heap delta", budgetErr.Violations)
+	}
+}
+
+func TestBoolBudget(t *testing.T) {
+	value := BoolBudget(true)
+	if value == nil || !*value {
+		t.Fatalf("BoolBudget(true) = %v, want pointer to true", value)
+	}
+}


### PR DESCRIPTION
## Summary
- add runner-level RunReportBudget checks for throughput, heap allocation delta, goroutine count, and expected failure-threshold state
- return structured budget violations so CLI and scripts can surface actionable failures
- cover pass, multi-violation, invalid-budget, and negative heap-delta cases

## Validation
- go test ./internal/runner -run "TestRunReportBudget|TestBoolBudget" -count=1
- git diff --check

Closes #107