### PR TITLE
[codex] Support matrix questions in answer plan builder

### DIFF
--- a/internal/answerplan/clone.go
+++ b/internal/answerplan/clone.go
@@ -12,6 +12,22 @@ func Clone(plan Plan) Plan {
 			QuestionID: answer.QuestionID,
 			OptionIDs:  append([]string(nil), answer.OptionIDs...),
 			Value:      answer.Value,
+			Rows:       cloneRows(answer.Rows),
+		}
+	}
+	return cloned
+}
+
+func cloneRows(rows []RowAnswer) []RowAnswer {
+	if len(rows) == 0 {
+		return nil
+	}
+	cloned := make([]RowAnswer, len(rows))
+	for i, row := range rows {
+		cloned[i] = RowAnswer{
+			RowID:     row.RowID,
+			OptionIDs: append([]string(nil), row.OptionIDs...),
+			Value:     row.Value,
 		}
 	}
 	return cloned

--- a/internal/answerplan/clone_test.go
+++ b/internal/answerplan/clone_test.go
@@ -5,7 +5,12 @@ import "testing"
 func TestClone(t *testing.T) {
 	plan := Plan{
 		Answers: []QuestionAnswer{
-			{QuestionID: "q1", OptionIDs: []string{"a", "b"}, Value: "x"},
+			{
+				QuestionID: "q1",
+				OptionIDs:  []string{"a", "b"},
+				Value:      "x",
+				Rows:       []RowAnswer{{RowID: "r1", OptionIDs: []string{"c"}, Value: "y"}},
+			},
 		},
 	}
 
@@ -13,8 +18,14 @@ func TestClone(t *testing.T) {
 	plan.Answers[0].QuestionID = "mutated"
 	plan.Answers[0].OptionIDs[0] = "mutated"
 	plan.Answers[0].Value = "mutated"
+	plan.Answers[0].Rows[0].RowID = "mutated"
+	plan.Answers[0].Rows[0].OptionIDs[0] = "mutated"
+	plan.Answers[0].Rows[0].Value = "mutated"
 
 	if cloned.Answers[0].QuestionID != "q1" || cloned.Answers[0].OptionIDs[0] != "a" || cloned.Answers[0].Value != "x" {
 		t.Fatalf("Clone() = %+v, want independent copy", cloned)
+	}
+	if cloned.Answers[0].Rows[0].RowID != "r1" || cloned.Answers[0].Rows[0].OptionIDs[0] != "c" || cloned.Answers[0].Rows[0].Value != "y" {
+		t.Fatalf("Clone() rows = %+v, want independent row copy", cloned.Answers[0].Rows)
 	}
 }

--- a/internal/answerplan/plan.go
+++ b/internal/answerplan/plan.go
@@ -10,6 +10,13 @@ type QuestionAnswer struct {
 	QuestionID string
 	OptionIDs  []string
 	Value      string
+	Rows       []RowAnswer
+}
+
+type RowAnswer struct {
+	RowID     string
+	OptionIDs []string
+	Value     string
 }
 
 func (p Plan) Empty() bool {
@@ -26,4 +33,20 @@ func (a QuestionAnswer) HasOptionIDs() bool {
 
 func (a QuestionAnswer) DirectValue() string {
 	return strings.TrimSpace(a.Value)
+}
+
+func (a QuestionAnswer) HasRows() bool {
+	return len(a.Rows) > 0
+}
+
+func (r RowAnswer) NormalizedRowID() string {
+	return strings.TrimSpace(r.RowID)
+}
+
+func (r RowAnswer) HasOptionIDs() bool {
+	return len(r.OptionIDs) > 0
+}
+
+func (r RowAnswer) DirectValue() string {
+	return strings.TrimSpace(r.Value)
 }

--- a/internal/answerplan/plan_test.go
+++ b/internal/answerplan/plan_test.go
@@ -16,6 +16,7 @@ func TestQuestionAnswerHelpers(t *testing.T) {
 		QuestionID: " q1 ",
 		OptionIDs:  []string{"a"},
 		Value:      " 1 ",
+		Rows:       []RowAnswer{{RowID: " r1 ", OptionIDs: []string{"b"}, Value: " 2 "}},
 	}
 	if answer.NormalizedQuestionID() != "q1" {
 		t.Fatalf("NormalizedQuestionID() = %q, want q1", answer.NormalizedQuestionID())
@@ -25,5 +26,11 @@ func TestQuestionAnswerHelpers(t *testing.T) {
 	}
 	if answer.DirectValue() != "1" {
 		t.Fatalf("DirectValue() = %q, want 1", answer.DirectValue())
+	}
+	if !answer.HasRows() {
+		t.Fatal("HasRows() = false, want true")
+	}
+	if answer.Rows[0].NormalizedRowID() != "r1" || !answer.Rows[0].HasOptionIDs() || answer.Rows[0].DirectValue() != "2" {
+		t.Fatalf("row helpers = %+v, want normalized row answer", answer.Rows[0])
 	}
 }

--- a/internal/runner/answer_plan_builder.go
+++ b/internal/runner/answer_plan_builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"sort"
 	"strings"
 
 	"github.com/LING71671/SurveyController-Go/internal/answer"
@@ -21,6 +22,12 @@ type compiledQuestionPlan struct {
 	picker     answer.WeightedPicker
 	selector   answer.SelectionPicker
 	textAnswer answer.TextAnswerRule
+	matrixRows []compiledMatrixRow
+}
+
+type compiledMatrixRow struct {
+	id     string
+	picker answer.WeightedPicker
 }
 
 func BuildAnswerPlan(rng *rand.Rand, questions []QuestionPlan) (answerplan.Plan, error) {
@@ -130,6 +137,12 @@ func compileQuestionPlan(question QuestionPlan) (compiledQuestionPlan, error) {
 			return compiledQuestionPlan{}, fmt.Errorf("question %q text answer: %w", questionID, err)
 		}
 		return compiledQuestionPlan{id: questionID, kind: kind, textAnswer: question.TextAnswer}, nil
+	case domain.QuestionKindMatrix:
+		rows, err := compileMatrixRows(question.MatrixWeights)
+		if err != nil {
+			return compiledQuestionPlan{}, fmt.Errorf("question %q matrix rows: %w", questionID, err)
+		}
+		return compiledQuestionPlan{id: questionID, kind: kind, matrixRows: rows}, nil
 	default:
 		return compiledQuestionPlan{}, fmt.Errorf("question %q kind %q is not supported for answer plan builder", questionID, kind)
 	}
@@ -155,9 +168,55 @@ func (q compiledQuestionPlan) buildAnswer(rng *rand.Rand) (answerplan.QuestionAn
 			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q text answer: %w", q.id, err)
 		}
 		return answerplan.QuestionAnswer{QuestionID: q.id, Value: value}, nil
+	case domain.QuestionKindMatrix:
+		rows, err := q.buildMatrixRows(rng)
+		if err != nil {
+			return answerplan.QuestionAnswer{}, fmt.Errorf("question %q matrix answer: %w", q.id, err)
+		}
+		return answerplan.QuestionAnswer{QuestionID: q.id, Rows: rows}, nil
 	default:
 		return answerplan.QuestionAnswer{}, fmt.Errorf("question %q kind %q is not supported for answer plan builder", q.id, q.kind)
 	}
+}
+
+func (q compiledQuestionPlan) buildMatrixRows(rng *rand.Rand) ([]answerplan.RowAnswer, error) {
+	if len(q.matrixRows) == 0 {
+		return nil, fmt.Errorf("rows are required")
+	}
+	rows := make([]answerplan.RowAnswer, 0, len(q.matrixRows))
+	for _, row := range q.matrixRows {
+		optionID, err := row.picker.Pick(rng)
+		if err != nil {
+			return nil, fmt.Errorf("row %q pick one: %w", row.id, err)
+		}
+		rows = append(rows, answerplan.RowAnswer{RowID: row.id, OptionIDs: []string{optionID}})
+	}
+	return rows, nil
+}
+
+func compileMatrixRows(matrixWeights map[string][]answer.OptionWeight) ([]compiledMatrixRow, error) {
+	if len(matrixWeights) == 0 {
+		return nil, fmt.Errorf("matrix_weights are required")
+	}
+	rowIDs := make([]string, 0, len(matrixWeights))
+	for rowID := range matrixWeights {
+		rowID = strings.TrimSpace(rowID)
+		if rowID == "" {
+			return nil, fmt.Errorf("row id is required")
+		}
+		rowIDs = append(rowIDs, rowID)
+	}
+	sort.Strings(rowIDs)
+
+	rows := make([]compiledMatrixRow, 0, len(rowIDs))
+	for _, rowID := range rowIDs {
+		picker, err := answer.NewWeightedPicker(matrixWeights[rowID])
+		if err != nil {
+			return nil, fmt.Errorf("row %q weights: %w", rowID, err)
+		}
+		rows = append(rows, compiledMatrixRow{id: rowID, picker: picker})
+	}
+	return rows, nil
 }
 
 func selectionRuleFromOptions(options map[string]any) answer.SelectionRule {

--- a/internal/runner/answer_plan_builder_test.go
+++ b/internal/runner/answer_plan_builder_test.go
@@ -54,13 +54,21 @@ func TestBuildAnswerPlan(t *testing.T) {
 				Values: []string{"hello"},
 			},
 		},
+		{
+			ID:   "q6",
+			Kind: "matrix",
+			MatrixWeights: map[string][]answer.OptionWeight{
+				"row2": {{OptionID: "no", Weight: 1}},
+				"row1": {{OptionID: "yes", Weight: 1}},
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("BuildAnswerPlan() returned error: %v", err)
 	}
 
-	if len(got.Answers) != 5 {
-		t.Fatalf("len(Answers) = %d, want 5", len(got.Answers))
+	if len(got.Answers) != 6 {
+		t.Fatalf("len(Answers) = %d, want 6", len(got.Answers))
 	}
 	if got.Answers[0].QuestionID != "q1" || got.Answers[0].OptionIDs[0] != "b" {
 		t.Fatalf("first answer = %+v, want q1=b", got.Answers[0])
@@ -73,6 +81,13 @@ func TestBuildAnswerPlan(t *testing.T) {
 	}
 	if got.Answers[4].QuestionID != "q5" || got.Answers[4].Value != "hello" {
 		t.Fatalf("text answer = %+v, want q5 hello", got.Answers[4])
+	}
+	matrix := got.Answers[5]
+	if matrix.QuestionID != "q6" || len(matrix.Rows) != 2 {
+		t.Fatalf("matrix answer = %+v, want q6 with two rows", matrix)
+	}
+	if matrix.Rows[0].RowID != "row1" || matrix.Rows[0].OptionIDs[0] != "yes" || matrix.Rows[1].RowID != "row2" || matrix.Rows[1].OptionIDs[0] != "no" {
+		t.Fatalf("matrix rows = %+v, want sorted row answers", matrix.Rows)
 	}
 }
 
@@ -204,6 +219,7 @@ func TestCompileAnswerPlanBuilderRejectsInvalidInput(t *testing.T) {
 		{name: "question id", questions: []QuestionPlan{{Kind: "single"}}, want: "question id"},
 		{name: "text rule", questions: []QuestionPlan{{ID: "q1", Kind: "text"}}, want: "text answer"},
 		{name: "weights", questions: []QuestionPlan{{ID: "q1", Kind: "single"}}, want: "weights"},
+		{name: "matrix rows", questions: []QuestionPlan{{ID: "q1", Kind: "matrix"}}, want: "matrix_weights"},
 		{
 			name: "multiple rule",
 			questions: []QuestionPlan{{
@@ -253,6 +269,7 @@ func TestBuildAnswerPlanRejectsInvalidInput(t *testing.T) {
 		{name: "question id", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{Kind: "single"}}, want: "question id"},
 		{name: "text rule", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{ID: "q1", Kind: "text"}}, want: "text answer"},
 		{name: "weights", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{ID: "q1", Kind: "single"}}, want: "weights"},
+		{name: "matrix rows", rng: rand.New(rand.NewSource(1)), questions: []QuestionPlan{{ID: "q1", Kind: "matrix"}}, want: "matrix_weights"},
 		{
 			name: "multiple rule",
 			rng:  rand.New(rand.NewSource(1)),


### PR DESCRIPTION
## Summary
- add row-level matrix answers to answerplan cloning and helpers
- compile matrix row weights into deterministic row pickers
- generate one planned answer per matrix row in runner answer planning

## Validation
- gofmt internal/answerplan/plan.go internal/answerplan/clone.go internal/answerplan/plan_test.go internal/answerplan/clone_test.go internal/runner/answer_plan_builder.go internal/runner/answer_plan_builder_test.go
- git diff --check
- go test ./internal/answerplan ./internal/runner
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for matrix-type questions, allowing row-based answer selections for each question.

* **Bug Fixes**
  * Improved answer data cloning to ensure complete deep-copying of row information, preventing unintended data mutations.

* **Tests**
  * Extended test coverage for matrix question handling, row-level answer validation, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->