### PR TITLE
[codex] Auto-detect provider for config generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ go vet ./...
 go run ./cmd/surveyctl version
 go run ./cmd/surveyctl link extract --text "https://www.wjx.cn/vm/example.aspx"
 go run ./cmd/surveyctl config validate examples/run.yaml
-go run ./cmd/surveyctl config generate --provider wjx --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx
+go run ./cmd/surveyctl config generate --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx
 go run ./cmd/surveyctl run --dry-run examples/run.yaml
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl

--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LING71671/SurveyController-Go/internal/domain"
 	"github.com/LING71671/SurveyController-Go/internal/linkextract"
 	"github.com/LING71671/SurveyController-Go/internal/logging"
+	"github.com/LING71671/SurveyController-Go/internal/provider/builtin"
 	"github.com/LING71671/SurveyController-Go/internal/provider/credamo"
 	"github.com/LING71671/SurveyController-Go/internal/provider/tencent"
 	"github.com/LING71671/SurveyController-Go/internal/provider/wjx"
@@ -31,7 +32,7 @@ Usage:
   surveyctl version
   surveyctl link extract [path] [--text <value>] [--json]
   surveyctl config validate [path]
-  surveyctl config generate --provider <id> --fixture <path> --url <url>
+  surveyctl config generate [--provider <id|auto>] --fixture <path> --url <url>
   surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
   surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>] [--min-throughput <n>] [--max-heap-delta <bytes>] [--max-goroutines <n>] [--expect-failure-threshold <true|false>]
   surveyctl run --wjx-http-preview [path] --fixture <html> [--json] [--seed <n>] [--target <n>] [--concurrency <n>]
@@ -51,7 +52,7 @@ Commands:
 
 const configUsage = `Usage:
   surveyctl config validate [path]
-  surveyctl config generate --provider <id> --fixture <path> --url <url>
+  surveyctl config generate [--provider <id|auto>] --fixture <path> --url <url>
 `
 
 const linkUsage = `Usage:
@@ -276,9 +277,6 @@ func runConfigGenerate(args []string, stdout io.Writer) error {
 			return usageError(fmt.Sprintf("unknown config generate argument %q", arg), configUsage)
 		}
 	}
-	if strings.TrimSpace(providerID) == "" {
-		return usageError("config generate requires --provider", configUsage)
-	}
 	if strings.TrimSpace(fixturePath) == "" {
 		return usageError("config generate requires --fixture", configUsage)
 	}
@@ -299,7 +297,7 @@ func runConfigGenerate(args []string, stdout io.Writer) error {
 }
 
 func generateConfigFromFixture(providerID string, fixturePath string, rawURL string) (config.RunConfig, error) {
-	id, err := domain.ParseProviderID(providerID)
+	id, err := resolveConfigGenerateProvider(providerID, rawURL)
 	if err != nil {
 		return config.RunConfig{}, err
 	}
@@ -325,6 +323,18 @@ func generateConfigFromFixture(providerID string, fixturePath string, rawURL str
 	}
 	survey.URL = strings.TrimSpace(rawURL)
 	return config.FromSurveyDefinition(survey)
+}
+
+func resolveConfigGenerateProvider(providerID string, rawURL string) (domain.ProviderID, error) {
+	trimmed := strings.TrimSpace(providerID)
+	if trimmed != "" && !strings.EqualFold(trimmed, "auto") {
+		return domain.ParseProviderID(trimmed)
+	}
+	id, ok := builtin.DetectProvider(rawURL)
+	if !ok {
+		return domain.ProviderUnknown, fmt.Errorf("detect provider from url %q: unsupported provider", rawURL)
+	}
+	return id, nil
 }
 
 func parseWJXFixture(fixturePath string, rawURL string) (domain.SurveyDefinition, error) {

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -206,19 +206,45 @@ func TestRunConfigGenerateFromFixtures(t *testing.T) {
 	}
 }
 
-func TestRunConfigGenerateRequiresProvider(t *testing.T) {
+func TestRunConfigGenerateDetectsProviderFromURL(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	fixture := filepath.Join("..", "..", "internal", "provider", "wjx", "testdata", "survey.html")
 
-	code := run([]string{"config", "generate", "--fixture", "survey.html", "--url", "https://example.com"}, &stdout, &stderr)
-	if code != exitUsage {
-		t.Fatalf("run(config generate missing provider) exit code = %d, want %d", code, exitUsage)
+	code := run([]string{"config", "generate", "--fixture", fixture, "--url", "https://www.wjx.cn/vm/example.aspx"}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(config generate auto provider) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "requires --provider") {
-		t.Fatalf("stderr = %q, want provider requirement", stderr.String())
+	var cfg config.RunConfig
+	if err := yaml.Unmarshal(stdout.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode generated yaml: %v; output=%q", err, stdout.String())
 	}
-	if stdout.Len() != 0 {
-		t.Fatalf("stdout = %q, want empty", stdout.String())
+	if cfg.Survey.Provider != "wjx" || cfg.Survey.URL != "https://www.wjx.cn/vm/example.aspx" {
+		t.Fatalf("Survey = %+v, want detected wjx provider", cfg.Survey)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunConfigGenerateAcceptsAutoProvider(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	fixture := filepath.Join("..", "..", "internal", "provider", "tencent", "testdata", "survey_api.json")
+
+	code := run([]string{"config", "generate", "--provider", "auto", "--fixture", fixture, "--url", "https://wj.qq.com/s2/example"}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(config generate provider auto) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	var cfg config.RunConfig
+	if err := yaml.Unmarshal(stdout.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode generated yaml: %v; output=%q", err, stdout.String())
+	}
+	if cfg.Survey.Provider != "tencent" {
+		t.Fatalf("Survey.Provider = %q, want tencent", cfg.Survey.Provider)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }
 
@@ -229,6 +255,22 @@ func TestRunConfigGenerateRejectsUnsupportedProvider(t *testing.T) {
 	code := run([]string{"config", "generate", "--provider", "nope", "--fixture", "survey.html", "--url", "https://example.com"}, &stdout, &stderr)
 	if code != exitFailure {
 		t.Fatalf("run(config generate unsupported provider) exit code = %d, want %d", code, exitFailure)
+	}
+	if !strings.Contains(stderr.String(), "unsupported provider") {
+		t.Fatalf("stderr = %q, want unsupported provider", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunConfigGenerateRejectsUnknownAutoProviderURL(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := run([]string{"config", "generate", "--fixture", "survey.html", "--url", "https://example.com"}, &stdout, &stderr)
+	if code != exitFailure {
+		t.Fatalf("run(config generate unknown auto provider) exit code = %d, want %d", code, exitFailure)
 	}
 	if !strings.Contains(stderr.String(), "unsupported provider") {
 		t.Fatalf("stderr = %q, want unsupported provider", stderr.String())

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,6 +64,8 @@ go run ./cmd/surveyctl link extract .\example-survey\qr.txt --json
 
 这一步适合作为配置生成前的轻量预检。后续如果要支持图片二维码，应作为可选能力进入，不影响 core 的纯文本路径。
 
+`surveyctl config generate` 会在未传 `--provider` 或传入 `--provider auto` 时根据 `--url` 自动识别平台。显式传入 `--provider wjx|tencent|credamo` 时仍以显式值为准，方便调试 fixture。
+
 ## 运行预览
 
 `surveyctl run` 当前只开放不会访问网络的预览能力：


### PR DESCRIPTION
## Summary
- allow `surveyctl config generate` to infer provider from `--url`
- keep `--provider auto` and explicit provider overrides supported
- document the lighter config generation flow

## Validation
- git diff --check
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- go run ./cmd/surveyctl config generate --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx

Closes #161