### PR TITLE
[codex] Connect WJX HTTP pipeline to app run entrypoint

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -58,26 +58,7 @@ func ApplyRunPlanOverrides(plan runner.Plan, overrides RunPlanOverrides) (runner
 }
 
 func RunMockPlan(ctx context.Context, plan runner.Plan, options MockRunOptions) (runner.RunPlanReport, error) {
-	if ctx == nil {
-		return runner.RunPlanReport{}, fmt.Errorf("context is required")
-	}
-	if options.Seed == 0 {
-		options.Seed = 1
-	}
-
-	beforeRuntime := sampleRuntime()
-	startedAt := time.Now()
-	snapshot, err := runner.RunPlanSubmissions(ctx, plan, runner.RunPlanOptions{
-		RNG:       rand.New(rand.NewSource(options.Seed)),
-		Submitter: mockSubmitter(options.FailEvery),
-		Events:    options.Events,
-	})
-	elapsed := time.Since(startedAt)
-	afterRuntime := sampleRuntime()
-	if err != nil {
-		return runner.RunPlanReport{}, err
-	}
-	return runner.NewTimedRunPlanReport(plan, snapshot, elapsed).WithResourceMetrics(runtimeMetrics(beforeRuntime, afterRuntime)), nil
+	return runPlanWithSubmitter(ctx, plan, options.Seed, mockSubmitter(options.FailEvery), options.Events)
 }
 
 func mockSubmitter(failEvery int) runner.AnswerPlanSubmitter {
@@ -85,6 +66,32 @@ func mockSubmitter(failEvery int) runner.AnswerPlanSubmitter {
 		return &runner.FailureInjectingMockSubmitter{FailEvery: failEvery}
 	}
 	return runner.MockAnswerPlanSubmitter{}
+}
+
+func runPlanWithSubmitter(ctx context.Context, plan runner.Plan, seed int64, submitter runner.AnswerPlanSubmitter, events chan<- logging.RunEvent) (runner.RunPlanReport, error) {
+	if ctx == nil {
+		return runner.RunPlanReport{}, fmt.Errorf("context is required")
+	}
+	if submitter == nil {
+		return runner.RunPlanReport{}, fmt.Errorf("answer plan submitter is required")
+	}
+	if seed == 0 {
+		seed = 1
+	}
+
+	beforeRuntime := sampleRuntime()
+	startedAt := time.Now()
+	snapshot, err := runner.RunPlanSubmissions(ctx, plan, runner.RunPlanOptions{
+		RNG:       rand.New(rand.NewSource(seed)),
+		Submitter: submitter,
+		Events:    events,
+	})
+	elapsed := time.Since(startedAt)
+	afterRuntime := sampleRuntime()
+	if err != nil {
+		return runner.RunPlanReport{}, err
+	}
+	return runner.NewTimedRunPlanReport(plan, snapshot, elapsed).WithResourceMetrics(runtimeMetrics(beforeRuntime, afterRuntime)), nil
 }
 
 type runtimeSample struct {

--- a/internal/app/wjx_http.go
+++ b/internal/app/wjx_http.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/LING71671/SurveyController-go/internal/domain"
+	"github.com/LING71671/SurveyController-go/internal/logging"
+	"github.com/LING71671/SurveyController-go/internal/provider/wjx"
+	"github.com/LING71671/SurveyController-go/internal/runner"
+)
+
+type WJXHTTPRunOptions struct {
+	Seed     int64
+	Events   chan<- logging.RunEvent
+	Executor wjx.HTTPSubmissionExecutor
+	Survey   domain.SurveyDefinition
+}
+
+func RunWJXHTTPPlan(ctx context.Context, plan runner.Plan, options WJXHTTPRunOptions) (runner.RunPlanReport, error) {
+	if strings.TrimSpace(plan.Provider) != domain.ProviderWJX.String() {
+		return runner.RunPlanReport{}, fmt.Errorf("wjx http run requires wjx provider")
+	}
+	if options.Executor == nil {
+		return runner.RunPlanReport{}, fmt.Errorf("wjx http submission executor is required")
+	}
+	if err := options.Survey.Validate(); err != nil {
+		return runner.RunPlanReport{}, fmt.Errorf("wjx survey: %w", err)
+	}
+
+	pipeline, err := wjx.NewHTTPSubmissionPipeline(wjx.Provider{}, plan.Mode, options.Survey, options.Executor)
+	if err != nil {
+		return runner.RunPlanReport{}, err
+	}
+	return runPlanWithSubmitter(ctx, plan, options.Seed, pipeline, options.Events)
+}

