### PR TITLE
[codex] Expand pure text answer strategy helpers

### DIFF
--- a/internal/answer/text.go
+++ b/internal/answer/text.go
@@ -3,6 +3,7 @@ package answer
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strings"
 )
 
@@ -13,11 +14,28 @@ type TextRule struct {
 	Separator string
 }
 
+type DigitsRule struct {
+	Length int
+	Prefix string
+}
+
+type PhoneRule struct {
+	Prefixes []string
+}
+
+type TemplateRule struct {
+	Template string
+	Slots    map[string][]string
+}
+
+var templateSlotRE = regexp.MustCompile(`\{([A-Za-z0-9_]+)\}`)
+
 func RandomText(rng *rand.Rand, rule TextRule) (string, error) {
 	if rng == nil {
 		return "", fmt.Errorf("rng is required")
 	}
-	if len(rule.Words) == 0 {
+	ruleWords := cleanWords(rule.Words)
+	if len(ruleWords) == 0 {
 		return "", fmt.Errorf("words are required")
 	}
 	min := rule.MinWords
@@ -42,10 +60,7 @@ func RandomText(rng *rand.Rand, rule TextRule) (string, error) {
 	}
 	words := make([]string, 0, count)
 	for len(words) < count {
-		candidate := strings.TrimSpace(rule.Words[rng.Intn(len(rule.Words))])
-		if candidate != "" {
-			words = append(words, candidate)
-		}
+		words = append(words, ruleWords[rng.Intn(len(ruleWords))])
 	}
 	return strings.Join(words, separator), nil
 }
@@ -61,4 +76,87 @@ func RandomInt(rng *rand.Rand, min int, max int) (int, error) {
 		return min, nil
 	}
 	return min + rng.Intn(max-min+1), nil
+}
+
+func RandomDigits(rng *rand.Rand, rule DigitsRule) (string, error) {
+	if rng == nil {
+		return "", fmt.Errorf("rng is required")
+	}
+	if rule.Length <= 0 {
+		return "", fmt.Errorf("length must be positive")
+	}
+	prefix := strings.TrimSpace(rule.Prefix)
+	if !isDigits(prefix) {
+		return "", fmt.Errorf("prefix must contain only digits")
+	}
+	if len(prefix) > rule.Length {
+		return "", fmt.Errorf("prefix length must not exceed length")
+	}
+	builder := strings.Builder{}
+	builder.Grow(rule.Length)
+	builder.WriteString(prefix)
+	for builder.Len() < rule.Length {
+		builder.WriteByte(byte('0' + rng.Intn(10)))
+	}
+	return builder.String(), nil
+}
+
+func RandomPhoneLike(rng *rand.Rand, rule PhoneRule) (string, error) {
+	if rng == nil {
+		return "", fmt.Errorf("rng is required")
+	}
+	prefixes := cleanWords(rule.Prefixes)
+	if len(prefixes) == 0 {
+		prefixes = []string{"130", "131", "132", "155", "156", "185", "186"}
+	}
+	for _, prefix := range prefixes {
+		if len(prefix) >= 11 || !isDigits(prefix) {
+			return "", fmt.Errorf("phone prefix %q must be digits shorter than 11", prefix)
+		}
+	}
+	prefix := prefixes[rng.Intn(len(prefixes))]
+	return RandomDigits(rng, DigitsRule{Length: 11, Prefix: prefix})
+}
+
+func RandomTemplateText(rng *rand.Rand, rule TemplateRule) (string, error) {
+	if rng == nil {
+		return "", fmt.Errorf("rng is required")
+	}
+	template := strings.TrimSpace(rule.Template)
+	if template == "" {
+		return "", fmt.Errorf("template is required")
+	}
+	result := templateSlotRE.ReplaceAllStringFunc(template, func(match string) string {
+		name := strings.TrimSuffix(strings.TrimPrefix(match, "{"), "}")
+		values := cleanWords(rule.Slots[name])
+		if len(values) == 0 {
+			return match
+		}
+		return values[rng.Intn(len(values))]
+	})
+	missing := templateSlotRE.FindAllString(result, -1)
+	if len(missing) > 0 {
+		return "", fmt.Errorf("template slot %s has no values", missing[0])
+	}
+	return result, nil
+}
+
+func cleanWords(words []string) []string {
+	cleaned := make([]string, 0, len(words))
+	for _, word := range words {
+		word = strings.TrimSpace(word)
+		if word != "" {
+			cleaned = append(cleaned, word)
+		}
+	}
+	return cleaned
+}
+
+func isDigits(value string) bool {
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/answer/text_test.go
+++ b/internal/answer/text_test.go
@@ -29,6 +29,7 @@ func TestRandomTextRejectsInvalidRules(t *testing.T) {
 		want string
 	}{
 		{name: "words", rule: TextRule{}, want: "words"},
+		{name: "blank words", rule: TextRule{Words: []string{" ", "\t"}}, want: "words"},
 		{name: "range", rule: TextRule{Words: []string{"a"}, MinWords: 3, MaxWords: 2}, want: "min words"},
 	}
 
@@ -37,6 +38,105 @@ func TestRandomTextRejectsInvalidRules(t *testing.T) {
 			_, err := RandomText(rand.New(rand.NewSource(1)), tt.rule)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("RandomText() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRandomDigits(t *testing.T) {
+	got, err := RandomDigits(rand.New(rand.NewSource(1)), DigitsRule{Length: 8, Prefix: "42"})
+	if err != nil {
+		t.Fatalf("RandomDigits() returned error: %v", err)
+	}
+	if len(got) != 8 || !strings.HasPrefix(got, "42") {
+		t.Fatalf("RandomDigits() = %q, want 8 digits with prefix 42", got)
+	}
+	for _, char := range got {
+		if char < '0' || char > '9' {
+			t.Fatalf("RandomDigits() = %q, want digits only", got)
+		}
+	}
+}
+
+func TestRandomDigitsRejectsInvalidRules(t *testing.T) {
+	tests := []struct {
+		name string
+		rule DigitsRule
+		want string
+	}{
+		{name: "length", rule: DigitsRule{}, want: "length"},
+		{name: "prefix chars", rule: DigitsRule{Length: 4, Prefix: "ab"}, want: "prefix"},
+		{name: "prefix too long", rule: DigitsRule{Length: 2, Prefix: "123"}, want: "prefix length"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := RandomDigits(rand.New(rand.NewSource(1)), tt.rule)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("RandomDigits() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRandomPhoneLike(t *testing.T) {
+	got, err := RandomPhoneLike(rand.New(rand.NewSource(1)), PhoneRule{Prefixes: []string{"177"}})
+	if err != nil {
+		t.Fatalf("RandomPhoneLike() returned error: %v", err)
+	}
+	if len(got) != 11 || !strings.HasPrefix(got, "177") {
+		t.Fatalf("RandomPhoneLike() = %q, want 11 digits with prefix 177", got)
+	}
+}
+
+func TestRandomPhoneLikeUsesDefaultPrefixes(t *testing.T) {
+	got, err := RandomPhoneLike(rand.New(rand.NewSource(1)), PhoneRule{})
+	if err != nil {
+		t.Fatalf("RandomPhoneLike(default) returned error: %v", err)
+	}
+	if len(got) != 11 {
+		t.Fatalf("RandomPhoneLike(default) = %q, want 11 digits", got)
+	}
+}
+
+func TestRandomPhoneLikeRejectsInvalidPrefix(t *testing.T) {
+	_, err := RandomPhoneLike(rand.New(rand.NewSource(1)), PhoneRule{Prefixes: []string{"phone"}})
+	if err == nil || !strings.Contains(err.Error(), "prefix") {
+		t.Fatalf("RandomPhoneLike() error = %v, want prefix error", err)
+	}
+}
+
+func TestRandomTemplateText(t *testing.T) {
+	got, err := RandomTemplateText(rand.New(rand.NewSource(1)), TemplateRule{
+		Template: "from {city} as {role}",
+		Slots: map[string][]string{
+			"city": {"shanghai", "hangzhou"},
+			"role": {"student"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RandomTemplateText() returned error: %v", err)
+	}
+	if !strings.HasPrefix(got, "from ") || strings.Contains(got, "{") {
+		t.Fatalf("RandomTemplateText() = %q, want rendered template", got)
+	}
+}
+
+func TestRandomTemplateTextRejectsInvalidRules(t *testing.T) {
+	tests := []struct {
+		name string
+		rule TemplateRule
+		want string
+	}{
+		{name: "template", rule: TemplateRule{}, want: "template"},
+		{name: "slot", rule: TemplateRule{Template: "hello {name}"}, want: "slot"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := RandomTemplateText(rand.New(rand.NewSource(1)), tt.rule)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("RandomTemplateText() error = %v, want %q", err, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add pure helpers for random digit strings, phone-like strings, and templated text
- make `RandomText` reject blank-only word pools instead of spinning
- cover validation, deterministic rng input, and default phone prefixes

## Validation
- git diff --check
- go test ./internal/answer
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #163