### PR TITLE
[codex] Add WJX HTTP dry-run stress script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --f
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events jsonl
 .\scripts\mock-stress.ps1
+.\scripts\wjx-http-dryrun-stress.ps1
 go run ./cmd/surveyctl doctor
 go run ./cmd/surveyctl doctor browser
 ```
@@ -87,6 +88,8 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 .\scripts\mock-stress.ps1 -Json
 .\scripts\mock-stress.ps1 -MinThroughput 1 -MaxGoroutines 1
 .\scripts\mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2
+.\scripts\wjx-http-dryrun-stress.ps1
+.\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000 -Json
 .\scripts\verify-local.ps1
 ```
 
@@ -119,6 +122,7 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --min-throughput 1 --max-goroutines 1
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events text
+.\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000
 ```
 
 ## 开发节奏

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,6 +46,7 @@ go run ./cmd/surveyctl run --dry-run examples/run.yaml
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --seed 7
 .\scripts\mock-stress.ps1
+.\scripts\wjx-http-dryrun-stress.ps1
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events text
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
@@ -55,6 +56,7 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --min-throughput 1 --max-goroutines 1
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events text
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events jsonl
+.\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000 -Json
 ```
 
 `--dry-run` 用于验证配置能否编译成运行计划；`--mock` 会实际经过答案计划生成、worker pool、运行状态和事件输出，但 submitter 是本地 mock，不访问任何平台。
@@ -66,6 +68,8 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 `--target` 和 `--concurrency` 可以覆盖配置中的运行规模，用于本地压测和验证资源上限。覆盖后的计划仍会重新走 runner 校验，因此 `browser` 模式不会被临时参数放大到超过小池限制。
 
 性能预算参数目前支持 `--mock` 和 `--wjx-http-dry-run`，因为这两个入口都会产生完整 `RunPlanReport`。纯 `--dry-run` 和 `--wjx-http-preview` 不执行 runner，因此不会接受预算参数。
