### PR TITLE
[codex] Add local validation for link and config flow

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -28,6 +28,8 @@ gofmt -w (git ls-files '*.go')
 
 默认会执行 `go test ./...`、`go vet ./...`、`staticcheck` 和轻量 mock stress matrix。需要完整 1000 并发 profile 时：
 
+默认验证还会运行一个本地 CLI smoke，覆盖 `surveyctl link extract` 和 `surveyctl config generate` 的 provider 自动识别链路。这个 smoke 不访问网络，只使用内置 fixture。
+
 ```powershell
 .\scripts\verify-local.ps1 -IncludeFullStress
 ```

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -31,12 +31,14 @@ pwsh -File scripts/verify-local.ps1
 - `go test ./...`
 - `go vet ./...`
 - `staticcheck ./...`
+- CLI local precheck smoke：`link extract` + `config generate` provider auto-detection
 - 轻量 mock stress matrix
 
 常用参数：
 
 ```powershell
 .\scripts\verify-local.ps1 -SkipStress
+.\scripts\verify-local.ps1 -SkipCLISmoke
 .\scripts\verify-local.ps1 -SkipStaticcheck
 .\scripts\verify-local.ps1 -IncludeFullStress
 .\scripts\verify-local.ps1 -IncludeWJXHTTPDryRunStress
@@ -49,7 +51,7 @@ CI smoke 使用：
 .\scripts\verify-local.ps1 -SkipGoChecks -SkipStaticcheck -SkipStress -IncludeWJXHTTPDryRunStress
 ```
 
-`-SkipGoChecks` 只用于上层流程已经单独跑过 Go 检查的场景，例如 CI quality job。普通本地提交前不建议跳过 Go 检查。
+`-SkipGoChecks` 只用于上层流程已经单独跑过 Go 检查的场景，例如 CI quality job。普通本地提交前不建议跳过 Go 检查。`-SkipCLISmoke` 会跳过链接预检和配置生成的 CLI smoke，通常只在调试脚本自身时使用。
 
 ## mock-stress.ps1
 
@@ -106,6 +108,7 @@ CI smoke 使用：
 
 - 日常提交前：`.\scripts\verify-local.ps1`
 - 只看 Go 代码：`.\scripts\verify-local.ps1 -SkipStress`
+- 只跳过 CLI smoke：`.\scripts\verify-local.ps1 -SkipCLISmoke`
 - WJX dry-run 快速回归：`.\scripts\verify-local.ps1 -IncludeWJXHTTPDryRunStress`
 - 发布前性能检查：`.\scripts\verify-local.ps1 -IncludeWJXHTTPDryRunStress -IncludeFullStress`
 - 调试单个 profile：直接运行对应的 `*-stress.ps1`

--- a/scripts/verify-local.ps1
+++ b/scripts/verify-local.ps1
@@ -2,6 +2,7 @@ param(
     [switch]$IncludeFullStress,
     [switch]$IncludeWJXHTTPDryRunStress,
     [switch]$SkipGoChecks,
+    [switch]$SkipCLISmoke,
     [switch]$SkipStaticcheck,
     [switch]$SkipStress
 )
@@ -32,6 +33,27 @@ try {
         & go run honnef.co/go/tools/cmd/staticcheck@latest ./...
         if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
+        }
+    }
+
+    if (-not $SkipCLISmoke) {
+        Write-Host "== cli local precheck smoke =="
+        $surveyURL = "https://www.wjx.cn/vm/example.aspx"
+        $linkOutput = & go run ./cmd/surveyctl link extract --text $surveyURL --json
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+        $linkSummary = $linkOutput | ConvertFrom-Json
+        if ($linkSummary.count -ne 1 -or $linkSummary.links[0].provider -ne "wjx" -or $linkSummary.network -ne "disabled (local extract)") {
+            Write-Error "unexpected link extract output: $linkOutput"
+        }
+
+        $configOutput = & go run ./cmd/surveyctl config generate --fixture internal/provider/wjx/testdata/survey.html --url $surveyURL
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+        if (($configOutput -join "`n") -notmatch "provider:\s*wjx") {
+            Write-Error "generated config did not contain provider: wjx"
         }
     }
 


### PR DESCRIPTION
## Summary
- add a fast CLI local precheck smoke to `verify-local.ps1`
- cover `surveyctl link extract` and provider auto-detection in `config generate`
- document the smoke and `-SkipCLISmoke` escape hatch

## Validation
- git diff --check
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- ./scripts/verify-local.ps1 -SkipGoChecks -SkipStaticcheck -SkipStress
- ./scripts/verify-local.ps1 -SkipStress

Closes #165