### PR TITLE
[codex] Add WJX HTTP submission preview

### DIFF
--- a/internal/app/wjx_preview.go
+++ b/internal/app/wjx_preview.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/LING71671/SurveyController-Go/internal/domain"
+	"github.com/LING71671/SurveyController-Go/internal/provider/wjx"
+	"github.com/LING71671/SurveyController-Go/internal/runner"
+)
+
+type WJXHTTPPreviewOptions struct {
+	Seed   int64
+	Survey domain.SurveyDefinition
+}
+
+type WJXHTTPSubmissionPreview struct {
+	Provider    string              `json:"provider"`
+	Mode        string              `json:"mode"`
+	Method      string              `json:"method"`
+	Endpoint    string              `json:"endpoint"`
+	SurveyID    string              `json:"survey_id"`
+	Header      map[string][]string `json:"header"`
+	Form        map[string][]string `json:"form"`
+	AnswerCount int                 `json:"answer_count"`
+}
+
+func PreviewWJXHTTPSubmission(plan runner.Plan, options WJXHTTPPreviewOptions) (WJXHTTPSubmissionPreview, error) {
+	if strings.TrimSpace(plan.Provider) != domain.ProviderWJX.String() {
+		return WJXHTTPSubmissionPreview{}, fmt.Errorf("wjx http preview requires wjx provider")
+	}
+	if err := options.Survey.Validate(); err != nil {
+		return WJXHTTPSubmissionPreview{}, fmt.Errorf("wjx survey: %w", err)
+	}
+	seed := options.Seed
+	if seed == 0 {
+		seed = 1
+	}
+
+	answerPlan, err := runner.BuildAnswerPlan(rand.New(rand.NewSource(seed)), plan.Questions)
+	if err != nil {
+		return WJXHTTPSubmissionPreview{}, err
+	}
+	draft, err := wjx.BuildHTTPSubmissionDraftFromAnswerPlan(options.Survey, answerPlan)
+	if err != nil {
+		return WJXHTTPSubmissionPreview{}, err
+	}
+	return previewFromWJXHTTPDraft(plan, draft, len(answerPlan.Answers)), nil
+}
+
+func previewFromWJXHTTPDraft(plan runner.Plan, draft wjx.HTTPSubmissionDraft, answerCount int) WJXHTTPSubmissionPreview {
+	return WJXHTTPSubmissionPreview{
+		Provider:    strings.TrimSpace(plan.Provider),
+		Mode:        plan.Mode.String(),
+		Method:      draft.Method,
+		Endpoint:    draft.Endpoint,
+		SurveyID:    draft.SurveyID,
+		Header:      cloneHeaderMap(draft.Header),
+		Form:        cloneValuesMap(draft.Form),
+		AnswerCount: answerCount,
+	}
+}
+
+func cloneHeaderMap(header http.Header) map[string][]string {
+	if len(header) == 0 {
+		return nil
+	}
+	cloned := make(map[string][]string, len(header))
+	for key, values := range header {
+		cloned[key] = append([]string(nil), values...)
+	}
+	return cloned
+}
+
+func cloneValuesMap(values url.Values) map[string][]string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string][]string, len(values))
+	for key, items := range values {
+		cloned[key] = append([]string(nil), items...)
+	}
+	return cloned
+}

--- a/internal/app/wjx_preview_test.go
+++ b/internal/app/wjx_preview_test.go
@@ -1,0 +1,95 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPreviewWJXHTTPSubmissionBuildsDraft(t *testing.T) {
+	plan, err := CompileRunPlanFromFile(writeRunConfig(t, validWJXRunConfig()), RunPlanOverrides{})
+	if err != nil {
+		t.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+
+	preview, err := PreviewWJXHTTPSubmission(plan, WJXHTTPPreviewOptions{
+		Seed:   7,
+		Survey: testWJXSurvey(),
+	})
+	if err != nil {
+		t.Fatalf("PreviewWJXHTTPSubmission() error = %v", err)
+	}
+
+	if preview.Provider != "wjx" || preview.Mode != "http" || preview.Method != "POST" {
+		t.Fatalf("preview = %+v, want wjx http POST", preview)
+	}
+	if preview.Endpoint != "https://www.wjx.cn/joinnew/processjq.ashx" || preview.SurveyID != "example" {
+		t.Fatalf("preview endpoint/id = %q/%q, want WJX process endpoint and survey id", preview.Endpoint, preview.SurveyID)
+	}
+	if preview.AnswerCount != 1 || preview.Form["q1"][0] != "1" || preview.Form["curID"][0] != "example" {
+		t.Fatalf("preview form = %+v, want generated answer draft", preview.Form)
+	}
+	if preview.Header["Referer"][0] != "https://www.wjx.cn/vm/example.aspx" {
+		t.Fatalf("preview header = %+v, want referer", preview.Header)
+	}
+}
+
+func TestPreviewWJXHTTPSubmissionRejectsInvalidInputs(t *testing.T) {
+	plan, err := CompileRunPlanFromFile(writeRunConfig(t, validWJXRunConfig()), RunPlanOverrides{})
+	if err != nil {
+		t.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "provider",
+			want: "wjx provider",
+		},
+		{
+			name: "survey",
+			want: "wjx url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testPlan := plan
+			survey := testWJXSurvey()
+			if tt.name == "provider" {
+				testPlan.Provider = "mock"
+			}
+			if tt.name == "survey" {
+				survey.URL = ""
+			}
+
+			_, err := PreviewWJXHTTPSubmission(testPlan, WJXHTTPPreviewOptions{Survey: survey})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("PreviewWJXHTTPSubmission() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreviewWJXHTTPSubmissionClonesDraftMaps(t *testing.T) {
+	plan, err := CompileRunPlanFromFile(writeRunConfig(t, validWJXRunConfig()), RunPlanOverrides{})
+	if err != nil {
+		t.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+
+	first, err := PreviewWJXHTTPSubmission(plan, WJXHTTPPreviewOptions{Survey: testWJXSurvey()})
+	if err != nil {
+		t.Fatalf("PreviewWJXHTTPSubmission() error = %v", err)
+	}
+	first.Form["q1"][0] = "mutated"
+	first.Header["Referer"][0] = "mutated"
+
+	second, err := PreviewWJXHTTPSubmission(plan, WJXHTTPPreviewOptions{Survey: testWJXSurvey()})
+	if err != nil {
+		t.Fatalf("PreviewWJXHTTPSubmission() error = %v", err)
+	}
+	if second.Form["q1"][0] != "1" || second.Header["Referer"][0] != "https://www.wjx.cn/vm/example.aspx" {
+		t.Fatalf("second preview = %+v, want independent maps", second)
+	}
+}


### PR DESCRIPTION
## Summary
- add app-level WJX HTTP submission preview without executing network requests
- generate a deterministic answer plan from the run plan seed
- expose the compiled HTTP draft as a structured preview for later CLI output

## Validation
- go test ./internal/app -run "TestPreviewWJXHTTPSubmission" -count=1
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #121