### PR TITLE
[codex] Add WJX HTTP dry-run stress matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 .\scripts\mock-stress.ps1 -MinThroughput 1 -MaxGoroutines 1
 .\scripts\mock-stress.ps1 -Target 5 -Concurrency 1 -FailEvery 2
 .\scripts\wjx-http-dryrun-stress.ps1
+.\scripts\wjx-http-dryrun-stress-matrix.ps1 -SkipFull
 .\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000 -Json
 .\scripts\verify-local.ps1
 ```
@@ -123,6 +124,7 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --target 1000 --concurrency 1000 --min-throughput 1 --max-goroutines 1
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events text
 .\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000
+.\scripts\wjx-http-dryrun-stress-matrix.ps1
 ```
 
 ## 开发节奏

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,6 +47,7 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurrency 1000 --seed 7
 .\scripts\mock-stress.ps1
 .\scripts\wjx-http-dryrun-stress.ps1
+.\scripts\wjx-http-dryrun-stress-matrix.ps1 -SkipFull
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events text
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
@@ -57,6 +58,7 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events text
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --events jsonl
 .\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000 -Json
+.\scripts\wjx-http-dryrun-stress-matrix.ps1
 ```
 
 `--dry-run` 用于验证配置能否编译成运行计划；`--mock` 会实际经过答案计划生成、worker pool、运行状态和事件输出，但 submitter 是本地 mock，不访问任何平台。
@@ -70,6 +72,8 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 性能预算参数目前支持 `--mock` 和 `--wjx-http-dry-run`，因为这两个入口都会产生完整 `RunPlanReport`。纯 `--dry-run` 和 `--wjx-http-preview` 不执行 runner，因此不会接受预算参数。
 
 `scripts/wjx-http-dryrun-stress.ps1` 是问卷星 HTTP dry-run 的专用压测入口。脚本内部仍调用 CLI 的本地 dry-run，不访问网络；默认输出压缩 summary，避免高并发时把所有 drafts 打到终端。
+
+`scripts/wjx-http-dryrun-stress-matrix.ps1` 用于一次性跑 smoke、预算和可选 1000x1000 profile。日常快速检查可加 `-SkipFull`，完整 profile 留给发布前或专门性能验证。
 
 常用压测入口见 [性能与压测](performance.md)。默认脚本会运行 1000 target / 1000 concurrency 的本地 mock；`-Json` 输出最终 JSON 汇总，`-FailEvery` 可验证失败阈值和停止行为。
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -94,6 +94,8 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 .\scripts\wjx-http-dryrun-stress.ps1
 .\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000 -MinThroughput 1 -MaxGoroutines 1
 .\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000 -Json
+.\scripts\wjx-http-dryrun-stress-matrix.ps1 -SkipFull
+.\scripts\wjx-http-dryrun-stress-matrix.ps1
 ```
 
 text 输出只展示汇总和首个 draft，避免高并发 dry-run 时刷屏；JSON 输出包含完整 `drafts`，适合脚本检查 answer plan 到 form 的稳定性。输出中的 `network: disabled (dry-run)` 是安全边界。
@@ -103,6 +105,8 @@ text 输出只展示汇总和首个 draft，避免高并发 dry-run 时刷屏；
 WJX HTTP dry-run 支持和 mock run 相同的预算参数。预算失败时 CLI 会先输出 dry-run 报告，再以非零退出码返回失败原因，便于 CI 和脚本保留诊断信息。
 
 脚本默认输出压缩后的 summary，包括成功数、失败数、吞吐、资源指标、draft 数量和首个 draft 的端点/答案数量；`-Json` 输出同样是压缩 summary，不会默认打印完整 drafts。
+
+矩阵脚本会复用单 profile 脚本，默认包含 smoke、预算和 1000x1000 profile；`-SkipFull` 只跑轻量 profile，适合本地快速回归。
 
 ## 预算断言
 

--- a/scripts/wjx-http-dryrun-stress-matrix.ps1
+++ b/scripts/wjx-http-dryrun-stress-matrix.ps1
@@ -1,0 +1,59 @@
+param(
+    [string]$Config = "examples/wjx-http-preview.yaml",
+    [string]$Fixture = "internal/provider/wjx/testdata/survey.html",
+    [switch]$SkipFull
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$stressScript = Join-Path $PSScriptRoot "wjx-http-dryrun-stress.ps1"
+
+$profiles = @(
+    @{
+        Name = "smoke"
+        Args = @("-Config", $Config, "-Fixture", $Fixture, "-Target", "10", "-Concurrency", "2", "-MaxGoroutines", "8", "-Json")
+    },
+    @{
+        Name = "budget"
+        Args = @("-Config", $Config, "-Fixture", $Fixture, "-Target", "25", "-Concurrency", "5", "-MinThroughput", "1", "-MaxGoroutines", "8", "-ExpectFailureThreshold", "false", "-Json")
+    }
+)
+
+if (-not $SkipFull) {
+    $profiles += @{
+        Name = "1000x1000"
+        Args = @("-Config", $Config, "-Fixture", $Fixture, "-Target", "1000", "-Concurrency", "1000", "-MinThroughput", "1", "-MaxGoroutines", "8", "-ExpectFailureThreshold", "false", "-Json")
+    }
+}
+
+Push-Location $repoRoot
+try {
+    $rows = @()
+    foreach ($profile in $profiles) {
+        $output = & powershell -ExecutionPolicy Bypass -File $stressScript @($profile.Args)
+        if ($LASTEXITCODE -ne 0) {
+            throw "profile $($profile.Name) failed with exit code $LASTEXITCODE"
+        }
+        $summary = $output | ConvertFrom-Json
+        $rows += [pscustomobject]@{
+            profile = $profile.Name
+            target = $summary.target
+            concurrency = $summary.concurrency
+            successes = $summary.successes
+            failures = $summary.failures
+            completed = $summary.completed
+            throughput_per_second = $summary.throughput_per_second
+            heap_alloc_delta_bytes = $summary.heap_alloc_delta_bytes
+            total_alloc_delta_bytes = $summary.total_alloc_delta_bytes
+            goroutines = $summary.goroutines
+            failure_threshold_reached = $summary.failure_threshold_reached
+            draft_count = $summary.draft_count
+            network = $summary.network
+        }
+    }
+    $rows | Format-Table -AutoSize
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add `scripts/wjx-http-dryrun-stress-matrix.ps1`
- run WJX HTTP dry-run smoke and budget profiles by default
- support `-SkipFull` and a 1000x1000 full profile
- document matrix usage in README, development, and performance docs

## Validation
- powershell -ExecutionPolicy Bypass -File scripts\wjx-http-dryrun-stress-matrix.ps1 -SkipFull
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #143