### PR TITLE
[codex] Expose WJX HTTP dry-run in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ go run ./cmd/surveyctl run --dry-run examples/run.yaml
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 .\scripts\mock-stress.ps1
 go run ./cmd/surveyctl doctor
 go run ./cmd/surveyctl doctor browser
@@ -108,6 +109,13 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 ```powershell
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --json
+```
+
+需要经过完整 runner/worker pool 但仍然禁用网络时，可以使用问卷星 HTTP dry-run。它会从本地 fixture 构建 survey schema，运行 answer plan 和 HTTP pipeline，并用本地 dry-run executor 记录 draft：
+
+```powershell
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
 ```
 
 ## 开发节奏

--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -33,6 +33,7 @@ Usage:
   surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
   surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>] [--min-throughput <n>] [--max-heap-delta <bytes>] [--max-goroutines <n>] [--expect-failure-threshold <true|false>]
   surveyctl run --wjx-http-preview [path] --fixture <html> [--json] [--seed <n>] [--target <n>] [--concurrency <n>]
+  surveyctl run --wjx-http-dry-run [path] --fixture <html> [--json] [--seed <n>] [--target <n>] [--concurrency <n>]
   surveyctl doctor [browser]
   surveyctl help
 
@@ -58,6 +59,7 @@ const runUsage = `Usage:
   surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
   surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>] [--min-throughput <n>] [--max-heap-delta <bytes>] [--max-goroutines <n>] [--expect-failure-threshold <true|false>]
   surveyctl run --wjx-http-preview [path] --fixture <html> [--json] [--seed <n>] [--target <n>] [--concurrency <n>]
+  surveyctl run --wjx-http-dry-run [path] --fixture <html> [--json] [--seed <n>] [--target <n>] [--concurrency <n>]
 `
 
 const (
@@ -266,11 +268,12 @@ func selectedRunModeCount(modes ...bool) int {
 
 func runRun(args []string, stdout io.Writer) error {
 	if len(args) == 0 {
-		return usageError("run requires --dry-run, --mock, or --wjx-http-preview", runUsage)
+		return usageError("run requires --dry-run, --mock, --wjx-http-preview, or --wjx-http-dry-run", runUsage)
 	}
 	dryRun := false
 	mockRun := false
 	wjxHTTPPreview := false
+	wjxHTTPDryRun := false
 	jsonOutput := false
 	eventFormat := logging.Format("")
 	overrides := app.RunPlanOverrides{}
@@ -296,6 +299,8 @@ func runRun(args []string, stdout io.Writer) error {
 			mockRun = true
 		case "--wjx-http-preview":
 			wjxHTTPPreview = true
+		case "--wjx-http-dry-run":
+			wjxHTTPDryRun = true
 		case "--json":
 			jsonOutput = true
 		case "--fixture":
@@ -416,12 +421,12 @@ func runRun(args []string, stdout io.Writer) error {
 			pathSet = true
 		}
 	}
-	modeCount := selectedRunModeCount(dryRun, mockRun, wjxHTTPPreview)
+	modeCount := selectedRunModeCount(dryRun, mockRun, wjxHTTPPreview, wjxHTTPDryRun)
 	if modeCount > 1 {
-		return usageError("run accepts only one of --dry-run, --mock, or --wjx-http-preview", runUsage)
+		return usageError("run accepts only one of --dry-run, --mock, --wjx-http-preview, or --wjx-http-dry-run", runUsage)
 	}
 	if modeCount == 0 {
-		return usageError("run requires --dry-run, --mock, or --wjx-http-preview", runUsage)
+		return usageError("run requires --dry-run, --mock, --wjx-http-preview, or --wjx-http-dry-run", runUsage)
 	}
 	if !mockRun && eventFormat != "" {
 		return usageError("run --events requires --mock", runUsage)
@@ -435,11 +440,14 @@ func runRun(args []string, stdout io.Writer) error {
 	if !mockRun && budgetSet {
 		return usageError("run budget flags require --mock", runUsage)
 	}
-	if !wjxHTTPPreview && strings.TrimSpace(fixturePath) != "" {
-		return usageError("run --fixture requires --wjx-http-preview", runUsage)
+	if !wjxHTTPPreview && !wjxHTTPDryRun && strings.TrimSpace(fixturePath) != "" {
+		return usageError("run --fixture requires --wjx-http-preview or --wjx-http-dry-run", runUsage)
 	}
 	if wjxHTTPPreview && strings.TrimSpace(fixturePath) == "" {
 		return usageError("run --wjx-http-preview requires --fixture", runUsage)
+	}
+	if wjxHTTPDryRun && strings.TrimSpace(fixturePath) == "" {
+		return usageError("run --wjx-http-dry-run requires --fixture", runUsage)
 	}
 
 	plan, err := app.CompileRunPlanFromFile(path, overrides)
@@ -447,6 +455,10 @@ func runRun(args []string, stdout io.Writer) error {
 		action := "dry-run"
 		if mockRun {
 			action = "mock"
+		} else if wjxHTTPPreview {
+			action = "wjx http preview"
+		} else if wjxHTTPDryRun {
+			action = "wjx http dry-run"
 		}
 		return commandError(exitFailure, fmt.Sprintf("run %s failed: %v", action, err), "")
 	}
@@ -470,6 +482,20 @@ func runRun(args []string, stdout io.Writer) error {
 			return commandError(exitFailure, fmt.Sprintf("run wjx http preview failed: %v", err), "")
 		}
 		return printWJXHTTPPreview(stdout, path, fixturePath, preview, jsonOutput)
+	}
+	if wjxHTTPDryRun {
+		survey, err := parseWJXFixture(fixturePath, plan.URL)
+		if err != nil {
+			return commandError(exitFailure, fmt.Sprintf("run wjx http dry-run failed: %v", err), "")
+		}
+		result, err := app.RunWJXHTTPDryRun(contextBackground(), plan, app.WJXHTTPRunOptions{
+			Seed:   seed,
+			Survey: survey,
+		})
+		if err != nil {
+			return commandError(exitFailure, fmt.Sprintf("run wjx http dry-run failed: %v", err), "")
+		}
+		return printWJXHTTPDryRun(stdout, path, fixturePath, result, seed, jsonOutput)
 	}
 	var finishEvents func() (int, error)
 	mockOptions := app.MockRunOptions{
@@ -677,6 +703,16 @@ type wjxHTTPPreviewSummary struct {
 	Network     string              `json:"network"`
 }
 
+type wjxHTTPDryRunSummary struct {
+	Path       string                         `json:"path"`
+	Fixture    string                         `json:"fixture"`
+	Seed       int64                          `json:"seed"`
+	Report     runner.RunPlanReport           `json:"report"`
+	DraftCount int                            `json:"draft_count"`
+	Drafts     []app.WJXHTTPSubmissionPreview `json:"drafts"`
+	Network    string                         `json:"network"`
+}
+
 func printDryRunPlan(stdout io.Writer, path string, plan runner.Plan, jsonOutput bool) error {
 	summary := dryRunPlanSummary{
 		Path:             path,
@@ -754,6 +790,62 @@ func printWJXHTTPPreview(stdout io.Writer, path string, fixture string, preview 
 	}
 	fmt.Fprintf(stdout, "  network: %s\n", summary.Network)
 	return nil
+}
+
+func printWJXHTTPDryRun(stdout io.Writer, path string, fixture string, result app.WJXHTTPDryRunResult, seed int64, jsonOutput bool) error {
+	summary := wjxHTTPDryRunSummary{
+		Path:       path,
+		Fixture:    fixture,
+		Seed:       seed,
+		Report:     result.Report,
+		DraftCount: len(result.Drafts),
+		Drafts:     result.Drafts,
+		Network:    "disabled (dry-run)",
+	}
+	if jsonOutput {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		return encoder.Encode(summary)
+	}
+
+	fmt.Fprintln(stdout, "wjx http dry-run:")
+	fmt.Fprintf(stdout, "  path: %s\n", summary.Path)
+	fmt.Fprintf(stdout, "  fixture: %s\n", summary.Fixture)
+	fmt.Fprintf(stdout, "  provider: %s\n", summary.Report.Provider)
+	fmt.Fprintf(stdout, "  url: %s\n", summary.Report.URL)
+	fmt.Fprintf(stdout, "  mode: %s\n", summary.Report.Mode)
+	fmt.Fprintf(stdout, "  target: %d\n", summary.Report.Target)
+	fmt.Fprintf(stdout, "  concurrency: %d\n", summary.Report.Concurrency)
+	fmt.Fprintf(stdout, "  seed: %d\n", summary.Seed)
+	fmt.Fprintf(stdout, "  successes: %d\n", summary.Report.Successes)
+	fmt.Fprintf(stdout, "  failures: %d\n", summary.Report.Failures)
+	fmt.Fprintf(stdout, "  completed: %d\n", summary.Report.Completed)
+	fmt.Fprintf(stdout, "  completion_rate: %s\n", formatPercent(summary.Report.CompletionRate))
+	fmt.Fprintf(stdout, "  success_rate: %s\n", formatPercent(summary.Report.SuccessRate))
+	fmt.Fprintf(stdout, "  duration_ms: %d\n", summary.Report.DurationMS)
+	fmt.Fprintf(stdout, "  throughput_per_second: %.2f\n", summary.Report.ThroughputPerSec)
+	fmt.Fprintf(stdout, "  goroutines: %d\n", summary.Report.Goroutines)
+	fmt.Fprintf(stdout, "  heap_alloc_bytes: %d\n", summary.Report.HeapAllocBytes)
+	fmt.Fprintf(stdout, "  heap_alloc_delta_bytes: %d\n", summary.Report.HeapAllocDelta)
+	fmt.Fprintf(stdout, "  total_alloc_delta_bytes: %d\n", summary.Report.TotalAllocDelta)
+	fmt.Fprintf(stdout, "  draft_count: %d\n", summary.DraftCount)
+	if summary.DraftCount > 0 {
+		printWJXHTTPDraftPreview(stdout, summary.Drafts[0])
+	}
+	fmt.Fprintf(stdout, "  network: %s\n", summary.Network)
+	return nil
+}
+
+func printWJXHTTPDraftPreview(stdout io.Writer, draft app.WJXHTTPSubmissionPreview) {
+	fmt.Fprintln(stdout, "  first_draft:")
+	fmt.Fprintf(stdout, "    method: %s\n", draft.Method)
+	fmt.Fprintf(stdout, "    endpoint: %s\n", draft.Endpoint)
+	fmt.Fprintf(stdout, "    survey_id: %s\n", draft.SurveyID)
+	fmt.Fprintf(stdout, "    answer_count: %d\n", draft.AnswerCount)
+	fmt.Fprintln(stdout, "    form:")
+	for _, key := range sortedMapKeys(draft.Form) {
+		fmt.Fprintf(stdout, "      %s: %s\n", key, strings.Join(draft.Form[key], ","))
+	}
 }
 
 func printMockRunSummary(stdout io.Writer, path string, report runner.RunPlanReport, seed int64, jsonOutput bool) error {

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -480,6 +480,58 @@ func TestRunWJXHTTPPreviewJSONPrintsSummary(t *testing.T) {
 	}
 }
 
+func TestRunWJXHTTPDryRunPrintsSummary(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, wjxPreviewConfig())
+	fixture := filepath.Join("..", "..", "internal", "provider", "wjx", "testdata", "survey.html")
+
+	code := run([]string{"run", "--wjx-http-dry-run", "--fixture", fixture, "--target", "2", "--concurrency", "1", "--seed", "7", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(wjx http dry-run) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	for _, want := range []string{"wjx http dry-run:", "provider: wjx", "mode: http", "target: 2", "successes: 2", "completed: 2", "draft_count: 2", "first_draft:", "q1: browser", "q2: q2_a,q2_b", "q4: 5", "network: disabled (dry-run)"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunWJXHTTPDryRunJSONPrintsSummary(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, wjxPreviewConfig())
+	fixture := filepath.Join("..", "..", "internal", "provider", "wjx", "testdata", "survey.html")
+
+	code := run([]string{"run", "--wjx-http-dry-run", "--fixture", fixture, "--json", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(wjx http dry-run json) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	var summary map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("json output decode failed: %v; output=%q", err, stdout.String())
+	}
+	if summary["network"] != "disabled (dry-run)" || summary["draft_count"] != float64(1) {
+		t.Fatalf("summary = %+v, want dry-run metadata", summary)
+	}
+	report := summary["report"].(map[string]any)
+	if report["successes"] != float64(1) || report["completed"] != float64(1) {
+		t.Fatalf("report = %+v, want one successful dry-run submission", report)
+	}
+	drafts := summary["drafts"].([]any)
+	first := drafts[0].(map[string]any)
+	form := first["form"].(map[string]any)
+	if values := form["q1"].([]any); values[0] != "browser" {
+		t.Fatalf("form = %+v, want q1 browser", form)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestRunWJXHTTPPreviewRequiresFixture(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -487,6 +539,22 @@ func TestRunWJXHTTPPreviewRequiresFixture(t *testing.T) {
 	code := run([]string{"run", "--wjx-http-preview"}, &stdout, &stderr)
 	if code != exitUsage {
 		t.Fatalf("run(wjx preview missing fixture) exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr.String(), "requires --fixture") {
+		t.Fatalf("stderr = %q, want fixture requirement", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunWJXHTTPDryRunRequiresFixture(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"run", "--wjx-http-dry-run"}, &stdout, &stderr)
+	if code != exitUsage {
+		t.Fatalf("run(wjx dry-run missing fixture) exit code = %d, want %d", code, exitUsage)
 	}
 	if !strings.Contains(stderr.String(), "requires --fixture") {
 		t.Fatalf("stderr = %q, want fixture requirement", stderr.String())
@@ -955,7 +1023,7 @@ func TestRunRequiresDryRun(t *testing.T) {
 	if code != exitUsage {
 		t.Fatalf("run(without dry-run) exit code = %d, want %d", code, exitUsage)
 	}
-	if !strings.Contains(stderr.String(), "requires --dry-run, --mock, or --wjx-http-preview") {
+	if !strings.Contains(stderr.String(), "requires --dry-run, --mock, --wjx-http-preview, or --wjx-http-dry-run") {
 		t.Fatalf("stderr = %q, want run mode requirement", stderr.String())
 	}
 	if stdout.Len() != 0 {

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,11 +50,15 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events text
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --json
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
 ```
 
 `--dry-run` 用于验证配置能否编译成运行计划；`--mock` 会实际经过答案计划生成、worker pool、运行状态和事件输出，但 submitter 是本地 mock，不访问任何平台。
 
 `--wjx-http-preview` 用于验证问卷星 answer plan 能否编译成 HTTP draft。它只读取本地 HTML fixture，不执行网络请求；输出中会明确标注 `network: disabled (preview)`。预览会校验配置计划和 fixture 的 provider、mode、URL、题目 ID、题型是否一致，避免把不匹配的配置误认为可提交路径。
+
+`--wjx-http-dry-run` 用于验证问卷星 HTTP 路径的完整本地执行闭环。它会经过 runner、worker pool、答案计划生成、HTTP pipeline 和本地 dry-run executor，输出成功数、完成数、吞吐、资源指标、draft 数量和首个 draft 详情；JSON 输出会包含完整 drafts。该命令仍然只使用本地 fixture，输出中会明确标注 `network: disabled (dry-run)`。
 
 `--target` 和 `--concurrency` 可以覆盖配置中的运行规模，用于本地压测和验证资源上限。覆盖后的计划仍会重新走 runner 校验，因此 `browser` 模式不会被临时参数放大到超过小池限制。
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -82,6 +82,17 @@ go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --f
 
 当前示例覆盖单选、多选和评分题，用于观察 answer plan 到 `processjq.ashx` form 的映射。后续真实网络运行必须继续复用 provider 能力门控，并在登录、验证、风控、设备次数上限或频控信号出现时停止并报告。
 
+## WJX HTTP Dry-Run
+
+需要验证完整 runner 和 HTTP pipeline 时，可以使用本地 dry-run executor。它会记录生成的 HTTP draft，但不会执行网络请求：
+
+```powershell
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
+```
+
+text 输出只展示汇总和首个 draft，避免高并发 dry-run 时刷屏；JSON 输出包含完整 `drafts`，适合脚本检查 answer plan 到 form 的稳定性。输出中的 `network: disabled (dry-run)` 是安全边界。
+
 ## 预算断言
 
 脚本支持轻量预算断言，适合本地提交前或后续 CI 使用。预算参数会透传给 `surveyctl run --mock`，由 CLI 基于同一份 `RunPlanReport` 统一判定；脚本只负责输出 JSON 或人类可读摘要：


### PR DESCRIPTION
## Summary
- add `surveyctl run --wjx-http-dry-run [path] --fixture <html>`
- print runner report, draft count, and first draft in text output
- include full dry-run report and drafts in JSON output
- document WJX HTTP dry-run in README, development, and performance docs

## Validation
- go test ./cmd/surveyctl -run "TestRunWJXHTTPDryRun|TestRunWJXHTTPPreview|TestRunRequiresDryRun|TestRunRejectsBothDryRunAndMock" -count=1
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 2 --concurrency 1 --seed 7

Closes #135