### PR TITLE
[codex] Add WJX HTTP dry-run executor

### DIFF
--- a/internal/provider/wjx/http_dryrun_executor.go
+++ b/internal/provider/wjx/http_dryrun_executor.go
@@ -1,0 +1,47 @@
+package wjx
+
+import (
+	"context"
+	"net/http"
+	"sync"
+)
+
+type DryRunHTTPSubmissionExecutor struct {
+	mu    sync.Mutex
+	calls []HTTPSubmissionDraft
+}
+
+func (e *DryRunHTTPSubmissionExecutor) ExecuteHTTPSubmission(ctx context.Context, draft HTTPSubmissionDraft) (HTTPSubmissionResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return HTTPSubmissionResponse{}, err
+	}
+	if err := validateHTTPSubmissionDraft(draft); err != nil {
+		return HTTPSubmissionResponse{}, err
+	}
+
+	e.mu.Lock()
+	e.calls = append(e.calls, cloneHTTPSubmissionDraft(draft))
+	e.mu.Unlock()
+
+	header := http.Header{}
+	header.Set("X-SurveyController-Dry-Run", "true")
+	return HTTPSubmissionResponse{
+		StatusCode: http.StatusAccepted,
+		Header:     header,
+		Body:       "submission accepted by local dry-run executor",
+	}, nil
+}
+
+func (e *DryRunHTTPSubmissionExecutor) Drafts() []HTTPSubmissionDraft {
+	if e == nil {
+		return nil
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	drafts := make([]HTTPSubmissionDraft, 0, len(e.calls))
+	for _, draft := range e.calls {
+		drafts = append(drafts, cloneHTTPSubmissionDraft(draft))
+	}
+	return drafts
+}

--- a/internal/provider/wjx/http_dryrun_executor_test.go
+++ b/internal/provider/wjx/http_dryrun_executor_test.go
@@ -1,0 +1,75 @@
+package wjx
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestDryRunHTTPSubmissionExecutorRecordsDraft(t *testing.T) {
+	executor := &DryRunHTTPSubmissionExecutor{}
+	draft, err := BuildHTTPSubmissionDraft("https://www.wjx.cn/vm/example.aspx", map[string]string{"q1": "a"})
+	if err != nil {
+		t.Fatalf("BuildHTTPSubmissionDraft() error = %v", err)
+	}
+
+	response, err := executor.ExecuteHTTPSubmission(context.Background(), draft)
+	if err != nil {
+		t.Fatalf("ExecuteHTTPSubmission() error = %v", err)
+	}
+	if response.StatusCode != http.StatusAccepted || response.Header.Get("X-SurveyController-Dry-Run") != "true" {
+		t.Fatalf("response = %+v, want accepted dry-run response", response)
+	}
+
+	drafts := executor.Drafts()
+	if len(drafts) != 1 || drafts[0].Form.Get("q1") != "a" {
+		t.Fatalf("drafts = %+v, want recorded draft", drafts)
+	}
+}
+
+func TestDryRunHTTPSubmissionExecutorClonesDrafts(t *testing.T) {
+	executor := &DryRunHTTPSubmissionExecutor{}
+	draft, err := BuildHTTPSubmissionDraft("https://www.wjx.cn/vm/example.aspx", map[string]string{"q1": "a"})
+	if err != nil {
+		t.Fatalf("BuildHTTPSubmissionDraft() error = %v", err)
+	}
+	if _, err := executor.ExecuteHTTPSubmission(context.Background(), draft); err != nil {
+		t.Fatalf("ExecuteHTTPSubmission() error = %v", err)
+	}
+
+	first := executor.Drafts()
+	first[0].Form.Set("q1", "mutated")
+	first[0].Header.Set("Referer", "mutated")
+
+	second := executor.Drafts()
+	if second[0].Form.Get("q1") != "a" || second[0].Header.Get("Referer") != "https://www.wjx.cn/vm/example.aspx" {
+		t.Fatalf("second drafts = %+v, want independent clone", second)
+	}
+}
+
+func TestDryRunHTTPSubmissionExecutorRejectsInvalidDraft(t *testing.T) {
+	executor := &DryRunHTTPSubmissionExecutor{}
+	_, err := executor.ExecuteHTTPSubmission(context.Background(), HTTPSubmissionDraft{})
+	if err == nil {
+		t.Fatalf("ExecuteHTTPSubmission() error = nil, want invalid draft error")
+	}
+	if len(executor.Drafts()) != 0 {
+		t.Fatalf("drafts = %+v, want no recorded invalid draft", executor.Drafts())
+	}
+}
+
+func TestDryRunHTTPSubmissionExecutorHonorsCancelledContext(t *testing.T) {
+	executor := &DryRunHTTPSubmissionExecutor{}
+	draft, err := BuildHTTPSubmissionDraft("https://www.wjx.cn/vm/example.aspx", map[string]string{"q1": "a"})
+	if err != nil {
+		t.Fatalf("BuildHTTPSubmissionDraft() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = executor.ExecuteHTTPSubmission(ctx, draft)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ExecuteHTTPSubmission() error = %v, want context.Canceled", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a no-network WJX HTTP dry-run executor
- record cloned submission drafts for later app/CLI reporting
- return an explicit local dry-run accepted response

## Validation
- go test ./internal/provider/wjx -run "TestDryRunHTTPSubmissionExecutor" -count=1
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #131