### PR TITLE
[codex] Emit events for WJX HTTP dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events jsonl
 .\scripts\mock-stress.ps1
 go run ./cmd/surveyctl doctor
 go run ./cmd/surveyctl doctor browser
@@ -102,7 +103,7 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events text
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 ```
 
-`--events jsonl` 面向后续脚本、CI 和轻量 GUI 外壳；`v1.0` 前不会把 GUI 放进核心，但事件流会保持足够稳定，让 UI 只做薄订阅层。
+`--events jsonl` 面向后续脚本、CI 和轻量 GUI 外壳；`v1.0` 前不会把 GUI 放进核心，但事件流会保持足够稳定，让 UI 只做薄订阅层。当前 mock run 和 WJX HTTP dry-run 共用这套事件协议。
 
 问卷星 HTTP 路径目前提供本地预览入口，用于检查 answer plan 到 HTTP form 的映射，不执行网络请求。预览会校验配置计划和本地 fixture 的 URL、题目 ID、题型是否一致：
 
@@ -116,6 +117,7 @@ go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --f
 ```powershell
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events text
 ```
 
 ## 开发节奏

--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -33,7 +33,7 @@ Usage:
   surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
   surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>] [--min-throughput <n>] [--max-heap-delta <bytes>] [--max-goroutines <n>] [--expect-failure-threshold <true|false>]
   surveyctl run --wjx-http-preview [path] --fixture <html> [--json] [--seed <n>] [--target <n>] [--concurrency <n>]
-  surveyctl run --wjx-http-dry-run [path] --fixture <html> [--json] [--seed <n>] [--target <n>] [--concurrency <n>]
+  surveyctl run --wjx-http-dry-run [path] --fixture <html> [--json] [--seed <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>]
   surveyctl doctor [browser]
   surveyctl help
 
@@ -59,7 +59,7 @@ const runUsage = `Usage:
   surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
   surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>] [--min-throughput <n>] [--max-heap-delta <bytes>] [--max-goroutines <n>] [--expect-failure-threshold <true|false>]
   surveyctl run --wjx-http-preview [path] --fixture <html> [--json] [--seed <n>] [--target <n>] [--concurrency <n>]
-  surveyctl run --wjx-http-dry-run [path] --fixture <html> [--json] [--seed <n>] [--target <n>] [--concurrency <n>]
+  surveyctl run --wjx-http-dry-run [path] --fixture <html> [--json] [--seed <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>]
 `
 
 const (
@@ -428,8 +428,8 @@ func runRun(args []string, stdout io.Writer) error {
 	if modeCount == 0 {
 		return usageError("run requires --dry-run, --mock, --wjx-http-preview, or --wjx-http-dry-run", runUsage)
 	}
-	if !mockRun && eventFormat != "" {
-		return usageError("run --events requires --mock", runUsage)
+	if !mockRun && !wjxHTTPDryRun && eventFormat != "" {
+		return usageError("run --events requires --mock or --wjx-http-dry-run", runUsage)
 	}
 	if jsonOutput && eventFormat != "" {
 		return usageError("run --events cannot be combined with --json summary output", runUsage)
@@ -488,10 +488,24 @@ func runRun(args []string, stdout io.Writer) error {
 		if err != nil {
 			return commandError(exitFailure, fmt.Sprintf("run wjx http dry-run failed: %v", err), "")
 		}
-		result, err := app.RunWJXHTTPDryRun(contextBackground(), plan, app.WJXHTTPRunOptions{
+		var finishEvents func() (int, error)
+		options := app.WJXHTTPRunOptions{
 			Seed:   seed,
 			Survey: survey,
-		})
+		}
+		if eventFormat != "" {
+			options.Events, finishEvents = startRunEventStream(stdout, eventFormat, runEventBufferSize(plan))
+		}
+		result, err := app.RunWJXHTTPDryRun(contextBackground(), plan, options)
+		if finishEvents != nil {
+			eventCount, eventErr := finishEvents()
+			if err == nil && eventErr != nil {
+				err = eventErr
+			}
+			if err == nil {
+				fmt.Fprintf(stdout, "events: %d\n", eventCount)
+			}
+		}
 		if err != nil {
 			return commandError(exitFailure, fmt.Sprintf("run wjx http dry-run failed: %v", err), "")
 		}

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -532,6 +532,55 @@ func TestRunWJXHTTPDryRunJSONPrintsSummary(t *testing.T) {
 	}
 }
 
+func TestRunWJXHTTPDryRunEventsTextPrintsEventStream(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, wjxPreviewConfig())
+	fixture := filepath.Join("..", "..", "internal", "provider", "wjx", "testdata", "survey.html")
+
+	code := run([]string{"run", "--wjx-http-dry-run", "--fixture", fixture, "--events", "text", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(wjx http dry-run events text) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	for _, want := range []string{"run_started", "worker_started", "submission_success", "run_finished", "events: 4", "wjx http dry-run:", "network: disabled (dry-run)"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunWJXHTTPDryRunEventsJSONLPrintsEventStream(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, wjxPreviewConfig())
+	fixture := filepath.Join("..", "..", "internal", "provider", "wjx", "testdata", "survey.html")
+
+	code := run([]string{"run", "--wjx-http-dry-run", "--fixture", fixture, "--events", "jsonl", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(wjx http dry-run events jsonl) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) < 6 {
+		t.Fatalf("stdout lines = %q, want event stream and summary", lines)
+	}
+	var firstEvent map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &firstEvent); err != nil {
+		t.Fatalf("first jsonl event decode failed: %v; line=%q", err, lines[0])
+	}
+	if firstEvent["type"] != "run_started" || firstEvent["level"] != "info" {
+		t.Fatalf("firstEvent = %+v, want run_started info", firstEvent)
+	}
+	if !strings.Contains(stdout.String(), "events: 4") || !strings.Contains(stdout.String(), "wjx http dry-run:") {
+		t.Fatalf("stdout = %q, want event count and summary", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestRunWJXHTTPPreviewRequiresFixture(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -959,7 +1008,7 @@ func TestRunDryRunRejectsEvents(t *testing.T) {
 	if code != exitUsage {
 		t.Fatalf("run(dry-run events) exit code = %d, want %d", code, exitUsage)
 	}
-	if !strings.Contains(stderr.String(), "requires --mock") {
+	if !strings.Contains(stderr.String(), "requires --mock or --wjx-http-dry-run") {
 		t.Fatalf("stderr = %q, want dry-run events error", stderr.String())
 	}
 	if stdout.Len() != 0 {

--- a/docs/development.md
+++ b/docs/development.md
@@ -52,13 +52,15 @@ go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --f
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --json
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events text
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events jsonl
 ```
 
 `--dry-run` 用于验证配置能否编译成运行计划；`--mock` 会实际经过答案计划生成、worker pool、运行状态和事件输出，但 submitter 是本地 mock，不访问任何平台。
 
 `--wjx-http-preview` 用于验证问卷星 answer plan 能否编译成 HTTP draft。它只读取本地 HTML fixture，不执行网络请求；输出中会明确标注 `network: disabled (preview)`。预览会校验配置计划和 fixture 的 provider、mode、URL、题目 ID、题型是否一致，避免把不匹配的配置误认为可提交路径。
 
-`--wjx-http-dry-run` 用于验证问卷星 HTTP 路径的完整本地执行闭环。它会经过 runner、worker pool、答案计划生成、HTTP pipeline 和本地 dry-run executor，输出成功数、完成数、吞吐、资源指标、draft 数量和首个 draft 详情；JSON 输出会包含完整 drafts。该命令仍然只使用本地 fixture，输出中会明确标注 `network: disabled (dry-run)`。
+`--wjx-http-dry-run` 用于验证问卷星 HTTP 路径的完整本地执行闭环。它会经过 runner、worker pool、答案计划生成、HTTP pipeline 和本地 dry-run executor，输出成功数、完成数、吞吐、资源指标、draft 数量和首个 draft 详情；JSON 输出会包含完整 drafts。该命令仍然只使用本地 fixture，输出中会明确标注 `network: disabled (dry-run)`。需要观察进度时可以使用 `--events text` 或 `--events jsonl`，事件语义和 mock run 保持一致。
 
 `--target` 和 `--concurrency` 可以覆盖配置中的运行规模，用于本地压测和验证资源上限。覆盖后的计划仍会重新走 runner 校验，因此 `browser` 模式不会被临时参数放大到超过小池限制。
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -89,9 +89,12 @@ go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --f
 ```powershell
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --events jsonl
 ```
 
 text 输出只展示汇总和首个 draft，避免高并发 dry-run 时刷屏；JSON 输出包含完整 `drafts`，适合脚本检查 answer plan 到 form 的稳定性。输出中的 `network: disabled (dry-run)` 是安全边界。
+
+`--events text|jsonl` 可用于观察 dry-run 期间的 runner 事件。高并发 profile 中建议优先使用 `--json` 汇总或脚本预算；事件流更适合小规模诊断和后续轻量 UI 订阅。
 
 ## 预算断言
 


### PR DESCRIPTION
## Summary
- allow `--events text|jsonl` with `surveyctl run --wjx-http-dry-run`
- keep event output mutually exclusive with final-summary `--json`
- keep pure plan dry-run and WJX preview event-free
- document WJX HTTP dry-run event usage in README and development/performance docs

## Validation
- go test ./cmd/surveyctl -run "TestRunWJXHTTPDryRunEvents|TestRunWJXHTTPDryRunPrintsSummary|TestRunWJXHTTPDryRunJSONPrintsSummary|TestRunMockRunEvents|TestRunDryRunRejectsEvents|TestRunMockRejectsEventsWithJSONSummary" -count=1
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events text

Closes #137