### PR TITLE
[codex] Wire text answers into answer plans

### DIFF
--- a/internal/answer/text.go
+++ b/internal/answer/text.go
@@ -28,7 +28,59 @@ type TemplateRule struct {
 	Slots    map[string][]string
 }
 
+type TextAnswerMode string
+
+const (
+	TextAnswerModeFixed    TextAnswerMode = "fixed"
+	TextAnswerModeWords    TextAnswerMode = "words"
+	TextAnswerModeDigits   TextAnswerMode = "digits"
+	TextAnswerModePhone    TextAnswerMode = "phone"
+	TextAnswerModeTemplate TextAnswerMode = "template"
+)
+
+type TextAnswerRule struct {
+	Mode     TextAnswerMode
+	Values   []string
+	Words    TextRule
+	Digits   DigitsRule
+	Phone    PhoneRule
+	Template TemplateRule
+}
+
 var templateSlotRE = regexp.MustCompile(`\{([A-Za-z0-9_]+)\}`)
+
+func RandomTextAnswer(rng *rand.Rand, rule TextAnswerRule) (string, error) {
+	if rng == nil {
+		return "", fmt.Errorf("rng is required")
+	}
+	mode := rule.Mode
+	if mode == "" {
+		mode = inferTextAnswerMode(rule)
+	}
+	switch mode {
+	case TextAnswerModeFixed:
+		values := cleanWords(rule.Values)
+		if len(values) == 0 {
+			return "", fmt.Errorf("fixed values are required")
+		}
+		return values[rng.Intn(len(values))], nil
+	case TextAnswerModeWords:
+		return RandomText(rng, rule.Words)
+	case TextAnswerModeDigits:
+		return RandomDigits(rng, rule.Digits)
+	case TextAnswerModePhone:
+		return RandomPhoneLike(rng, rule.Phone)
+	case TextAnswerModeTemplate:
+		return RandomTemplateText(rng, rule.Template)
+	default:
+		return "", fmt.Errorf("unsupported text answer mode %q", rule.Mode)
+	}
+}
+
+func ValidateTextAnswerRule(rule TextAnswerRule) error {
+	_, err := RandomTextAnswer(rand.New(rand.NewSource(1)), rule)
+	return err
+}
 
 func RandomText(rng *rand.Rand, rule TextRule) (string, error) {
 	if rng == nil {
@@ -63,6 +115,25 @@ func RandomText(rng *rand.Rand, rule TextRule) (string, error) {
 		words = append(words, ruleWords[rng.Intn(len(ruleWords))])
 	}
 	return strings.Join(words, separator), nil
+}
+
+func inferTextAnswerMode(rule TextAnswerRule) TextAnswerMode {
+	if len(rule.Values) > 0 {
+		return TextAnswerModeFixed
+	}
+	if strings.TrimSpace(rule.Template.Template) != "" {
+		return TextAnswerModeTemplate
+	}
+	if rule.Digits.Length > 0 || strings.TrimSpace(rule.Digits.Prefix) != "" {
+		return TextAnswerModeDigits
+	}
+	if len(rule.Phone.Prefixes) > 0 {
+		return TextAnswerModePhone
+	}
+	if len(rule.Words.Words) > 0 {
+		return TextAnswerModeWords
+	}
+	return ""
 }
 
 func RandomInt(rng *rand.Rand, min int, max int) (int, error) {

--- a/internal/answer/text_test.go
+++ b/internal/answer/text_test.go
@@ -58,6 +58,79 @@ func TestRandomDigits(t *testing.T) {
 	}
 }
 
+func TestRandomTextAnswer(t *testing.T) {
+	tests := []struct {
+		name string
+		rule TextAnswerRule
+		want func(string) bool
+	}{
+		{
+			name: "fixed",
+			rule: TextAnswerRule{Mode: TextAnswerModeFixed, Values: []string{"alpha"}},
+			want: func(got string) bool { return got == "alpha" },
+		},
+		{
+			name: "words inferred",
+			rule: TextAnswerRule{Words: TextRule{Words: []string{"alpha", "beta"}, MinWords: 2, MaxWords: 2}},
+			want: func(got string) bool { return len(strings.Fields(got)) == 2 },
+		},
+		{
+			name: "digits",
+			rule: TextAnswerRule{Mode: TextAnswerModeDigits, Digits: DigitsRule{Length: 6, Prefix: "42"}},
+			want: func(got string) bool { return len(got) == 6 && strings.HasPrefix(got, "42") },
+		},
+		{
+			name: "phone",
+			rule: TextAnswerRule{Mode: TextAnswerModePhone, Phone: PhoneRule{Prefixes: []string{"177"}}},
+			want: func(got string) bool { return len(got) == 11 && strings.HasPrefix(got, "177") },
+		},
+		{
+			name: "template",
+			rule: TextAnswerRule{
+				Mode: TextAnswerModeTemplate,
+				Template: TemplateRule{
+					Template: "from {city}",
+					Slots:    map[string][]string{"city": {"shanghai"}},
+				},
+			},
+			want: func(got string) bool { return got == "from shanghai" },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RandomTextAnswer(rand.New(rand.NewSource(1)), tt.rule)
+			if err != nil {
+				t.Fatalf("RandomTextAnswer() returned error: %v", err)
+			}
+			if !tt.want(got) {
+				t.Fatalf("RandomTextAnswer() = %q, did not satisfy expectation", got)
+			}
+		})
+	}
+}
+
+func TestRandomTextAnswerRejectsInvalidRules(t *testing.T) {
+	tests := []struct {
+		name string
+		rule TextAnswerRule
+		want string
+	}{
+		{name: "mode", rule: TextAnswerRule{Mode: "magic"}, want: "unsupported"},
+		{name: "fixed", rule: TextAnswerRule{Mode: TextAnswerModeFixed}, want: "values"},
+		{name: "inferred empty", rule: TextAnswerRule{}, want: "unsupported"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := RandomTextAnswer(rand.New(rand.NewSource(1)), tt.rule)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("RandomTextAnswer() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestRandomDigitsRejectsInvalidRules(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/config/text.go
+++ b/internal/config/text.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/LING71671/SurveyController-Go/internal/answer"
+)
+
+func QuestionTextAnswerRule(question QuestionConfig) (answer.TextAnswerRule, bool, error) {
+	raw, ok := question.Options["text"]
+	if !ok {
+		return answer.TextAnswerRule{}, false, nil
+	}
+	rawMap, err := asMap(raw, "options.text")
+	if err != nil {
+		return answer.TextAnswerRule{}, true, err
+	}
+
+	words, err := optionalStringList(rawMap["words"], "options.text.words")
+	if err != nil {
+		return answer.TextAnswerRule{}, true, err
+	}
+	values, err := optionalStringList(rawMap["values"], "options.text.values")
+	if err != nil {
+		return answer.TextAnswerRule{}, true, err
+	}
+	prefixes, err := optionalStringList(rawMap["prefixes"], "options.text.prefixes")
+	if err != nil {
+		return answer.TextAnswerRule{}, true, err
+	}
+	minWords, err := optionalInt(rawMap["min_words"], "options.text.min_words")
+	if err != nil {
+		return answer.TextAnswerRule{}, true, err
+	}
+	maxWords, err := optionalInt(rawMap["max_words"], "options.text.max_words")
+	if err != nil {
+		return answer.TextAnswerRule{}, true, err
+	}
+	length, err := optionalInt(rawMap["length"], "options.text.length")
+	if err != nil {
+		return answer.TextAnswerRule{}, true, err
+	}
+	slots, err := optionalStringSlots(rawMap["slots"])
+	if err != nil {
+		return answer.TextAnswerRule{}, true, err
+	}
+
+	rule := answer.TextAnswerRule{
+		Mode: answer.TextAnswerMode(optionalString(rawMap["mode"])),
+		Words: answer.TextRule{
+			Words:     words,
+			MinWords:  minWords,
+			MaxWords:  maxWords,
+			Separator: optionalString(rawMap["separator"]),
+		},
+		Digits: answer.DigitsRule{
+			Length: length,
+			Prefix: optionalString(rawMap["prefix"]),
+		},
+		Phone: answer.PhoneRule{
+			Prefixes: prefixes,
+		},
+		Template: answer.TemplateRule{
+			Template: optionalString(rawMap["template"]),
+			Slots:    slots,
+		},
+		Values: values,
+	}
+	if err := answer.ValidateTextAnswerRule(rule); err != nil {
+		return answer.TextAnswerRule{}, true, fmt.Errorf("options.text: %w", err)
+	}
+	return rule, true, nil
+}
+
+func optionalString(raw any) string {
+	value, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}
+
+func optionalInt(raw any, name string) (int, error) {
+	if raw == nil {
+		return 0, nil
+	}
+	value, err := numeric(raw, name)
+	if err != nil {
+		return 0, err
+	}
+	return int(value), nil
+}
+
+func optionalStringList(raw any, name string) ([]string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	if value, ok := raw.(string); ok {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, nil
+		}
+		return []string{value}, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be a string or list", name)
+	}
+	values := make([]string, 0, len(items))
+	for index, item := range items {
+		value, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s[%d] must be a string", name, index)
+		}
+		value = strings.TrimSpace(value)
+		if value != "" {
+			values = append(values, value)
+		}
+	}
+	return values, nil
+}
+
+func optionalStringSlots(raw any) (map[string][]string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	rawMap, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("options.text.slots must be an object")
+	}
+	slots := make(map[string][]string, len(rawMap))
+	for key, value := range rawMap {
+		key = strings.TrimSpace(key)
+		values, err := optionalStringList(value, "options.text.slots."+key)
+		if err != nil {
+			return nil, err
+		}
+		if key != "" && len(values) > 0 {
+			slots[key] = values
+		}
+	}
+	return slots, nil
+}

--- a/internal/config/text_test.go
+++ b/internal/config/text_test.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LING71671/SurveyController-Go/internal/answer"
+)
+
+func TestQuestionTextAnswerRuleParsesModes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  map[string]any
+		want answer.TextAnswerMode
+	}{
+		{
+			name: "fixed",
+			raw: map[string]any{
+				"text": map[string]any{
+					"mode":   "fixed",
+					"values": []any{"alpha", "beta"},
+				},
+			},
+			want: answer.TextAnswerModeFixed,
+		},
+		{
+			name: "words",
+			raw: map[string]any{
+				"text": map[string]any{
+					"mode":      "words",
+					"words":     []any{"alpha", "beta"},
+					"min_words": 2,
+					"max_words": 3,
+					"separator": "-",
+				},
+			},
+			want: answer.TextAnswerModeWords,
+		},
+		{
+			name: "digits",
+			raw: map[string]any{
+				"text": map[string]any{
+					"mode":   "digits",
+					"length": 6,
+					"prefix": "42",
+				},
+			},
+			want: answer.TextAnswerModeDigits,
+		},
+		{
+			name: "phone",
+			raw: map[string]any{
+				"text": map[string]any{
+					"mode":     "phone",
+					"prefixes": []any{"177"},
+				},
+			},
+			want: answer.TextAnswerModePhone,
+		},
+		{
+			name: "template",
+			raw: map[string]any{
+				"text": map[string]any{
+					"mode":     "template",
+					"template": "from {city}",
+					"slots": map[string]any{
+						"city": []any{"shanghai"},
+					},
+				},
+			},
+			want: answer.TextAnswerModeTemplate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := QuestionTextAnswerRule(QuestionConfig{ID: "q1", Options: tt.raw})
+			if err != nil {
+				t.Fatalf("QuestionTextAnswerRule() returned error: %v", err)
+			}
+			if !ok {
+				t.Fatal("QuestionTextAnswerRule() ok=false, want true")
+			}
+			if got.Mode != tt.want {
+				t.Fatalf("Mode = %q, want %q", got.Mode, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuestionTextAnswerRuleReturnsFalseWhenMissing(t *testing.T) {
+	got, ok, err := QuestionTextAnswerRule(QuestionConfig{ID: "q1"})
+	if err != nil {
+		t.Fatalf("QuestionTextAnswerRule() returned error: %v", err)
+	}
+	if ok || got.Mode != "" {
+		t.Fatalf("QuestionTextAnswerRule() = (%+v, %v), want empty false", got, ok)
+	}
+}
+
+func TestQuestionTextAnswerRuleRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		options map[string]any
+		want    string
+	}{
+		{
+			name:    "object",
+			options: map[string]any{"text": "bad"},
+			want:    "object",
+		},
+		{
+			name: "mode",
+			options: map[string]any{
+				"text": map[string]any{"mode": "magic"},
+			},
+			want: "unsupported",
+		},
+		{
+			name: "words type",
+			options: map[string]any{
+				"text": map[string]any{
+					"mode":  "words",
+					"words": 1,
+				},
+			},
+			want: "words",
+		},
+		{
+			name: "length type",
+			options: map[string]any{
+				"text": map[string]any{
+					"mode":   "digits",
+					"length": "bad",
+				},
+			},
+			want: "length",
+		},
+		{
+			name: "template slot",
+			options: map[string]any{
+				"text": map[string]any{
+					"mode":     "template",
+					"template": "hello {name}",
+				},
+			},
+			want: "slot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := QuestionTextAnswerRule(QuestionConfig{ID: "q1", Options: tt.options})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("QuestionTextAnswerRule() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runner/answer_plan_builder.go
+++ b/internal/runner/answer_plan_builder.go
@@ -16,10 +16,11 @@ type AnswerPlanBuilder struct {
 }
 
 type compiledQuestionPlan struct {
-	id       string
-	kind     domain.QuestionKind
-	picker   answer.WeightedPicker
-	selector answer.SelectionPicker
+	id         string
+	kind       domain.QuestionKind
+	picker     answer.WeightedPicker
+	selector   answer.SelectionPicker
+	textAnswer answer.TextAnswerRule
 }
 
 func BuildAnswerPlan(rng *rand.Rand, questions []QuestionPlan) (answerplan.Plan, error) {
@@ -121,6 +122,14 @@ func compileQuestionPlan(question QuestionPlan) (compiledQuestionPlan, error) {
 			return compiledQuestionPlan{}, fmt.Errorf("question %q weights: %w", questionID, err)
 		}
 		return compiledQuestionPlan{id: questionID, kind: kind, selector: selector}, nil
+	case domain.QuestionKindText, domain.QuestionKindTextarea:
+		if !question.HasTextAnswer {
+			return compiledQuestionPlan{}, fmt.Errorf("question %q text answer rule is required", questionID)
+		}
+		if err := answer.ValidateTextAnswerRule(question.TextAnswer); err != nil {
+			return compiledQuestionPlan{}, fmt.Errorf("question %q text answer: %w", questionID, err)
+		}
+		return compiledQuestionPlan{id: questionID, kind: kind, textAnswer: question.TextAnswer}, nil
 	default:
 		return compiledQuestionPlan{}, fmt.Errorf("question %q kind %q is not supported for answer plan builder", questionID, kind)
 	}
@@ -140,6 +149,12 @@ func (q compiledQuestionPlan) buildAnswer(rng *rand.Rand) (answerplan.QuestionAn
 			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q pick many: %w", q.id, err)
 		}
 		return answerplan.QuestionAnswer{QuestionID: q.id, OptionIDs: selected.OptionIDs}, nil
+	case domain.QuestionKindText, domain.QuestionKindTextarea:
+		value, err := answer.RandomTextAnswer(rng, q.textAnswer)
+		if err != nil {
+			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q text answer: %w", q.id, err)
+		}
+		return answerplan.QuestionAnswer{QuestionID: q.id, Value: value}, nil
 	default:
 		return answerplan.QuestionAnswer{}, fmt.Errorf("question %q kind %q is not supported for answer plan builder", q.id, q.kind)
 	}

--- a/internal/runner/answer_plan_builder_test.go
+++ b/internal/runner/answer_plan_builder_test.go
@@ -45,13 +45,22 @@ func TestBuildAnswerPlan(t *testing.T) {
 				{OptionID: "city2", Weight: 1},
 			},
 		},
+		{
+			ID:            "q5",
+			Kind:          "text",
+			HasTextAnswer: true,
+			TextAnswer: answer.TextAnswerRule{
+				Mode:   answer.TextAnswerModeFixed,
+				Values: []string{"hello"},
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("BuildAnswerPlan() returned error: %v", err)
 	}
 
-	if len(got.Answers) != 4 {
-		t.Fatalf("len(Answers) = %d, want 4", len(got.Answers))
+	if len(got.Answers) != 5 {
+		t.Fatalf("len(Answers) = %d, want 5", len(got.Answers))
 	}
 	if got.Answers[0].QuestionID != "q1" || got.Answers[0].OptionIDs[0] != "b" {
 		t.Fatalf("first answer = %+v, want q1=b", got.Answers[0])
@@ -61,6 +70,9 @@ func TestBuildAnswerPlan(t *testing.T) {
 	}
 	if got.Answers[2].OptionIDs[0] != "score5" || got.Answers[3].OptionIDs[0] != "city2" {
 		t.Fatalf("rating/dropdown answers = %+v/%+v, want score5/city2", got.Answers[2], got.Answers[3])
+	}
+	if got.Answers[4].QuestionID != "q5" || got.Answers[4].Value != "hello" {
+		t.Fatalf("text answer = %+v, want q5 hello", got.Answers[4])
 	}
 }
 
@@ -190,7 +202,7 @@ func TestCompileAnswerPlanBuilderRejectsInvalidInput(t *testing.T) {
 	}{
 		{name: "questions", want: "questions"},
 		{name: "question id", questions: []QuestionPlan{{Kind: "single"}}, want: "question id"},
-		{name: "kind", questions: []QuestionPlan{{ID: "q1", Kind: "text"}}, want: "not supported"},
+		{name: "text rule", questions: []QuestionPlan{{ID: "q1", Kind: "text"}}, want: "text answer"},
 		{name: "weights", questions: []QuestionPlan{{ID: "q1", Kind: "single"}}, want: "weights"},
 		{
 			name: "multiple rule",
@@ -239,7 +251,7 @@ func TestBuildAnswerPlanRejectsInvalidInput(t *testing.T) {
 		{name: "rng", questions: []QuestionPlan{{ID: "q1", Kind: "single"}}, want: "rng"},
 		{name: "questions", rng: rand.New(rand.NewSource(1)), want: "questions"},
 		{name: "question id", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{Kind: "single"}}, want: "question id"},
-		{name: "kind", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{ID: "q1", Kind: "text"}}, want: "not supported"},
+		{name: "text rule", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{ID: "q1", Kind: "text"}}, want: "text answer"},
 		{name: "weights", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{ID: "q1", Kind: "single"}}, want: "weights"},
 		{
 			name: "multiple rule",

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -34,6 +34,8 @@ type QuestionPlan struct {
 	Options       map[string]any
 	Weights       []answer.OptionWeight
 	MatrixWeights map[string][]answer.OptionWeight
+	TextAnswer    answer.TextAnswerRule
+	HasTextAnswer bool
 }
 
 type Runner struct{}
@@ -77,6 +79,10 @@ func CompilePlan(cfg config.RunConfig) (Plan, error) {
 		if err != nil {
 			return Plan{}, fmt.Errorf("question %q matrix weights: %w", questionID, err)
 		}
+		textAnswer, hasTextAnswer, err := config.QuestionTextAnswerRule(question)
+		if err != nil {
+			return Plan{}, fmt.Errorf("question %q text answer: %w", questionID, err)
+		}
 		plan.Questions = append(plan.Questions, QuestionPlan{
 			ID:            questionID,
 			Kind:          strings.TrimSpace(question.Kind),
@@ -84,6 +90,8 @@ func CompilePlan(cfg config.RunConfig) (Plan, error) {
 			Options:       cloneOptions(question.Options),
 			Weights:       weights,
 			MatrixWeights: matrixWeights,
+			TextAnswer:    textAnswer,
+			HasTextAnswer: hasTextAnswer,
 		})
 	}
 	if err := New().ValidatePlan(plan); err != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -142,6 +142,32 @@ func TestCompilePlanParsesQuestionWeights(t *testing.T) {
 	}
 }
 
+func TestCompilePlanParsesTextAnswerRule(t *testing.T) {
+	cfg := config.DefaultRunConfig()
+	cfg.Survey.URL = "https://example.com/survey"
+	cfg.Survey.Provider = "mock"
+	cfg.Questions = []config.QuestionConfig{
+		{
+			ID:   "q1",
+			Kind: "text",
+			Options: map[string]any{
+				"text": map[string]any{
+					"mode":   "fixed",
+					"values": []any{"alpha"},
+				},
+			},
+		},
+	}
+
+	plan, err := CompilePlan(cfg)
+	if err != nil {
+		t.Fatalf("CompilePlan() returned error: %v", err)
+	}
+	if !plan.Questions[0].HasTextAnswer || plan.Questions[0].TextAnswer.Values[0] != "alpha" {
+		t.Fatalf("TextAnswer = %+v/%t, want fixed alpha rule", plan.Questions[0].TextAnswer, plan.Questions[0].HasTextAnswer)
+	}
+}
+
 func TestCompilePlanRejectsInvalidQuestionWeights(t *testing.T) {
 	cfg := config.DefaultRunConfig()
 	cfg.Survey.URL = "https://example.com/survey"


### PR DESCRIPTION
## Summary
- add a unified text answer rule with fixed, words, digits, phone, and template modes
- parse `questions[].options.text` into typed config rules
- allow text and textarea questions in the answer plan builder

## Validation
- git diff --check
- go test ./internal/answer ./internal/config ./internal/runner
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #167