### PR TITLE
[codex] Add verify-local smoke mode for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
       - name: 运行 staticcheck
         run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
 
-      - name: 运行 WJX HTTP dry-run smoke
+      - name: 运行本地验证 smoke
         shell: pwsh
-        run: ./scripts/wjx-http-dryrun-stress-matrix.ps1 -SkipFull
+        run: ./scripts/verify-local.ps1 -SkipGoChecks -SkipStaticcheck -SkipStress -IncludeWJXHTTPDryRunStress
 
   race:
     name: 竞态检查

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,6 +44,12 @@ gofmt -w (git ls-files '*.go')
 .\scripts\verify-local.ps1 -SkipStress
 ```
 
+CI smoke 会复用同一个入口，但跳过已由 CI 前置步骤覆盖的 Go 检查：
+
+```powershell
+.\scripts\verify-local.ps1 -SkipGoChecks -SkipStaticcheck -SkipStress -IncludeWJXHTTPDryRunStress
+```
+
 ## 运行预览
 
 `surveyctl run` 当前只开放不会访问网络的预览能力：

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -66,6 +66,8 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 .\scripts\verify-local.ps1 -IncludeWJXHTTPDryRunStress -IncludeFullStress
 ```
 
+CI 使用 `-SkipGoChecks` 跑轻量 smoke，避免重复执行已经单独跑过的 Go 检查，同时覆盖本地验证脚本的编排逻辑。
+
 ## JSON 汇总
 
 脚本可输出单个 JSON 汇总，方便后续 CI 或轻量 GUI 读取：

--- a/scripts/verify-local.ps1
+++ b/scripts/verify-local.ps1
@@ -1,6 +1,7 @@
 param(
     [switch]$IncludeFullStress,
     [switch]$IncludeWJXHTTPDryRunStress,
+    [switch]$SkipGoChecks,
     [switch]$SkipStaticcheck,
     [switch]$SkipStress
 )
@@ -12,19 +13,21 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 $powerShellCommand = Resolve-SurveyControllerPowerShell
 Push-Location $repoRoot
 try {
-    Write-Host "== go test ./... =="
-    & go test ./...
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
+    if (-not $SkipGoChecks) {
+        Write-Host "== go test ./... =="
+        & go test ./...
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+
+        Write-Host "== go vet ./... =="
+        & go vet ./...
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
     }
 
-    Write-Host "== go vet ./... =="
-    & go vet ./...
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
-    }
-
-    if (-not $SkipStaticcheck) {
+    if (-not $SkipGoChecks -and -not $SkipStaticcheck) {
         Write-Host "== staticcheck ./... =="
         & go run honnef.co/go/tools/cmd/staticcheck@latest ./...
         if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
## Summary
- add `-SkipGoChecks` to `scripts/verify-local.ps1`
- route CI smoke through `verify-local.ps1` instead of calling the WJX matrix directly
- keep default local verification behavior unchanged
- document the smoke-mode command

## Validation
- powershell -ExecutionPolicy Bypass -File scripts\verify-local.ps1 -SkipGoChecks -SkipStaticcheck -SkipStress -IncludeWJXHTTPDryRunStress
- powershell -ExecutionPolicy Bypass -File scripts\verify-local.ps1 -SkipStaticcheck -SkipStress -IncludeWJXHTTPDryRunStress
- go test ./...
- go vet ./...
- git diff --check
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #151