### PR TITLE
[codex] Expose mock run budget flags

### DIFF
--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -33,7 +33,7 @@ Usage:
   surveyctl config validate [path]
   surveyctl config generate --provider <id> --fixture <path> --url <url>
   surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
-  surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>]
+  surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>] [--min-throughput <n>] [--max-heap-delta <bytes>] [--max-goroutines <n>] [--expect-failure-threshold <true|false>]
   surveyctl doctor [browser]
   surveyctl help
 
@@ -57,7 +57,7 @@ const doctorUsage = `Usage:
 
 const runUsage = `Usage:
   surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
-  surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>]
+  surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>] [--min-throughput <n>] [--max-heap-delta <bytes>] [--max-goroutines <n>] [--expect-failure-threshold <true|false>]
 `
 
 const (
@@ -254,6 +254,8 @@ func runRun(args []string, stdout io.Writer) error {
 	jsonOutput := false
 	eventFormat := logging.Format("")
 	overrides := runPlanOverrides{}
+	budget := runner.RunReportBudget{}
+	budgetSet := false
 	mockFailEvery := 0
 	seed := int64(1)
 	path := "survey.yaml"
@@ -328,6 +330,54 @@ func runRun(args []string, stdout io.Writer) error {
 			}
 			mockFailEvery = failEvery
 			i = next
+		case "--min-throughput":
+			value, next, err := readRunFlagValue(args, i, "--min-throughput")
+			if err != nil {
+				return err
+			}
+			minThroughput, err := parseNonNegativeRunFloat(value, "--min-throughput")
+			if err != nil {
+				return err
+			}
+			budget.MinThroughput = minThroughput
+			budgetSet = true
+			i = next
+		case "--max-heap-delta":
+			value, next, err := readRunFlagValue(args, i, "--max-heap-delta")
+			if err != nil {
+				return err
+			}
+			maxHeapDelta, err := parsePositiveRunUint64(value, "--max-heap-delta")
+			if err != nil {
+				return err
+			}
+			budget.MaxHeapAllocDelta = maxHeapDelta
+			budgetSet = true
+			i = next
+		case "--max-goroutines":
+			value, next, err := readRunFlagValue(args, i, "--max-goroutines")
+			if err != nil {
+				return err
+			}
+			maxGoroutines, err := parsePositiveRunInt(value, "--max-goroutines")
+			if err != nil {
+				return err
+			}
+			budget.MaxGoroutines = maxGoroutines
+			budgetSet = true
+			i = next
+		case "--expect-failure-threshold":
+			value, next, err := readRunFlagValue(args, i, "--expect-failure-threshold")
+			if err != nil {
+				return err
+			}
+			expectFailureThreshold, err := parseRunBool(value, "--expect-failure-threshold")
+			if err != nil {
+				return err
+			}
+			budget.ExpectFailureThreshold = runner.BoolBudget(expectFailureThreshold)
+			budgetSet = true
+			i = next
 		default:
 			if pathSet {
 				return usageError("run accepts at most one path", runUsage)
@@ -350,6 +400,9 @@ func runRun(args []string, stdout io.Writer) error {
 	}
 	if dryRun && mockFailEvery > 0 {
 		return usageError("run --mock-fail-every requires --mock", runUsage)
+	}
+	if dryRun && budgetSet {
+		return usageError("run budget flags require --mock", runUsage)
 	}
 
 	plan, err := compileRunPlanFromFile(path, overrides)
@@ -392,7 +445,16 @@ func runRun(args []string, stdout io.Writer) error {
 	if err != nil {
 		return commandError(exitFailure, fmt.Sprintf("run mock failed: %v", err), "")
 	}
-	return printMockRunSummary(stdout, path, plan, snapshot, seed, elapsed, runtimeMetrics(beforeRuntime, afterRuntime), jsonOutput)
+	report := runner.NewTimedRunPlanReport(plan, snapshot, elapsed).WithResourceMetrics(runtimeMetrics(beforeRuntime, afterRuntime))
+	if err := printMockRunSummary(stdout, path, report, seed, jsonOutput); err != nil {
+		return err
+	}
+	if budgetSet {
+		if err := budget.Check(report); err != nil {
+			return commandError(exitFailure, fmt.Sprintf("run mock budget failed: %v", err), "")
+		}
+	}
+	return nil
 }
 
 func mockSubmitter(failEvery int) runner.AnswerPlanSubmitter {
@@ -453,6 +515,33 @@ func parsePositiveRunInt(value string, flag string) (int, error) {
 		return 0, usageError(fmt.Sprintf("%s requires a positive integer", flag), runUsage)
 	}
 	return parsed, nil
+}
+
+func parsePositiveRunUint64(value string, flag string) (uint64, error) {
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil || parsed == 0 {
+		return 0, usageError(fmt.Sprintf("%s requires a positive integer", flag), runUsage)
+	}
+	return parsed, nil
+}
+
+func parseNonNegativeRunFloat(value string, flag string) (float64, error) {
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil || parsed < 0 {
+		return 0, usageError(fmt.Sprintf("%s requires a non-negative number", flag), runUsage)
+	}
+	return parsed, nil
+}
+
+func parseRunBool(value string, flag string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, usageError(fmt.Sprintf("%s requires true or false", flag), runUsage)
+	}
 }
 
 func parseRunEventFormat(value string) (logging.Format, error) {
@@ -643,8 +732,7 @@ func printDryRunPlan(stdout io.Writer, path string, plan runner.Plan, jsonOutput
 	return nil
 }
 
-func printMockRunSummary(stdout io.Writer, path string, plan runner.Plan, snapshot runner.StateSnapshot, seed int64, elapsed time.Duration, metrics runner.RunResourceMetrics, jsonOutput bool) error {
-	report := runner.NewTimedRunPlanReport(plan, snapshot, elapsed).WithResourceMetrics(metrics)
+func printMockRunSummary(stdout io.Writer, path string, report runner.RunPlanReport, seed int64, jsonOutput bool) error {
 	summary := mockRunSummary{
 		Path:              path,
 		Provider:          report.Provider,

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -283,7 +283,13 @@ run:
   target: 1
   concurrency: 1
   mode: http
-questions: []
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
 `)
 
 	code := run([]string{"run", "--dry-run", "--target", "7", "--concurrency", "3", path}, &stdout, &stderr)