+
+`scripts/wjx-http-dryrun-stress.ps1` 是问卷星 HTTP dry-run 的专用压测入口。脚本内部仍调用 CLI 的本地 dry-run，不访问网络；默认输出压缩 summary，避免高并发时把所有 drafts 打到终端。
 
 常用压测入口见 [性能与压测](performance.md)。默认脚本会运行 1000 target / 1000 concurrency 的本地 mock；`-Json` 输出最终 JSON 汇总，`-FailEvery` 可验证失败阈值和停止行为。
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -91,6 +91,9 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --json
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --min-throughput 1 --max-goroutines 1
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --events jsonl
+.\scripts\wjx-http-dryrun-stress.ps1
+.\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000 -MinThroughput 1 -MaxGoroutines 1
+.\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000 -Json
 ```
 
 text 输出只展示汇总和首个 draft，避免高并发 dry-run 时刷屏；JSON 输出包含完整 `drafts`，适合脚本检查 answer plan 到 form 的稳定性。输出中的 `network: disabled (dry-run)` 是安全边界。
@@ -98,6 +101,8 @@ text 输出只展示汇总和首个 draft，避免高并发 dry-run 时刷屏；
 `--events text|jsonl` 可用于观察 dry-run 期间的 runner 事件。高并发 profile 中建议优先使用 `--json` 汇总或脚本预算；事件流更适合小规模诊断和后续轻量 UI 订阅。
 
 WJX HTTP dry-run 支持和 mock run 相同的预算参数。预算失败时 CLI 会先输出 dry-run 报告，再以非零退出码返回失败原因，便于 CI 和脚本保留诊断信息。
+
+脚本默认输出压缩后的 summary，包括成功数、失败数、吞吐、资源指标、draft 数量和首个 draft 的端点/答案数量；`-Json` 输出同样是压缩 summary，不会默认打印完整 drafts。
 
 ## 预算断言
 

--- a/scripts/wjx-http-dryrun-stress.ps1
+++ b/scripts/wjx-http-dryrun-stress.ps1
@@ -1,0 +1,153 @@
+param(
+    [string]$Config = "examples/wjx-http-preview.yaml",
+    [string]$Fixture = "internal/provider/wjx/testdata/survey.html",
+    [int]$Target = 1000,
+    [int]$Concurrency = 1000,
+    [int]$Seed = 7,
+    [double]$MinThroughput = 0,
+    [UInt64]$MaxHeapDelta = 0,
+    [int]$MaxGoroutines = 0,
+    [ValidateSet("", "true", "false")]
+    [string]$ExpectFailureThreshold = "",
+    [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($Target -le 0) {
+    throw "Target must be greater than 0."
+}
+if ($Concurrency -le 0) {
+    throw "Concurrency must be greater than 0."
+}
+if ($Seed -eq 0) {
+    throw "Seed must not be 0."
+}
+if ($MinThroughput -lt 0) {
+    throw "MinThroughput must not be negative."
+}
+if ($MaxGoroutines -lt 0) {
+    throw "MaxGoroutines must not be negative."
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$invariantCulture = [System.Globalization.CultureInfo]::InvariantCulture
+Push-Location $repoRoot
+try {
+    $surveyctlArgs = @(
+        "run",
+        "--wjx-http-dry-run",
+        $Config,
+        "--fixture",
+        $Fixture,
+        "--target",
+        $Target,
+        "--concurrency",
+        $Concurrency,
+        "--seed",
+        $Seed
+    )
+
+    if ($MinThroughput -gt 0) {
+        $surveyctlArgs += @("--min-throughput", $MinThroughput.ToString($invariantCulture))
+    }
+    if ($MaxHeapDelta -gt 0) {
+        $surveyctlArgs += @("--max-heap-delta", $MaxHeapDelta.ToString($invariantCulture))
+    }
+    if ($MaxGoroutines -gt 0) {
+        $surveyctlArgs += @("--max-goroutines", $MaxGoroutines)
+    }
+    if ($ExpectFailureThreshold -ne "") {
+        $surveyctlArgs += @("--expect-failure-threshold", $ExpectFailureThreshold)
+    }
+    $surveyctlArgs += "--json"
+
+    $raw = & go run ./cmd/surveyctl @surveyctlArgs
+    $exitCode = $LASTEXITCODE
+    $summary = $null
+    if ($raw) {
+        try {
+            $result = $raw | ConvertFrom-Json
+            $report = $result.report
+            $firstDraft = $null
+            if ($result.drafts.Count -gt 0) {
+                $firstDraft = $result.drafts[0]
+            }
+            $firstDraftEndpoint = ""
+            $firstDraftAnswerCount = 0
+            if ($null -ne $firstDraft) {
+                $firstDraftEndpoint = $firstDraft.endpoint
+                $firstDraftAnswerCount = $firstDraft.answer_count
+            }
+            $throughput = 0
+            $heapAllocDelta = 0
+            $totalAllocDelta = 0
+            if ($null -ne $report.throughput_per_second) {
+                $throughput = $report.throughput_per_second
+            }
+            if ($null -ne $report.heap_alloc_delta_bytes) {
+                $heapAllocDelta = $report.heap_alloc_delta_bytes
+            }
+            if ($null -ne $report.total_alloc_delta_bytes) {
+                $totalAllocDelta = $report.total_alloc_delta_bytes
+            }
+            $summary = [pscustomobject]@{
+                path = $result.path
+                fixture = $result.fixture
+                target = $report.target
+                concurrency = $report.concurrency
+                seed = $result.seed
+                successes = $report.successes
+                failures = $report.failures
+                completed = $report.completed
+                throughput_per_second = $throughput
+                heap_alloc_delta_bytes = $heapAllocDelta
+                total_alloc_delta_bytes = $totalAllocDelta
+                goroutines = $report.goroutines
+                failure_threshold_reached = $report.failure_threshold_reached
+                draft_count = $result.draft_count
+                first_draft_endpoint = $firstDraftEndpoint
+                first_draft_answer_count = $firstDraftAnswerCount
+                network = $result.network
+            }
+        }
+        catch {
+            $raw
+            exit $exitCode
+        }
+    }
+
+    if ($Json) {
+        if ($null -ne $summary) {
+            $summary | ConvertTo-Json -Depth 4
+        }
+    }
+    elseif ($null -ne $summary) {
+        Write-Host "wjx http dry-run stress:"
+        Write-Host "  target: $($summary.target)"
+        Write-Host "  concurrency: $($summary.concurrency)"
+        Write-Host "  successes: $($summary.successes)"
+        Write-Host "  failures: $($summary.failures)"
+        Write-Host "  completed: $($summary.completed)"
+        Write-Host "  throughput_per_second: $($summary.throughput_per_second)"
+        Write-Host "  heap_alloc_delta_bytes: $($summary.heap_alloc_delta_bytes)"
+        Write-Host "  total_alloc_delta_bytes: $($summary.total_alloc_delta_bytes)"
+        Write-Host "  goroutines: $($summary.goroutines)"
+        Write-Host "  failure_threshold_reached: $($summary.failure_threshold_reached)"
+        Write-Host "  draft_count: $($summary.draft_count)"
+        Write-Host "  first_draft_endpoint: $($summary.first_draft_endpoint)"
+        Write-Host "  first_draft_answer_count: $($summary.first_draft_answer_count)"
+        Write-Host "  network: $($summary.network)"
+    }
+    elseif ($raw) {
+        $raw
+    }
+
+    if ($exitCode -ne 0) {
+        exit $exitCode
+    }
+    exit 0
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add `scripts/wjx-http-dryrun-stress.ps1` for repeatable WJX HTTP dry-run stress profiles
- support target, concurrency, seed, and existing budget flags
- emit compact human and JSON summaries instead of dumping every recorded draft
- document the script in README, development, and performance docs

## Validation
- powershell -ExecutionPolicy Bypass -File scripts\wjx-http-dryrun-stress.ps1 -Target 2 -Concurrency 1
- powershell -ExecutionPolicy Bypass -File scripts\wjx-http-dryrun-stress.ps1 -Target 2 -Concurrency 1 -Json
- powershell -ExecutionPolicy Bypass -File scripts\wjx-http-dryrun-stress.ps1 -Target 1 -Concurrency 1
- powershell -ExecutionPolicy Bypass -File scripts\wjx-http-dryrun-stress.ps1 -Target 1 -Concurrency 1 -Json
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #141