### PR TITLE
[codex] Support budgets for WJX HTTP dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --f
 ```powershell
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --min-throughput 1 --max-goroutines 1
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events text
 ```
 

--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -437,8 +437,8 @@ func runRun(args []string, stdout io.Writer) error {
 	if !mockRun && mockFailEvery > 0 {
 		return usageError("run --mock-fail-every requires --mock", runUsage)
 	}
-	if !mockRun && budgetSet {
-		return usageError("run budget flags require --mock", runUsage)
+	if !mockRun && !wjxHTTPDryRun && budgetSet {
+		return usageError("run budget flags require --mock or --wjx-http-dry-run", runUsage)
 	}
 	if !wjxHTTPPreview && !wjxHTTPDryRun && strings.TrimSpace(fixturePath) != "" {
 		return usageError("run --fixture requires --wjx-http-preview or --wjx-http-dry-run", runUsage)
@@ -509,7 +509,15 @@ func runRun(args []string, stdout io.Writer) error {
 		if err != nil {
 			return commandError(exitFailure, fmt.Sprintf("run wjx http dry-run failed: %v", err), "")
 		}
-		return printWJXHTTPDryRun(stdout, path, fixturePath, result, seed, jsonOutput)
+		if err := printWJXHTTPDryRun(stdout, path, fixturePath, result, seed, jsonOutput); err != nil {
+			return err
+		}
+		if budgetSet {
+			if err := budget.Check(result.Report); err != nil {
+				return commandError(exitFailure, fmt.Sprintf("run wjx http dry-run budget failed: %v", err), "")
+			}
+		}
+		return nil
 	}
 	var finishEvents func() (int, error)
 	mockOptions := app.MockRunOptions{

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -613,6 +613,44 @@ func TestRunWJXHTTPDryRunRequiresFixture(t *testing.T) {
 	}
 }
 
+func TestRunWJXHTTPDryRunBudgetPasses(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, wjxPreviewConfig())
+	fixture := filepath.Join("..", "..", "internal", "provider", "wjx", "testdata", "survey.html")
+
+	code := run([]string{"run", "--wjx-http-dry-run", "--fixture", fixture, "--min-throughput", "0", "--max-goroutines", "1000", "--expect-failure-threshold", "false", path}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(wjx dry-run budget pass) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "wjx http dry-run:") || !strings.Contains(stdout.String(), "network: disabled (dry-run)") {
+		t.Fatalf("stdout = %q, want dry-run summary", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunWJXHTTPDryRunBudgetFailureStillPrintsSummary(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	path := writeConfig(t, wjxPreviewConfig())
+	fixture := filepath.Join("..", "..", "internal", "provider", "wjx", "testdata", "survey.html")
+
+	code := run([]string{"run", "--wjx-http-dry-run", "--fixture", fixture, "--min-throughput", "999999999", path}, &stdout, &stderr)
+	if code != exitFailure {
+		t.Fatalf("run(wjx dry-run budget failure) exit code = %d, want %d", code, exitFailure)
+	}
+	if !strings.Contains(stdout.String(), "wjx http dry-run:") {
+		t.Fatalf("stdout = %q, want diagnostic summary", stdout.String())
+	}
+	for _, want := range []string{"run wjx http dry-run budget failed", "throughput_per_second"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
 func TestRunMockRunBudgetPasses(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -722,7 +760,8 @@ func TestRunRejectsInvalidBudgetFlags(t *testing.T) {
 		{name: "throughput", args: []string{"run", "--mock", "--min-throughput", "-1"}, want: "--min-throughput requires a non-negative number"},
 		{name: "heap", args: []string{"run", "--mock", "--max-heap-delta", "0"}, want: "--max-heap-delta requires a positive integer"},
 		{name: "bool", args: []string{"run", "--mock", "--expect-failure-threshold", "yes"}, want: "--expect-failure-threshold requires true or false"},
-		{name: "dry-run", args: []string{"run", "--dry-run", "--min-throughput", "1"}, want: "budget flags require --mock"},
+		{name: "dry-run", args: []string{"run", "--dry-run", "--min-throughput", "1"}, want: "budget flags require --mock or --wjx-http-dry-run"},
+		{name: "preview", args: []string{"run", "--wjx-http-preview", "--min-throughput", "1"}, want: "budget flags require --mock or --wjx-http-dry-run"},
 	}
 
 	for _, tt := range tests {

--- a/docs/development.md
+++ b/docs/development.md
@@ -52,6 +52,7 @@ go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --f
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --json
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --min-throughput 1 --max-goroutines 1
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events text
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events jsonl
 ```
@@ -63,6 +64,8 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 `--wjx-http-dry-run` 用于验证问卷星 HTTP 路径的完整本地执行闭环。它会经过 runner、worker pool、答案计划生成、HTTP pipeline 和本地 dry-run executor，输出成功数、完成数、吞吐、资源指标、draft 数量和首个 draft 详情；JSON 输出会包含完整 drafts。该命令仍然只使用本地 fixture，输出中会明确标注 `network: disabled (dry-run)`。需要观察进度时可以使用 `--events text` 或 `--events jsonl`，事件语义和 mock run 保持一致。
 
 `--target` 和 `--concurrency` 可以覆盖配置中的运行规模，用于本地压测和验证资源上限。覆盖后的计划仍会重新走 runner 校验，因此 `browser` 模式不会被临时参数放大到超过小池限制。
+
+性能预算参数目前支持 `--mock` 和 `--wjx-http-dry-run`，因为这两个入口都会产生完整 `RunPlanReport`。纯 `--dry-run` 和 `--wjx-http-preview` 不执行 runner，因此不会接受预算参数。
 
 常用压测入口见 [性能与压测](performance.md)。默认脚本会运行 1000 target / 1000 concurrency 的本地 mock；`-Json` 输出最终 JSON 汇总，`-FailEvery` 可验证失败阈值和停止行为。
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -89,12 +89,15 @@ go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --f
 ```powershell
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
+go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --min-throughput 1 --max-goroutines 1
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --events jsonl
 ```
 
 text 输出只展示汇总和首个 draft，避免高并发 dry-run 时刷屏；JSON 输出包含完整 `drafts`，适合脚本检查 answer plan 到 form 的稳定性。输出中的 `network: disabled (dry-run)` 是安全边界。
 
 `--events text|jsonl` 可用于观察 dry-run 期间的 runner 事件。高并发 profile 中建议优先使用 `--json` 汇总或脚本预算；事件流更适合小规模诊断和后续轻量 UI 订阅。
+
+WJX HTTP dry-run 支持和 mock run 相同的预算参数。预算失败时 CLI 会先输出 dry-run 报告，再以非零退出码返回失败原因，便于 CI 和脚本保留诊断信息。
 
 ## 预算断言
 


### PR DESCRIPTION
## Summary
- allow WJX HTTP dry-run to use the existing run budget flags
- preserve summary-first diagnostics before budget failures
- keep budget flags rejected for pure plan dry-run and WJX HTTP preview
- document WJX dry-run budget usage

## Validation
- go test ./cmd/surveyctl -run "TestRunWJXHTTPDryRunBudget|TestRunMockRunBudget|TestRunRejectsInvalidBudgetFlags" -count=1
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --min-throughput 0 --max-heap-delta 999999999 --max-goroutines 1000 --expect-failure-threshold false

Closes #139