@@ -419,6 +425,137 @@ questions:
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunMockRunBudgetPasses(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 2
+  concurrency: 1
+  mode: http
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+`)
+
+	code := run([]string{"run", "--mock", "--min-throughput", "0", "--max-heap-delta", "999999999", "--max-goroutines", "1000", "--expect-failure-threshold", "false", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(mock budget pass) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "mock run:") {
+		t.Fatalf("stdout = %q, want mock summary", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunMockRunBudgetFailureStillPrintsSummary(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 1
+  concurrency: 1
+  mode: http
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+`)
+
+	code := run([]string{"run", "--mock", "--min-throughput", "999999999", path}, &stdout, &stderr)
+	if code != exitFailure {
+		t.Fatalf("run(mock budget failure) exit code = %d, want %d", code, exitFailure)
+	}
+	if !strings.Contains(stdout.String(), "mock run:") {
+		t.Fatalf("stdout = %q, want diagnostic summary", stdout.String())
+	}
+	for _, want := range []string{"run mock budget failed", "throughput_per_second"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestRunMockRunBudgetChecksFailureThreshold(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, `schema_version: 1
+survey:
+  url: "https://example.com/survey"
+  provider: "mock"
+run:
+  target: 5
+  concurrency: 1
+  mode: http
+  failure_threshold: 1
+  fail_stop_enabled: true
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+`)
+
+	code := run([]string{"run", "--mock", "--mock-fail-every", "2", "--expect-failure-threshold", "true", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(mock failure threshold budget) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "failure_threshold_reached: true") {
+		t.Fatalf("stdout = %q, want threshold reached", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunRejectsInvalidBudgetFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "throughput", args: []string{"run", "--mock", "--min-throughput", "-1"}, want: "--min-throughput requires a non-negative number"},
+		{name: "heap", args: []string{"run", "--mock", "--max-heap-delta", "0"}, want: "--max-heap-delta requires a positive integer"},
+		{name: "bool", args: []string{"run", "--mock", "--expect-failure-threshold", "yes"}, want: "--expect-failure-threshold requires true or false"},
+		{name: "dry-run", args: []string{"run", "--dry-run", "--min-throughput", "1"}, want: "budget flags require --mock"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := run(tt.args, &stdout, &stderr)
+			if code != exitUsage {
+				t.Fatalf("run(invalid budget) exit code = %d, want %d", code, exitUsage)
+			}
+			if !strings.Contains(stderr.String(), tt.want) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), tt.want)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- expose runner report budgets through `surveyctl run --mock`
- keep budget flags mock-only and validate numeric/bool inputs at the CLI boundary
- print the mock summary before returning a budget failure so diagnostics stay available to users and scripts

## Validation
- go test ./cmd/surveyctl -run "TestRunMockRunBudget|TestRunRejectsInvalidBudget" -count=1
- go test ./...
- git diff --check
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #109