### PR TITLE
[codex] Validate WJX HTTP preview compatibility

### DIFF
--- a/internal/app/wjx_preview.go
+++ b/internal/app/wjx_preview.go
@@ -29,11 +29,8 @@ type WJXHTTPSubmissionPreview struct {
 }
 
 func PreviewWJXHTTPSubmission(plan runner.Plan, options WJXHTTPPreviewOptions) (WJXHTTPSubmissionPreview, error) {
-	if strings.TrimSpace(plan.Provider) != domain.ProviderWJX.String() {
-		return WJXHTTPSubmissionPreview{}, fmt.Errorf("wjx http preview requires wjx provider")
-	}
-	if err := options.Survey.Validate(); err != nil {
-		return WJXHTTPSubmissionPreview{}, fmt.Errorf("wjx survey: %w", err)
+	if err := ValidateWJXHTTPPreview(plan, options.Survey); err != nil {
+		return WJXHTTPSubmissionPreview{}, err
 	}
 	seed := options.Seed
 	if seed == 0 {
@@ -49,6 +46,58 @@ func PreviewWJXHTTPSubmission(plan runner.Plan, options WJXHTTPPreviewOptions) (
 		return WJXHTTPSubmissionPreview{}, err
 	}
 	return previewFromWJXHTTPDraft(plan, draft, len(answerPlan.Answers)), nil
+}
+
+func ValidateWJXHTTPPreview(plan runner.Plan, survey domain.SurveyDefinition) error {
+	if strings.TrimSpace(plan.Provider) != domain.ProviderWJX.String() {
+		return fmt.Errorf("wjx http preview requires wjx provider")
+	}
+	if plan.Mode.String() != "http" {
+		return fmt.Errorf("wjx http preview requires http mode")
+	}
+	if strings.TrimSpace(plan.URL) != strings.TrimSpace(survey.URL) {
+		return fmt.Errorf("wjx http preview url mismatch: plan %q, survey %q", plan.URL, survey.URL)
+	}
+	if err := survey.Validate(); err != nil {
+		return fmt.Errorf("wjx survey: %w", err)
+	}
+	questions, err := wjxPreviewQuestionIndex(survey.Questions)
+	if err != nil {
+		return err
+	}
+	for _, question := range plan.Questions {
+		id := strings.TrimSpace(question.ID)
+		if id == "" {
+			return fmt.Errorf("wjx http preview question id is required")
+		}
+		surveyQuestion, ok := questions[id]
+		if !ok {
+			return fmt.Errorf("wjx http preview question %q is not present in survey fixture", id)
+		}
+		kind := strings.TrimSpace(question.Kind)
+		if kind == "" {
+			return fmt.Errorf("wjx http preview question %q kind is required", id)
+		}
+		if surveyQuestion.Kind.String() != kind {
+			return fmt.Errorf("wjx http preview question %q kind mismatch: plan %q, survey %q", id, kind, surveyQuestion.Kind)
+		}
+	}
+	return nil
+}
+
+func wjxPreviewQuestionIndex(questions []domain.QuestionDefinition) (map[string]domain.QuestionDefinition, error) {
+	index := make(map[string]domain.QuestionDefinition, len(questions))
+	for _, question := range questions {
+		id := strings.TrimSpace(question.ID)
+		if id == "" {
+			return nil, fmt.Errorf("wjx survey question id is required")
+		}
+		if _, exists := index[id]; exists {
+			return nil, fmt.Errorf("wjx survey question %q is defined more than once", id)
+		}
+		index[id] = question
+	}
+	return index, nil
 }
 
 func previewFromWJXHTTPDraft(plan runner.Plan, draft wjx.HTTPSubmissionDraft, answerCount int) WJXHTTPSubmissionPreview {

--- a/internal/app/wjx_preview_test.go
+++ b/internal/app/wjx_preview_test.go
@@ -3,6 +3,9 @@ package app
 import (
 	"strings"
 	"testing"
+
+	"github.com/LING71671/SurveyController-Go/internal/domain"
+	"github.com/LING71671/SurveyController-Go/internal/runner"
 )
 
 func TestPreviewWJXHTTPSubmissionBuildsDraft(t *testing.T) {
@@ -49,7 +52,7 @@ func TestPreviewWJXHTTPSubmissionRejectsInvalidInputs(t *testing.T) {
 		},
 		{
 			name: "survey",
-			want: "wjx url",
+			want: "url mismatch",
 		},
 	}
 
@@ -67,6 +70,62 @@ func TestPreviewWJXHTTPSubmissionRejectsInvalidInputs(t *testing.T) {
 			_, err := PreviewWJXHTTPSubmission(testPlan, WJXHTTPPreviewOptions{Survey: survey})
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("PreviewWJXHTTPSubmission() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateWJXHTTPPreviewRejectsIncompatiblePlan(t *testing.T) {
+	plan, err := CompileRunPlanFromFile(writeRunConfig(t, validWJXRunConfig()), RunPlanOverrides{})
+	if err != nil {
+		t.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+
+	tests := []struct {
+		name string
+		mut  func(*runnerPlanForTest, *surveyForTest)
+		want string
+	}{
+		{
+			name: "mode",
+			mut: func(p *runnerPlanForTest, s *surveyForTest) {
+				p.Mode = "hybrid"
+			},
+			want: "http mode",
+		},
+		{
+			name: "url",
+			mut: func(p *runnerPlanForTest, s *surveyForTest) {
+				s.URL = "https://www.wjx.cn/vm/other.aspx"
+			},
+			want: "url mismatch",
+		},
+		{
+			name: "question",
+			mut: func(p *runnerPlanForTest, s *surveyForTest) {
+				p.Questions[0].ID = "missing"
+			},
+			want: "not present",
+		},
+		{
+			name: "kind",
+			mut: func(p *runnerPlanForTest, s *surveyForTest) {
+				p.Questions[0].Kind = "multiple"
+			},
+			want: "kind mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testPlan := plan
+			testPlan.Questions = append([]runner.QuestionPlan(nil), plan.Questions...)
+			testSurvey := testWJXSurvey()
+			tt.mut((*runnerPlanForTest)(&testPlan), (*surveyForTest)(&testSurvey))
+
+			err := ValidateWJXHTTPPreview(testPlan, testSurvey)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ValidateWJXHTTPPreview() error = %v, want %q", err, tt.want)
 			}
 		})
 	}
@@ -93,3 +152,6 @@ func TestPreviewWJXHTTPSubmissionClonesDraftMaps(t *testing.T) {
 		t.Fatalf("second preview = %+v, want independent maps", second)
 	}
 }
+
+type runnerPlanForTest = runner.Plan
+type surveyForTest = domain.SurveyDefinition


### PR DESCRIPTION
## Summary
- add compatibility validation before WJX HTTP preview draft generation
- check provider, mode, URL, question presence, and question kind alignment
- improve mismatch errors for CLI preview callers

## Validation
- go test ./internal/app -run "TestPreviewWJXHTTPSubmission|TestValidateWJXHTTPPreview" -count=1
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved validation error messages for WJX HTTP preview submissions with clearer, more descriptive feedback when validation fails.

* **Tests**
  * Expanded test coverage for WJX preview validation across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->