--- a/internal/app/wjx_http_test.go
+++ b/internal/app/wjx_http_test.go
@@ -1,0 +1,159 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/LING71671/SurveyController-go/internal/domain"
+	"github.com/LING71671/SurveyController-go/internal/provider/wjx"
+	"github.com/LING71671/SurveyController-go/internal/runner"
+)
+
+func TestRunWJXHTTPPlanSubmitsThroughPipeline(t *testing.T) {
+	plan, err := CompileRunPlanFromFile(writeRunConfig(t, validWJXRunConfig()), RunPlanOverrides{Target: 2, Concurrency: 1})
+	if err != nil {
+		t.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+	executor := &recordingWJXHTTPExecutor{
+		response: wjx.HTTPSubmissionResponse{StatusCode: http.StatusOK, Body: "提交成功"},
+	}
+
+	report, err := RunWJXHTTPPlan(context.Background(), plan, WJXHTTPRunOptions{
+		Seed:     7,
+		Executor: executor,
+		Survey:   testWJXSurvey(),
+	})
+	if err != nil {
+		t.Fatalf("RunWJXHTTPPlan() error = %v", err)
+	}
+	if report.Successes != 2 || report.Failures != 0 || report.Completed != 2 {
+		t.Fatalf("report = %+v, want two successful submissions", report)
+	}
+	if len(executor.calls) != 2 {
+		t.Fatalf("executor calls = %d, want 2", len(executor.calls))
+	}
+	if got := executor.calls[0].Form.Get("q1"); got != "1" {
+		t.Fatalf("first form q1 = %q, want mapped option value", got)
+	}
+}
+
+func TestRunWJXHTTPPlanStopsOnVerification(t *testing.T) {
+	plan, err := CompileRunPlanFromFile(writeRunConfig(t, validWJXRunConfig()), RunPlanOverrides{Target: 5, Concurrency: 1})
+	if err != nil {
+		t.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+	plan.FailureThreshold = 1
+	plan.FailStopEnabled = true
+	executor := &recordingWJXHTTPExecutor{
+		response: wjx.HTTPSubmissionResponse{StatusCode: http.StatusOK, Body: "请完成验证码"},
+	}
+
+	report, err := RunWJXHTTPPlan(context.Background(), plan, WJXHTTPRunOptions{
+		Seed:     7,
+		Executor: executor,
+		Survey:   testWJXSurvey(),
+	})
+	if err != nil {
+		t.Fatalf("RunWJXHTTPPlan() error = %v", err)
+	}
+	if !report.StopRequested || !report.FailureThreshold || report.Failures != 1 {
+		t.Fatalf("report = %+v, want verification stop", report)
+	}
+}
+
+func TestRunWJXHTTPPlanRejectsInvalidInputs(t *testing.T) {
+	plan, err := CompileRunPlanFromFile(writeRunConfig(t, validWJXRunConfig()), RunPlanOverrides{})
+	if err != nil {
+		t.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		plan    func() runner.Plan
+		options WJXHTTPRunOptions
+		want    string
+	}{
+		{
+			name:    "executor",
+			options: WJXHTTPRunOptions{Survey: testWJXSurvey()},
+			want:    "executor",
+		},
+		{
+			name: "provider",
+			plan: func() runner.Plan {
+				other := plan
+				other.Provider = "mock"
+				return other
+			},
+			options: WJXHTTPRunOptions{Survey: testWJXSurvey(), Executor: &recordingWJXHTTPExecutor{}},
+			want:    "wjx provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testPlan := plan
+			if tt.plan != nil {
+				testPlan = tt.plan()
+			}
+			_, err := RunWJXHTTPPlan(context.Background(), testPlan, tt.options)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("RunWJXHTTPPlan() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+type recordingWJXHTTPExecutor struct {
+	response wjx.HTTPSubmissionResponse
+	calls    []wjx.HTTPSubmissionDraft
+}
+
+func (e *recordingWJXHTTPExecutor) ExecuteHTTPSubmission(ctx context.Context, draft wjx.HTTPSubmissionDraft) (wjx.HTTPSubmissionResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return wjx.HTTPSubmissionResponse{}, err
+	}
+	e.calls = append(e.calls, draft)
+	return e.response, nil
+}
+
+func validWJXRunConfig() string {
+	return `schema_version: 1
+survey:
+  url: "https://www.wjx.cn/vm/example.aspx"
+  provider: "wjx"
+run:
+  target: 1
+  concurrency: 1
+  mode: http
+  failure_threshold: 1
+  fail_stop_enabled: true
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+`
+}
+
+func testWJXSurvey() domain.SurveyDefinition {
+	return domain.SurveyDefinition{
+		Provider: domain.ProviderWJX,
+		Title:    "WJX HTTP",
+		URL:      "https://www.wjx.cn/vm/example.aspx",
+		Questions: []domain.QuestionDefinition{
+			{
+				ID:    "q1",
+				Title: "Single",
+				Kind:  domain.QuestionKindSingle,
+				Options: []domain.OptionDefinition{
+					{ID: "a", Label: "A", Value: "1"},
+				},
+			},
+		},
+	}
+}

--- a/internal/provider/wjx/parser.go
+++ b/internal/provider/wjx/parser.go
@@ -25,8 +25,10 @@ func (Provider) MatchURL(rawURL string) bool {
 
 func (Provider) Capabilities() provider.Capabilities {
 	return provider.Capabilities{
-		ParseHTTP:    true,
-		ParseBrowser: true,
+		ParseHTTP:      true,
+		ParseBrowser:   true,
+		SubmitHTTP:     true,
+		SupportsHybrid: true,
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an app-level WJX HTTP run entrypoint backed by the existing WJX HTTP submission pipeline
- reuse the shared runner/report path for provider-backed HTTP submissions
- declare WJX HTTP submit capability for the pipeline gate
- verify success and verification-stop behavior through an injected fake executor

## Validation
- go test ./internal/app ./internal/provider/wjx -count=1
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP-based WJX submission plan execution with configurable seed values and event monitoring capabilities
  * WJX provider now supports hybrid mode operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->