### PR TITLE
[codex] Reuse CLI budgets in mock stress scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,15 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 ```powershell
 .\scripts\mock-stress.ps1
 .\scripts\mock-stress.ps1 -Json
+.\scripts\mock-stress.ps1 -MinThroughput 1 -MaxGoroutines 1
 .\scripts\mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2
 .\scripts\verify-local.ps1
+```
+
+mock 压测预算也可以直接走 CLI，例如：
+
+```powershell
+go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --min-throughput 1 --max-goroutines 1
 ```
 
 需要观察运行事件时可加：

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -71,7 +71,7 @@ JSON 汇总不要和 `--events jsonl` 混用。前者是最终报告，后者是
 
 ## 预算断言
 
-脚本支持轻量预算断言，适合本地提交前或后续 CI 使用：
+脚本支持轻量预算断言，适合本地提交前或后续 CI 使用。预算参数会透传给 `surveyctl run --mock`，由 CLI 基于同一份 `RunPlanReport` 统一判定；脚本只负责输出 JSON 或人类可读摘要：
 
 ```powershell
 .\scripts\mock-stress.ps1 -Target 1000 -Concurrency 1000 -MinThroughput 1000 -MaxGoroutines 1
@@ -84,7 +84,7 @@ JSON 汇总不要和 `--events jsonl` 混用。前者是最终报告，后者是
 - `-MaxGoroutines`：要求运行结束后的 goroutine 数不高于指定值。
 - `-ExpectFailureThreshold`：要求 `failure_threshold_reached` 等于指定布尔值。
 
-这些预算应先设得保守，主要用于抓明显退化。严苛性能门槛必须先在 CI 机器上积累基线。
+预算失败时 CLI 会先输出 mock run 报告，再以非零退出码返回失败原因。这样本地脚本、矩阵脚本和后续 CI 可以共享同一套判定语义。预算应先设得保守，主要用于抓明显退化；严苛性能门槛必须先在 CI 机器上积累基线。
 
 ## 失败注入
 

--- a/scripts/mock-stress.ps1
+++ b/scripts/mock-stress.ps1
@@ -29,12 +29,9 @@ if ($MinThroughput -lt 0) {
 if ($MaxGoroutines -lt 0) {
     throw "MaxGoroutines must not be negative."
 }
-$expectFailureThresholdValue = $null
-if ($ExpectFailureThreshold -ne "") {
-    $expectFailureThresholdValue = [bool]::Parse($ExpectFailureThreshold)
-}
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
+$invariantCulture = [System.Globalization.CultureInfo]::InvariantCulture
 Push-Location $repoRoot
 try {
     $surveyctlArgs = @(
@@ -52,33 +49,39 @@ try {
     if ($FailEvery -gt 0) {
         $surveyctlArgs += @("--mock-fail-every", $FailEvery)
     }
+    if ($MinThroughput -gt 0) {
+        $surveyctlArgs += @("--min-throughput", $MinThroughput.ToString($invariantCulture))
+    }
+    if ($MaxHeapDelta -gt 0) {
+        $surveyctlArgs += @("--max-heap-delta", $MaxHeapDelta.ToString($invariantCulture))
+    }
+    if ($MaxGoroutines -gt 0) {
+        $surveyctlArgs += @("--max-goroutines", $MaxGoroutines)
+    }
+    if ($ExpectFailureThreshold -ne "") {
+        $surveyctlArgs += @("--expect-failure-threshold", $ExpectFailureThreshold)
+    }
     $surveyctlArgs += "--json"
 
     $raw = & go run ./cmd/surveyctl @surveyctlArgs
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
-    }
-
-    $summary = $raw | ConvertFrom-Json
-    $failures = @()
-
-    if ($MinThroughput -gt 0 -and [double]$summary.throughput_per_second -lt $MinThroughput) {
-        $failures += "throughput_per_second $($summary.throughput_per_second) is below $MinThroughput"
-    }
-    if ($MaxHeapDelta -gt 0 -and [UInt64]$summary.heap_alloc_delta_bytes -gt $MaxHeapDelta) {
-        $failures += "heap_alloc_delta_bytes $($summary.heap_alloc_delta_bytes) is above $MaxHeapDelta"
-    }
-    if ($MaxGoroutines -gt 0 -and [int]$summary.goroutines -gt $MaxGoroutines) {
-        $failures += "goroutines $($summary.goroutines) is above $MaxGoroutines"
-    }
-    if ($null -ne $expectFailureThresholdValue -and [bool]$summary.failure_threshold_reached -ne $expectFailureThresholdValue) {
-        $failures += "failure_threshold_reached $($summary.failure_threshold_reached) does not match $expectFailureThresholdValue"
+    $exitCode = $LASTEXITCODE
+    $summary = $null
+    if ($raw) {
+        try {
+            $summary = $raw | ConvertFrom-Json
+        }
+        catch {
+            $raw
+            exit $exitCode
+        }
     }
 
     if ($Json) {
-        $raw
+        if ($raw) {
+            $raw
+        }
     }
-    else {
+    elseif ($null -ne $summary) {
         Write-Host "mock stress:"
         Write-Host "  target: $($summary.target)"
         Write-Host "  concurrency: $($summary.concurrency)"
@@ -91,12 +94,12 @@ try {
         Write-Host "  goroutines: $($summary.goroutines)"
         Write-Host "  failure_threshold_reached: $($summary.failure_threshold_reached)"
     }
+    elseif ($raw) {
+        $raw
+    }
 
-    if ($failures.Count -gt 0) {
-        foreach ($failure in $failures) {
-            Write-Error $failure
-        }
-        exit 1
+    if ($exitCode -ne 0) {
+        exit $exitCode
     }
     exit 0
 }


### PR DESCRIPTION
## Summary
- pass mock stress budget options through to `surveyctl run --mock`
- remove duplicate PowerShell budget assertions while preserving JSON and human summaries
- document the shared CLI budget path in README and performance docs

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress.ps1 -Target 3 -Concurrency 1 -Json
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2 -ExpectFailureThreshold true -Json
- powershell -ExecutionPolicy Bypass -File scripts/mock-stress-matrix.ps1 -SkipFull
- powershell -ExecutionPolicy Bypass -Command '& .\scripts\mock-stress.ps1 -Target 3 -Concurrency 1 -MinThroughput 999999999 -Json; if ($LASTEXITCODE -eq 0) { throw "expected budget failure" } else { Write-Output "budget_failed_exit=$LASTEXITCODE"; exit 0 }'
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #111