### PR TITLE
[codex] Document WJX HTTP preview boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 
 `--events jsonl` 面向后续脚本、CI 和轻量 GUI 外壳；`v1.0` 前不会把 GUI 放进核心，但事件流会保持足够稳定，让 UI 只做薄订阅层。
 
-问卷星 HTTP 路径目前提供本地预览入口，用于检查 answer plan 到 HTTP form 的映射，不执行网络请求：
+问卷星 HTTP 路径目前提供本地预览入口，用于检查 answer plan 到 HTTP form 的映射，不执行网络请求。预览会校验配置计划和本地 fixture 的 URL、题目 ID、题型是否一致：
 
 ```powershell
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html

--- a/docs/development.md
+++ b/docs/development.md
@@ -48,9 +48,13 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 .\scripts\mock-stress.ps1
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events text
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
+go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
+go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --json
 ```
 
 `--dry-run` 用于验证配置能否编译成运行计划；`--mock` 会实际经过答案计划生成、worker pool、运行状态和事件输出，但 submitter 是本地 mock，不访问任何平台。
+
+`--wjx-http-preview` 用于验证问卷星 answer plan 能否编译成 HTTP draft。它只读取本地 HTML fixture，不执行网络请求；输出中会明确标注 `network: disabled (preview)`。预览会校验配置计划和 fixture 的 provider、mode、URL、题目 ID、题型是否一致，避免把不匹配的配置误认为可提交路径。
 
 `--target` 和 `--concurrency` 可以覆盖配置中的运行规模，用于本地压测和验证资源上限。覆盖后的计划仍会重新走 runner 校验，因此 `browser` 模式不会被临时参数放大到超过小池限制。
 
@@ -64,6 +68,8 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 - `--events` 不和 `--json` 同时使用，避免把事件流和单个 JSON 汇总混成不稳定协议。
 
 新增真实运行能力时，优先复用 runner 层的 `RunPlanReport` 和 logging 事件类型。CLI、CI、脚本和后续轻量 GUI 都应订阅同一套 core 事件，不要为 UI 单独分叉业务状态。
+
+真实网络开关进入 CLI 前，必须先具备对应 provider 的本地 preview、fixture 回归、能力门控和停止态检测。预览命令不是提交命令，不能偷偷执行 HTTP 请求。
 
 ## 性能习惯
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -69,6 +69,19 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 
 JSON 汇总不要和 `--events jsonl` 混用。前者是最终报告，后者是事件流。
 
+## WJX HTTP 预览
+
+问卷星 HTTP 路径目前先提供本地预览，不执行网络请求：
+
+```powershell
+go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
+go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --json
+```
+
+预览会经过配置编译、答案计划生成、问卷星 HTTP form 映射和 plan/fixture 兼容性校验，但不会调用 HTTP executor。输出中的 `network: disabled (preview)` 是这个阶段的安全边界。
+
+当前示例覆盖单选、多选和评分题，用于观察 answer plan 到 `processjq.ashx` form 的映射。后续真实网络运行必须继续复用 provider 能力门控，并在登录、验证、风控、设备次数上限或频控信号出现时停止并报告。
+
 ## 预算断言
 
 脚本支持轻量预算断言，适合本地提交前或后续 CI 使用。预算参数会透传给 `surveyctl run --mock`，由 CLI 基于同一份 `RunPlanReport` 统一判定；脚本只负责输出 JSON 或人类可读摘要：


### PR DESCRIPTION
## Summary
- document WJX HTTP preview commands in development and performance docs
- make the local-fixture/no-network boundary explicit
- note plan/fixture compatibility checks and provider stop-boundary requirements

## Validation
- go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #129