### PR TITLE
[codex] Move answer-plan submission contract to engine

### DIFF
--- a/internal/engine/submission_pipeline.go
+++ b/internal/engine/submission_pipeline.go
@@ -1,0 +1,25 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
+)
+
+type AnswerPlanSubmitter interface {
+	Submit(ctx context.Context, plan answerplan.Plan) (SubmissionResult, error)
+}
+
+func SubmitAnswerPlan(ctx context.Context, submitter AnswerPlanSubmitter, plan answerplan.Plan) (SubmissionResult, error) {
+	if ctx == nil {
+		return SubmissionResult{}, fmt.Errorf("context is required")
+	}
+	if submitter == nil {
+		return SubmissionResult{}, fmt.Errorf("answer plan submitter is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return SubmissionResult{}, err
+	}
+	return submitter.Submit(ctx, plan)
+}

--- a/internal/engine/submission_pipeline_test.go
+++ b/internal/engine/submission_pipeline_test.go
@@ -1,0 +1,80 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/answerplan"
+	"github.com/LING71671/SurveyController-go/internal/provider"
+)
+
+func TestSubmitAnswerPlanCallsSubmitter(t *testing.T) {
+	submitter := &recordingAnswerPlanSubmitter{
+		result: SubmissionResult{
+			State:   provider.SubmissionStateSuccess,
+			Message: "ok",
+			Success: true,
+		},
+	}
+	plan := answerplan.Plan{Answers: []answerplan.QuestionAnswer{{QuestionID: "q1", OptionIDs: []string{"a"}}}}
+
+	result, err := SubmitAnswerPlan(context.Background(), submitter, plan)
+	if err != nil {
+		t.Fatalf("SubmitAnswerPlan() error = %v", err)
+	}
+	if !result.Success || result.Message != "ok" {
+		t.Fatalf("result = %+v, want success ok", result)
+	}
+	if submitter.calls != 1 || submitter.lastPlan.Answers[0].QuestionID != "q1" {
+		t.Fatalf("submitter = %+v, want one call with q1", submitter)
+	}
+}
+
+func TestSubmitAnswerPlanRejectsInvalidInputs(t *testing.T) {
+	tests := []struct {
+		name      string
+		ctx       context.Context
+		submitter AnswerPlanSubmitter
+		want      string
+	}{
+		{name: "context", submitter: &recordingAnswerPlanSubmitter{}, want: "context"},
+		{name: "submitter", ctx: context.Background(), want: "submitter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := SubmitAnswerPlan(tt.ctx, tt.submitter, answerplan.Plan{})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("SubmitAnswerPlan() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubmitAnswerPlanHonorsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := SubmitAnswerPlan(ctx, &recordingAnswerPlanSubmitter{}, answerplan.Plan{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("SubmitAnswerPlan() error = %v, want context.Canceled", err)
+	}
+}
+
+type recordingAnswerPlanSubmitter struct {
+	result   SubmissionResult
+	err      error
+	calls    int
+	lastPlan answerplan.Plan
+}
+
+func (s *recordingAnswerPlanSubmitter) Submit(ctx context.Context, plan answerplan.Plan) (SubmissionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return SubmissionResult{}, err
+	}
+	s.calls++
+	s.lastPlan = answerplan.Clone(plan)
+	return s.result, s.err
+}

--- a/internal/runner/run_plan.go
+++ b/internal/runner/run_plan.go
@@ -52,7 +52,7 @@ func RunPlanSubmissions(ctx context.Context, plan Plan, options RunPlanOptions) 
 		taskPlan := answerPlan
 		return func(ctx context.Context, workerID int) (engine.SubmissionResult, error) {
 			_ = workerID
-			return options.Submitter.Submit(ctx, taskPlan)
+			return engine.SubmitAnswerPlan(ctx, options.Submitter, taskPlan)
 		}, nil
 	})
 }

--- a/internal/runner/submission_tasks.go
+++ b/internal/runner/submission_tasks.go
@@ -9,9 +9,7 @@ import (
 	"github.com/LING71671/SurveyController-go/internal/engine"
 )
 
-type AnswerPlanSubmitter interface {
-	Submit(ctx context.Context, plan answerplan.Plan) (engine.SubmissionResult, error)
-}
+type AnswerPlanSubmitter = engine.AnswerPlanSubmitter
 
 func SubmissionTasksFromAnswerPlans(submitter AnswerPlanSubmitter, plans []answerplan.Plan) ([]SubmissionTask, error) {
 	if submitter == nil {
@@ -26,7 +24,7 @@ func SubmissionTasksFromAnswerPlans(submitter AnswerPlanSubmitter, plans []answe
 		taskPlan := answerplan.Clone(plan)
 		tasks = append(tasks, func(ctx context.Context, workerID int) (engine.SubmissionResult, error) {
 			_ = workerID
-			return submitter.Submit(ctx, taskPlan)
+			return engine.SubmitAnswerPlan(ctx, submitter, taskPlan)
 		})
 	}
 	return tasks, nil
@@ -53,7 +51,7 @@ func SubmissionTasksFromPlan(rng *rand.Rand, plan Plan, submitter AnswerPlanSubm
 		taskPlan := answerPlan
 		tasks = append(tasks, func(ctx context.Context, workerID int) (engine.SubmissionResult, error) {
 			_ = workerID
-			return submitter.Submit(ctx, taskPlan)
+			return engine.SubmitAnswerPlan(ctx, submitter, taskPlan)
 		})
 	}
 	return tasks, nil


### PR DESCRIPTION
## Summary
- add the answer-plan submitter contract to `internal/engine`
- keep runner compatibility through a type alias
- route runner-generated submissions through `engine.SubmitAnswerPlan`

## Validation
- go test ./internal/engine ./internal/runner -count=1
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #113