### PR TITLE
[codex] Add app-level WJX HTTP dry-run runner

### DIFF
--- a/internal/app/wjx_http.go
+++ b/internal/app/wjx_http.go
@@ -18,6 +18,32 @@ type WJXHTTPRunOptions struct {
 	Survey   domain.SurveyDefinition
 }
 
+type WJXHTTPDryRunResult struct {
+	Report runner.RunPlanReport       `json:"report"`
+	Drafts []WJXHTTPSubmissionPreview `json:"drafts"`
+}
+
+func RunWJXHTTPDryRun(ctx context.Context, plan runner.Plan, options WJXHTTPRunOptions) (WJXHTTPDryRunResult, error) {
+	if err := validateWJXHTTPPlanCompatibility(plan, options.Survey, "dry-run"); err != nil {
+		return WJXHTTPDryRunResult{}, err
+	}
+
+	executor := &wjx.DryRunHTTPSubmissionExecutor{}
+	report, err := RunWJXHTTPPlan(ctx, plan, WJXHTTPRunOptions{
+		Seed:     options.Seed,
+		Events:   options.Events,
+		Executor: executor,
+		Survey:   options.Survey,
+	})
+	if err != nil {
+		return WJXHTTPDryRunResult{}, err
+	}
+	return WJXHTTPDryRunResult{
+		Report: report,
+		Drafts: previewsFromWJXHTTPDrafts(plan, executor.Drafts()),
+	}, nil
+}
+
 func RunWJXHTTPPlan(ctx context.Context, plan runner.Plan, options WJXHTTPRunOptions) (runner.RunPlanReport, error) {
 	if strings.TrimSpace(plan.Provider) != domain.ProviderWJX.String() {
 		return runner.RunPlanReport{}, fmt.Errorf("wjx http run requires wjx provider")
@@ -34,4 +60,28 @@ func RunWJXHTTPPlan(ctx context.Context, plan runner.Plan, options WJXHTTPRunOpt
 		return runner.RunPlanReport{}, err
 	}
 	return runPlanWithSubmitter(ctx, plan, options.Seed, pipeline, options.Events)
+}
+
+func previewsFromWJXHTTPDrafts(plan runner.Plan, drafts []wjx.HTTPSubmissionDraft) []WJXHTTPSubmissionPreview {
+	if len(drafts) == 0 {
+		return nil
+	}
+	previews := make([]WJXHTTPSubmissionPreview, 0, len(drafts))
+	for _, draft := range drafts {
+		previews = append(previews, previewFromWJXHTTPDraft(plan, draft, wjxHTTPDraftAnswerCount(draft)))
+	}
+	return previews
+}
+
+func wjxHTTPDraftAnswerCount(draft wjx.HTTPSubmissionDraft) int {
+	count := 0
+	for key := range draft.Form {
+		switch strings.TrimSpace(key) {
+		case "", "curID", "submittype":
+			continue
+		default:
+			count++
+		}
+	}
+	return count
 }

--- a/internal/app/wjx_http_test.go
+++ b/internal/app/wjx_http_test.go
@@ -63,6 +63,54 @@ func TestRunWJXHTTPPlanStopsOnVerification(t *testing.T) {
 	}
 }
 
