### PR TITLE
[codex] Unify cross-platform PowerShell invocation

### DIFF
--- a/scripts/lib/powershell.ps1
+++ b/scripts/lib/powershell.ps1
@@ -1,0 +1,28 @@
+function Resolve-SurveyControllerPowerShell {
+    $command = Get-Command pwsh -ErrorAction SilentlyContinue
+    if ($null -eq $command) {
+        $command = Get-Command powershell -ErrorAction SilentlyContinue
+    }
+    if ($null -eq $command) {
+        throw "PowerShell executable was not found."
+    }
+    return $command
+}
+
+function New-SurveyControllerPowerShellFileArgs {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Command,
+        [Parameter(Mandatory = $true)]
+        [string]$File,
+        [object[]]$Arguments = @()
+    )
+
+    $commandArgs = @("-NoProfile")
+    if ($Command.Name -like "powershell*") {
+        $commandArgs += @("-ExecutionPolicy", "Bypass")
+    }
+    $commandArgs += @("-File", $File)
+    $commandArgs += $Arguments
+    return $commandArgs
+}

--- a/scripts/mock-stress-matrix.ps1
+++ b/scripts/mock-stress-matrix.ps1
@@ -7,6 +7,8 @@ $ErrorActionPreference = "Stop"
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $stressScript = Join-Path $PSScriptRoot "mock-stress.ps1"
+. (Join-Path $PSScriptRoot "lib/powershell.ps1")
+$powerShellCommand = Resolve-SurveyControllerPowerShell
 
 $profiles = @(
     @{
@@ -30,7 +32,8 @@ Push-Location $repoRoot
 try {
     $rows = @()
     foreach ($profile in $profiles) {
-        $output = & powershell -ExecutionPolicy Bypass -File $stressScript @($profile.Args)
+        $commandArgs = New-SurveyControllerPowerShellFileArgs -Command $powerShellCommand -File $stressScript -Arguments $profile.Args
+        $output = & $powerShellCommand.Source @commandArgs
         if ($LASTEXITCODE -ne 0) {
             throw "profile $($profile.Name) failed with exit code $LASTEXITCODE"
         }

--- a/scripts/verify-local.ps1
+++ b/scripts/verify-local.ps1
@@ -8,6 +8,8 @@ param(
 $ErrorActionPreference = "Stop"
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
+. (Join-Path $PSScriptRoot "lib/powershell.ps1")
+$powerShellCommand = Resolve-SurveyControllerPowerShell
 Push-Location $repoRoot
 try {
     Write-Host "== go test ./... =="
@@ -36,7 +38,8 @@ try {
         if (-not $IncludeFullStress) {
             $stressArgs += "-SkipFull"
         }
-        & powershell -ExecutionPolicy Bypass -File scripts/mock-stress-matrix.ps1 @stressArgs
+        $commandArgs = New-SurveyControllerPowerShellFileArgs -Command $powerShellCommand -File "scripts/mock-stress-matrix.ps1" -Arguments $stressArgs
+        & $powerShellCommand.Source @commandArgs
         if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
         }
@@ -48,7 +51,8 @@ try {
         if (-not $IncludeFullStress) {
             $wjxStressArgs += "-SkipFull"
         }
-        & powershell -ExecutionPolicy Bypass -File scripts/wjx-http-dryrun-stress-matrix.ps1 @wjxStressArgs
+        $commandArgs = New-SurveyControllerPowerShellFileArgs -Command $powerShellCommand -File "scripts/wjx-http-dryrun-stress-matrix.ps1" -Arguments $wjxStressArgs
+        & $powerShellCommand.Source @commandArgs
         if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
         }

--- a/scripts/wjx-http-dryrun-stress-matrix.ps1
+++ b/scripts/wjx-http-dryrun-stress-matrix.ps1
@@ -8,13 +8,8 @@ $ErrorActionPreference = "Stop"
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $stressScript = Join-Path $PSScriptRoot "wjx-http-dryrun-stress.ps1"
-$powerShellCommand = Get-Command pwsh -ErrorAction SilentlyContinue
-if ($null -eq $powerShellCommand) {
-    $powerShellCommand = Get-Command powershell -ErrorAction SilentlyContinue
-}
-if ($null -eq $powerShellCommand) {
-    throw "PowerShell executable was not found."
-}
+. (Join-Path $PSScriptRoot "lib/powershell.ps1")
+$powerShellCommand = Resolve-SurveyControllerPowerShell
 
 $profiles = @(
     @{
@@ -38,12 +33,7 @@ Push-Location $repoRoot
 try {
     $rows = @()
     foreach ($profile in $profiles) {
-        $commandArgs = @("-NoProfile")
-        if ($powerShellCommand.Name -like "powershell*") {
-            $commandArgs += @("-ExecutionPolicy", "Bypass")
-        }
-        $commandArgs += @("-File", $stressScript)
-        $commandArgs += $profile.Args
+        $commandArgs = New-SurveyControllerPowerShellFileArgs -Command $powerShellCommand -File $stressScript -Arguments $profile.Args
         $output = & $powerShellCommand.Source @commandArgs
         if ($LASTEXITCODE -ne 0) {
             throw "profile $($profile.Name) failed with exit code $LASTEXITCODE"


### PR DESCRIPTION
## Summary
- add `scripts/lib/powershell.ps1` for resolving `pwsh` or Windows PowerShell
- update mock and WJX stress matrix scripts to use the helper
- update `verify-local.ps1` child script calls to use the helper
- keep script behavior unchanged on Windows while supporting Linux/macOS CI runners

## Validation
- powershell -ExecutionPolicy Bypass -File scripts\mock-stress-matrix.ps1 -SkipFull
- powershell -ExecutionPolicy Bypass -File scripts\wjx-http-dryrun-stress-matrix.ps1 -SkipFull
- powershell -ExecutionPolicy Bypass -File scripts\verify-local.ps1 -SkipStaticcheck -SkipStress -IncludeWJXHTTPDryRunStress
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #149