### PR TITLE
[codex] Map WJX HTTP matrix answers

### DIFF
--- a/internal/provider/wjx/http_answer_plan.go
+++ b/internal/provider/wjx/http_answer_plan.go
@@ -20,6 +20,7 @@ type httpQuestionSpec struct {
 	id      string
 	kind    domain.QuestionKind
 	options map[string]string
+	rows    map[string]struct{}
 }
 
 func BuildHTTPSubmissionDraftFromAnswerPlan(survey domain.SurveyDefinition, plan answerplan.Plan) (HTTPSubmissionDraft, error) {
@@ -100,6 +101,7 @@ func compileHTTPQuestionSpec(question domain.QuestionDefinition) (httpQuestionSp
 		id:      strings.TrimSpace(question.ID),
 		kind:    question.Kind,
 		options: make(map[string]string, len(question.Options)),
+		rows:    make(map[string]struct{}, len(question.Rows)),
 	}
 	for _, option := range question.Options {
 		id, value, err := compileHTTPOptionValue(option)
@@ -111,6 +113,15 @@ func compileHTTPQuestionSpec(question domain.QuestionDefinition) (httpQuestionSp
 				return httpQuestionSpec{}, fmt.Errorf("question %q option %q is defined more than once", spec.id, id)
 			}
 			spec.options[id] = value
+		}
+	}
+	for _, row := range question.Rows {
+		id := strings.TrimSpace(row.ID)
+		if id != "" {
+			if _, exists := spec.rows[id]; exists {
+				return httpQuestionSpec{}, fmt.Errorf("question %q row %q is defined more than once", spec.id, id)
+			}
+			spec.rows[id] = struct{}{}
 		}
 	}
 	return spec, nil
@@ -148,6 +159,8 @@ func (q httpQuestionSpec) mapAnswer(planned answerplan.QuestionAnswer) (string, 
 		return q.mapMultipleAnswer(planned)
 	case domain.QuestionKindRating:
 		return q.mapRatingAnswer(planned)
+	case domain.QuestionKindMatrix:
+		return q.mapMatrixAnswer(planned)
 	default:
 		return "", fmt.Errorf("kind %q is not supported for HTTP answer plan", q.kind)
 	}
@@ -197,6 +210,50 @@ func (q httpQuestionSpec) mapRatingAnswer(planned answerplan.QuestionAnswer) (st
 		return q.optionValue(planned.OptionIDs[0])
 	}
 	return directAnswerValue(planned.Value)