+func TestRunWJXHTTPDryRunReportsAndDrafts(t *testing.T) {
+	plan, err := CompileRunPlanFromFile(writeRunConfig(t, validWJXRunConfig()), RunPlanOverrides{Target: 2, Concurrency: 1})
+	if err != nil {
+		t.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+
+	result, err := RunWJXHTTPDryRun(context.Background(), plan, WJXHTTPRunOptions{
+		Seed:   7,
+		Survey: testWJXSurvey(),
+	})
+	if err != nil {
+		t.Fatalf("RunWJXHTTPDryRun() error = %v", err)
+	}
+
+	if result.Report.Successes != 2 || result.Report.Failures != 0 || result.Report.Completed != 2 {
+		t.Fatalf("report = %+v, want two successful dry-run submissions", result.Report)
+	}
+	if len(result.Drafts) != 2 {
+		t.Fatalf("drafts = %d, want 2", len(result.Drafts))
+	}
+	for _, draft := range result.Drafts {
+		if draft.Provider != "wjx" || draft.Mode != "http" || draft.Method != http.MethodPost {
+			t.Fatalf("draft = %+v, want wjx http POST preview", draft)
+		}
+		if draft.Endpoint != "https://www.wjx.cn/joinnew/processjq.ashx" || draft.SurveyID != "example" {
+			t.Fatalf("draft endpoint/id = %q/%q, want WJX process endpoint and survey id", draft.Endpoint, draft.SurveyID)
+		}
+		if draft.AnswerCount != 1 || draft.Form["q1"][0] != "1" || draft.Form["curID"][0] != "example" {
+			t.Fatalf("draft form = %+v, want generated answer draft", draft.Form)
+		}
+	}
+}
+
+func TestRunWJXHTTPDryRunRejectsIncompatiblePlan(t *testing.T) {
+	plan, err := CompileRunPlanFromFile(writeRunConfig(t, validWJXRunConfig()), RunPlanOverrides{})
+	if err != nil {
+		t.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+	plan.URL = "https://www.wjx.cn/vm/other.aspx"
+
+	_, err = RunWJXHTTPDryRun(context.Background(), plan, WJXHTTPRunOptions{
+		Survey: testWJXSurvey(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "dry-run url mismatch") {
+		t.Fatalf("RunWJXHTTPDryRun() error = %v, want url mismatch", err)
+	}
+}
+
 func TestRunWJXHTTPPlanRejectsInvalidInputs(t *testing.T) {
 	plan, err := CompileRunPlanFromFile(writeRunConfig(t, validWJXRunConfig()), RunPlanOverrides{})
 	if err != nil {

--- a/internal/app/wjx_preview.go
+++ b/internal/app/wjx_preview.go
@@ -49,14 +49,18 @@ func PreviewWJXHTTPSubmission(plan runner.Plan, options WJXHTTPPreviewOptions) (
 }
 
 func ValidateWJXHTTPPreview(plan runner.Plan, survey domain.SurveyDefinition) error {
+	return validateWJXHTTPPlanCompatibility(plan, survey, "preview")
+}
+
+func validateWJXHTTPPlanCompatibility(plan runner.Plan, survey domain.SurveyDefinition, operation string) error {
 	if strings.TrimSpace(plan.Provider) != domain.ProviderWJX.String() {
-		return fmt.Errorf("wjx http preview requires wjx provider")
+		return fmt.Errorf("wjx http %s requires wjx provider", operation)
 	}
 	if plan.Mode.String() != "http" {
-		return fmt.Errorf("wjx http preview requires http mode")
+		return fmt.Errorf("wjx http %s requires http mode", operation)
 	}
 	if strings.TrimSpace(plan.URL) != strings.TrimSpace(survey.URL) {
-		return fmt.Errorf("wjx http preview url mismatch: plan %q, survey %q", plan.URL, survey.URL)
+		return fmt.Errorf("wjx http %s url mismatch: plan %q, survey %q", operation, plan.URL, survey.URL)
 	}
 	if err := survey.Validate(); err != nil {
 		return fmt.Errorf("wjx survey: %w", err)

--- a/internal/provider/wjx/http_dryrun_executor.go
+++ b/internal/provider/wjx/http_dryrun_executor.go
@@ -28,7 +28,7 @@ func (e *DryRunHTTPSubmissionExecutor) ExecuteHTTPSubmission(ctx context.Context
 	return HTTPSubmissionResponse{
 		StatusCode: http.StatusAccepted,
 		Header:     header,
-		Body:       "submission accepted by local dry-run executor",
+		Body:       "submission accepted by local dry-run executor; success",
 	}, nil
 }
 

--- a/internal/provider/wjx/http_submission_pipeline_test.go
+++ b/internal/provider/wjx/http_submission_pipeline_test.go
@@ -39,6 +39,26 @@ func TestHTTPSubmissionPipelineSubmitSuccess(t *testing.T) {
 	}
 }
 
+func TestHTTPSubmissionPipelineAcceptsDryRunExecutor(t *testing.T) {
+	executor := &DryRunHTTPSubmissionExecutor{}
+	pipeline, err := testHTTPSubmissionPipeline(executor, provider.Capabilities{SubmitHTTP: true})
+	if err != nil {
+		t.Fatalf("NewHTTPSubmissionPipeline() returned error: %v", err)
+	}
+
+	result, err := pipeline.Submit(context.Background(), testPipelineAnswerPlan())
+	if err != nil {
+		t.Fatalf("Submit() returned error: %v", err)
+	}
+
+	if !result.Success || result.State != provider.SubmissionStateSuccess {
+		t.Fatalf("Submit() = %+v, want successful dry-run result", result)
+	}
+	if drafts := executor.Drafts(); len(drafts) != 1 || drafts[0].Form.Get("q1") != "2" {
+		t.Fatalf("dry-run drafts = %+v, want recorded mapped draft", drafts)
+	}
+}
+
 func TestHTTPSubmissionPipelineRequiresSubmitCapability(t *testing.T) {
 	executor := &pipelineRecordingExecutor{
 		response: HTTPSubmissionResponse{StatusCode: http.StatusOK, Body: "提交成功"},


### PR DESCRIPTION
## Summary
- add `RunWJXHTTPDryRun` for app-level WJX HTTP dry-run execution
- return runner report plus recorded HTTP draft previews
- reuse shared plan/fixture compatibility validation for preview and dry-run
- make the local dry-run executor detectable as a successful pipeline submission

## Validation
- go test ./internal/app ./internal/provider/wjx -run "TestRunWJXHTTPDryRun|TestRunWJXHTTPPlan|TestPreviewWJXHTTPSubmission|TestValidateWJXHTTPPreview|TestHTTPSubmissionPipelineAcceptsDryRunExecutor|TestDryRunHTTPSubmissionExecutor" -count=1
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dry-run support for WJX HTTP submissions, allowing users to preview submission outcomes and draft previews before finalizing.

* **Tests**
  * Added comprehensive test coverage for dry-run execution and plan compatibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->