### PR TITLE
[codex] Document and validate generated text answer strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ go run ./cmd/surveyctl link extract --text "问卷 https://www.wjx.cn/vm/example
 go run ./cmd/surveyctl link extract .\example-survey\qr.txt --json
 ```
 
+`config generate` 会为文本题生成可编辑的 `options.text` 骨架，默认使用 `mode: fixed` 和 `sample answer`，后续可改成 `words`、`digits`、`phone` 或 `template` 文本策略。
+
 当前 `surveyctl run` 已经支持两个本地预览入口：
 
 - `--dry-run`：只编译配置和运行计划，不生成提交任务，不访问网络。

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,6 +68,8 @@ go run ./cmd/surveyctl link extract .\example-survey\qr.txt --json
 
 `surveyctl config generate` 会在未传 `--provider` 或传入 `--provider auto` 时根据 `--url` 自动识别平台。显式传入 `--provider wjx|tencent|credamo` 时仍以显式值为准，方便调试 fixture。
 
+生成配置遇到 `text` 或 `textarea` 题时，会写入一个可编辑的 `options.text` 骨架。默认是 `mode: fixed` 和 `sample answer`，确保生成配置能直接进入 answer plan；后续可按题目需要改成 `words`、`digits`、`phone` 或 `template`。
+
 ## 运行预览
 
 `surveyctl run` 当前只开放不会访问网络的预览能力：

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -31,7 +31,7 @@ pwsh -File scripts/verify-local.ps1
 - `go test ./...`
 - `go vet ./...`
 - `staticcheck ./...`
-- CLI local precheck smoke：`link extract` + `config generate` provider auto-detection
+- CLI local precheck smoke：`link extract` + `config generate` provider auto-detection + generated text answer skeleton
 - 轻量 mock stress matrix
 
 常用参数：

--- a/scripts/verify-local.ps1
+++ b/scripts/verify-local.ps1
@@ -55,6 +55,9 @@ try {
         if (($configOutput -join "`n") -notmatch "provider:\s*wjx") {
             Write-Error "generated config did not contain provider: wjx"
         }
+        if (($configOutput -join "`n") -notmatch "mode:\s*fixed" -or ($configOutput -join "`n") -notmatch "sample answer") {
+            Write-Error "generated config did not contain a text answer skeleton"
+        }
     }
 
     if (-not $SkipStress) {


### PR DESCRIPTION
## Summary
- document generated `options.text` skeletons and supported text strategy modes
- extend local CLI smoke to assert generated text answer skeletons
- update script docs for the broader smoke coverage

## Validation
- ./scripts/verify-local.ps1 -SkipGoChecks -SkipStaticcheck -SkipStress
- git diff --check
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...
- ./scripts/verify-local.ps1 -SkipStress

Closes #171