+}
+
+func (q httpQuestionSpec) mapMatrixAnswer(planned answerplan.QuestionAnswer) (string, error) {
+	if planned.HasOptionIDs() {
+		return "", fmt.Errorf("matrix answer expects row answers")
+	}
+	if !planned.HasRows() {
+		return directAnswerValue(planned.Value)
+	}
+
+	seen := map[string]bool{}
+	values := make([]string, 0, len(planned.Rows))
+	for _, row := range planned.Rows {
+		rowID := row.NormalizedRowID()
+		if rowID == "" {
+			return "", fmt.Errorf("row id is required")
+		}
+		if len(q.rows) > 0 {
+			if _, ok := q.rows[rowID]; !ok {
+				return "", fmt.Errorf("row %q is not defined", rowID)
+			}
+		}
+		if seen[rowID] {
+			return "", fmt.Errorf("row %q is answered more than once", rowID)
+		}
+		seen[rowID] = true
+
+		value, err := q.mapMatrixRowValue(row)
+		if err != nil {
+			return "", fmt.Errorf("row %q: %w", rowID, err)
+		}
+		values = append(values, rowID+":"+value)
+	}
+	return strings.Join(values, ";"), nil
+}
+
+func (q httpQuestionSpec) mapMatrixRowValue(row answerplan.RowAnswer) (string, error) {
+	if len(row.OptionIDs) > 1 {
+		return "", fmt.Errorf("matrix row expects one option")
+	}
+	if row.HasOptionIDs() {
+		return q.optionValue(row.OptionIDs[0])
+	}
+	return directAnswerValue(row.Value)
 }
 
 func directAnswerValue(value string) (string, error) {

--- a/internal/provider/wjx/http_answer_plan_test.go
+++ b/internal/provider/wjx/http_answer_plan_test.go
@@ -17,6 +17,10 @@ func TestBuildHTTPAnswers(t *testing.T) {
 			{QuestionID: "q2", OptionIDs: []string{"a", "c"}},
 			{QuestionID: "q3", OptionIDs: []string{"score5"}},
 			{QuestionID: "q4", OptionIDs: []string{"city2"}},
+			{QuestionID: "q6", Rows: []answerplan.RowAnswer{
+				{RowID: "row1", OptionIDs: []string{"agree"}},
+				{RowID: "row2", OptionIDs: []string{"neutral"}},
+			}},
 		},
 	})
 	if err != nil {
@@ -28,6 +32,7 @@ func TestBuildHTTPAnswers(t *testing.T) {
 		"q2": "A,C",
 		"q3": "5",
 		"q4": "shanghai",
+		"q6": "row1:5;row2:3",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("len(answers) = %d, want %d: %+v", len(got), len(want), got)
@@ -102,6 +107,25 @@ func TestBuildHTTPAnswersSupportsDirectValues(t *testing.T) {
 	}
 }
 
+func TestBuildHTTPAnswersSupportsMatrixRows(t *testing.T) {
+	survey := testAnswerPlanSurvey()
+
+	got, err := BuildHTTPAnswers(survey, answerplan.Plan{
+		Answers: []answerplan.QuestionAnswer{
+			{QuestionID: "q6", Rows: []answerplan.RowAnswer{
+				{RowID: "row1", OptionIDs: []string{"agree"}},
+				{RowID: "row2", Value: "4"},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildHTTPAnswers() returned error: %v", err)
+	}
+	if got["q6"] != "row1:5;row2:4" {
+		t.Fatalf("answers[q6] = %q, want row mapped matrix answer", got["q6"])
+	}
+}
+
 func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 	survey := testAnswerPlanSurvey()
 	tests := []struct {
@@ -157,6 +181,14 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 			want: "defined more than once",
 		},
 		{
+			name:   "duplicate matrix row definition",
+			survey: replaceQuestion(survey, 5, duplicateMatrixRowQuestion()),
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
+				{QuestionID: "q6", Rows: []answerplan.RowAnswer{{RowID: "row1", OptionIDs: []string{"agree"}}}},
+			}},
+			want: "defined more than once",
+		},
+		{
 			name:   "unsupported kind",
 			survey: survey,
 			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
@@ -196,6 +228,49 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 			}},
 			want: "answer value",
 		},
+		{
+			name:   "matrix top-level options",
+			survey: survey,
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
+				{QuestionID: "q6", OptionIDs: []string{"agree"}},
+			}},
+			want: "row answers",
+		},
+		{
+			name:   "matrix unknown row",
+			survey: survey,
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
+				{QuestionID: "q6", Rows: []answerplan.RowAnswer{{RowID: "missing", OptionIDs: []string{"agree"}}}},
+			}},
+			want: "not defined",
+		},
+		{
+			name:   "matrix duplicate row",
+			survey: survey,
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
+				{QuestionID: "q6", Rows: []answerplan.RowAnswer{
+					{RowID: "row1", OptionIDs: []string{"agree"}},
+					{RowID: "row1", OptionIDs: []string{"neutral"}},
+				}},
+			}},
+			want: "more than once",
+		},
+		{
+			name:   "matrix row multiple options",
+			survey: survey,
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
+				{QuestionID: "q6", Rows: []answerplan.RowAnswer{{RowID: "row1", OptionIDs: []string{"agree", "neutral"}}}},
+			}},
+			want: "expects one option",
+		},
+		{
+			name:   "matrix row unknown option",
+			survey: survey,
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
+				{QuestionID: "q6", Rows: []answerplan.RowAnswer{{RowID: "row1", OptionIDs: []string{"missing"}}}},
+			}},
+			want: "not defined",
+		},
 	}
 
 	for _, tt := range tests {
@@ -230,6 +305,21 @@ func duplicateOptionQuestion() domain.QuestionDefinition {
 		Options: []domain.OptionDefinition{
 			{ID: "a", Label: "A", Value: "1"},
 			{ID: "a", Label: "A again", Value: "2"},
+		},
+	}
+}
+
+func duplicateMatrixRowQuestion() domain.QuestionDefinition {
+	return domain.QuestionDefinition{
+		ID:    "q6",
+		Title: "Matrix",
+		Kind:  domain.QuestionKindMatrix,
+		Rows: []domain.OptionDefinition{
+			{ID: "row1", Label: "UX"},
+			{ID: "row1", Label: "UX again"},
+		},
+		Options: []domain.OptionDefinition{
+			{ID: "agree", Label: "Agree", Value: "5"},
 		},
 	}
 }
@@ -281,6 +371,19 @@ func testAnswerPlanSurvey() domain.SurveyDefinition {
 				ID:    "q5",
 				Title: "Text",
 				Kind:  domain.QuestionKindText,
+			},
+			{
+				ID:    "q6",
+				Title: "Matrix",
+				Kind:  domain.QuestionKindMatrix,
+				Rows: []domain.OptionDefinition{
+					{ID: "row1", Label: "UX"},
+					{ID: "row2", Label: "Performance"},
+				},
+				Options: []domain.OptionDefinition{
+					{ID: "agree", Label: "Agree", Value: "5"},
+					{ID: "neutral", Label: "Neutral", Value: "3"},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- compile WJX matrix row IDs into the HTTP answer schema
- map row-level matrix answers into stable dry-run form values
- reject malformed matrix answers, duplicate rows, unknown rows, and unknown options

## Validation
- gofmt internal/provider/wjx/http_answer_plan.go internal/provider/wjx/http_answer_plan_test.go
- git diff --check
- go test ./internal/provider/wjx
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #175