### PR TITLE
[codex] Add local survey link extraction core

### DIFF
--- a/internal/linkextract/extract.go
+++ b/internal/linkextract/extract.go
@@ -1,0 +1,79 @@
+package linkextract
+
+import (
+	"html"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/LING71671/SurveyController-Go/internal/domain"
+	"github.com/LING71671/SurveyController-Go/internal/provider/builtin"
+)
+
+var httpURLRE = regexp.MustCompile("(?i)https?://[^\\s<>\"'`]+")
+
+type Candidate struct {
+	Raw      string            `json:"raw"`
+	URL      string            `json:"url"`
+	Provider domain.ProviderID `json:"provider"`
+}
+
+func Extract(text string) []Candidate {
+	text = html.UnescapeString(strings.TrimSpace(text))
+	if text == "" {
+		return nil
+	}
+
+	matches := httpURLRE.FindAllString(text, -1)
+	candidates := make([]Candidate, 0, len(matches))
+	seen := map[string]struct{}{}
+	for _, match := range matches {
+		raw := strings.TrimSpace(match)
+		normalized, ok := normalizeURL(raw)
+		if !ok {
+			continue
+		}
+		providerID, ok := builtin.DetectProvider(normalized)
+		if !ok {
+			continue
+		}
+		key := strings.ToLower(normalized)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		candidates = append(candidates, Candidate{
+			Raw:      raw,
+			URL:      normalized,
+			Provider: providerID,
+		})
+	}
+	return candidates
+}
+
+func First(text string) (Candidate, bool) {
+	candidates := Extract(text)
+	if len(candidates) == 0 {
+		return Candidate{}, false
+	}
+	return candidates[0], true
+}
+
+func normalizeURL(raw string) (string, bool) {
+	candidate := strings.TrimSpace(raw)
+	for candidate != "" {
+		candidate = strings.TrimRight(candidate, trailingURLPunctuation)
+		parsed, err := url.Parse(candidate)
+		if err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Hostname() != "" {
+			return parsed.String(), true
+		}
+		next := strings.TrimRight(candidate, trailingURLPunctuation)
+		if next == candidate {
+			return "", false
+		}
+		candidate = next
+	}
+	return "", false
+}
+
+const trailingURLPunctuation = ".,;:!?)]}>\"'`，。；：！？）】》、"

--- a/internal/linkextract/extract_test.go
+++ b/internal/linkextract/extract_test.go
@@ -1,0 +1,65 @@
+package linkextract
+
+import (
+	"testing"
+
+	"github.com/LING71671/SurveyController-Go/internal/domain"
+)
+
+func TestExtractFindsSupportedSurveyLinks(t *testing.T) {
+	text := `扫码文本：
+问卷星 https://www.wjx.cn/vm/example.aspx?from=qr。
+腾讯 https://wj.qq.com/s2/123456/hash?source=copy
+Credamo https://www.credamo.com/answer.html#/s/demo）`
+
+	got := Extract(text)
+	if len(got) != 3 {
+		t.Fatalf("Extract() returned %d candidates, want 3: %+v", len(got), got)
+	}
+	assertCandidate(t, got[0], domain.ProviderWJX, "https://www.wjx.cn/vm/example.aspx?from=qr")
+	assertCandidate(t, got[1], domain.ProviderTencent, "https://wj.qq.com/s2/123456/hash?source=copy")
+	assertCandidate(t, got[2], domain.ProviderCredamo, "https://www.credamo.com/answer.html#/s/demo")
+}
+
+func TestExtractSkipsUnsupportedAndInvalidURLs(t *testing.T) {
+	text := `noise https://example.com/survey https:// / not-url`
+
+	got := Extract(text)
+	if len(got) != 0 {
+		t.Fatalf("Extract() = %+v, want no supported candidates", got)
+	}
+}
+
+func TestExtractUnescapesHTMLAndDeduplicates(t *testing.T) {
+	text := `href="https://www.wjx.cn/vm/example.aspx?x=1&amp;y=2" copy https://www.wjx.cn/vm/example.aspx?x=1&y=2`
+
+	got := Extract(text)
+	if len(got) != 1 {
+		t.Fatalf("Extract() returned %d candidates, want 1: %+v", len(got), got)
+	}
+	assertCandidate(t, got[0], domain.ProviderWJX, "https://www.wjx.cn/vm/example.aspx?x=1&y=2")
+}
+
+func TestFirstReturnsFirstCandidate(t *testing.T) {
+	got, ok := First(`unsupported https://example.com then https://wj.qq.com/s2/123/hash`)
+	if !ok {
+		t.Fatal("First() returned ok=false, want true")
+	}
+	assertCandidate(t, got, domain.ProviderTencent, "https://wj.qq.com/s2/123/hash")
+}
+
+func TestFirstReturnsFalseForEmptyInput(t *testing.T) {
+	if got, ok := First("   "); ok {
+		t.Fatalf("First(empty) = (%+v, true), want false", got)
+	}
+}
+
+func assertCandidate(t *testing.T, got Candidate, wantProvider domain.ProviderID, wantURL string) {
+	t.Helper()
+	if got.Provider != wantProvider || got.URL != wantURL {
+		t.Fatalf("candidate = %+v, want provider %q url %q", got, wantProvider, wantURL)
+	}
+	if got.Raw == "" {
+		t.Fatal("candidate raw is empty")
+	}
+}


### PR DESCRIPTION
## Summary
- add a pure local link extraction package for pasted text and decoded QR text
- detect supported survey providers through the existing builtin provider registry
- cover punctuation trimming, HTML escaping, duplicates, unsupported URLs, and first-candidate lookup

## Validation
- git diff --check
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #157