### PR TITLE
[codex] Generate text answer skeletons

### DIFF
--- a/internal/config/generate.go
+++ b/internal/config/generate.go
@@ -37,6 +37,9 @@ func defaultQuestionOptions(question domain.QuestionDefinition) map[string]any {
 	if len(question.Options) > 0 {
 		options["weights"] = defaultOptionWeights(question.Options)
 	}
+	if isTextQuestion(question.Kind) {
+		options["text"] = defaultTextAnswerSkeleton()
+	}
 	if len(question.Rows) > 0 && len(question.Options) > 0 {
 		rows := make([]map[string]any, 0, len(question.Rows))
 		for _, row := range question.Rows {
@@ -54,6 +57,17 @@ func defaultQuestionOptions(question domain.QuestionDefinition) map[string]any {
 		}
 	}
 	return options
+}
+
+func isTextQuestion(kind domain.QuestionKind) bool {
+	return kind == domain.QuestionKindText || kind == domain.QuestionKindTextarea
+}
+
+func defaultTextAnswerSkeleton() map[string]any {
+	return map[string]any{
+		"mode":   "fixed",
+		"values": []string{"sample answer"},
+	}
 }
 
 func defaultOptionWeights(options []domain.OptionDefinition) []map[string]any {

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -63,11 +63,39 @@ func TestFromSurveyDefinitionBuildsDefaultRunConfig(t *testing.T) {
 	if len(weights) != 2 || weights[0]["option_id"] != "a" || weights[0]["weight"] != 1 {
 		t.Fatalf("weights = %+v, want default weights for options", weights)
 	}
-	if len(cfg.Questions[1].Options) != 0 {
-		t.Fatalf("text question options = %+v, want empty options", cfg.Questions[1].Options)
+	textOptions, ok := cfg.Questions[1].Options["text"].(map[string]any)
+	if !ok {
+		t.Fatalf("text question options = %+v, want text answer skeleton", cfg.Questions[1].Options)
+	}
+	values, ok := textOptions["values"].([]string)
+	if textOptions["mode"] != "fixed" || !ok || len(values) != 1 || values[0] != "sample answer" {
+		t.Fatalf("text skeleton = %+v, want fixed sample answer", textOptions)
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("generated config did not validate: %v", err)
+	}
+}
+
+func TestFromSurveyDefinitionBuildsTextAreaSkeleton(t *testing.T) {
+	survey := domain.SurveyDefinition{
+		Provider: domain.ProviderWJX,
+		Title:    "Text area survey",
+		URL:      "https://www.wjx.cn/vm/example.aspx",
+		Questions: []domain.QuestionDefinition{
+			{
+				ID:    "q1",
+				Title: "Long comment",
+				Kind:  domain.QuestionKindTextarea,
+			},
+		},
+	}
+
+	cfg, err := FromSurveyDefinition(survey)
+	if err != nil {
+		t.Fatalf("FromSurveyDefinition() returned error: %v", err)
+	}
+	if _, ok := cfg.Questions[0].Options["text"].(map[string]any); !ok {
+		t.Fatalf("textarea options = %+v, want text answer skeleton", cfg.Questions[0].Options)
 	}
 }
 


### PR DESCRIPTION
## Summary
- generate editable `options.text` skeletons for text and textarea questions
- keep generated text questions answer-plan compatible by default
- cover text and textarea generation in tests

## Validation
- git diff --check
- go test ./internal/config ./internal/runner
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- go run ./cmd/surveyctl config generate --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx

Closes #169