### PR TITLE
[codex] Add WJX dry-run matrix to local verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 .\scripts\wjx-http-dryrun-stress-matrix.ps1 -SkipFull
 .\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000 -Json
 .\scripts\verify-local.ps1
+.\scripts\verify-local.ps1 -IncludeWJXHTTPDryRunStress
 ```
 
 mock 压测预算也可以直接走 CLI，例如：

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,6 +31,13 @@ gofmt -w (git ls-files '*.go')
 .\scripts\verify-local.ps1 -IncludeFullStress
 ```
 
+需要把问卷星 HTTP dry-run 矩阵也纳入本地验证时：
+
+```powershell
+.\scripts\verify-local.ps1 -IncludeWJXHTTPDryRunStress
+.\scripts\verify-local.ps1 -IncludeWJXHTTPDryRunStress -IncludeFullStress
+```
+
 如果只是快速检查 Go 代码、不跑压测：
 
 ```powershell

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -59,6 +59,13 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 .\scripts\verify-local.ps1 -IncludeFullStress
 ```
 
+要同时包含 WJX HTTP dry-run matrix：
+
+```powershell
+.\scripts\verify-local.ps1 -IncludeWJXHTTPDryRunStress
+.\scripts\verify-local.ps1 -IncludeWJXHTTPDryRunStress -IncludeFullStress
+```
+
 ## JSON 汇总
 
 脚本可输出单个 JSON 汇总，方便后续 CI 或轻量 GUI 读取：

--- a/scripts/verify-local.ps1
+++ b/scripts/verify-local.ps1
@@ -1,5 +1,6 @@
 param(
     [switch]$IncludeFullStress,
+    [switch]$IncludeWJXHTTPDryRunStress,
     [switch]$SkipStaticcheck,
     [switch]$SkipStress
 )
@@ -36,6 +37,18 @@ try {
             $stressArgs += "-SkipFull"
         }
         & powershell -ExecutionPolicy Bypass -File scripts/mock-stress-matrix.ps1 @stressArgs
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    }
+
+    if ($IncludeWJXHTTPDryRunStress) {
+        Write-Host "== wjx http dry-run stress matrix =="
+        $wjxStressArgs = @()
+        if (-not $IncludeFullStress) {
+            $wjxStressArgs += "-SkipFull"
+        }
+        & powershell -ExecutionPolicy Bypass -File scripts/wjx-http-dryrun-stress-matrix.ps1 @wjxStressArgs
         if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
         }


### PR DESCRIPTION
## Summary
- add `-IncludeWJXHTTPDryRunStress` to `scripts/verify-local.ps1`
- keep mock stress behavior unchanged by default
- reuse `-IncludeFullStress` to control the WJX 1000x1000 profile
- document local verification examples

## Validation
- powershell -ExecutionPolicy Bypass -File scripts\verify-local.ps1 -SkipStaticcheck -SkipStress -IncludeWJXHTTPDryRunStress
- powershell -ExecutionPolicy Bypass -File scripts\verify-local.ps1 -SkipStaticcheck -SkipStress -IncludeWJXHTTPDryRunStress -IncludeFullStress
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #145