### PR TITLE
[codex] Cover WJX matrix local verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 
 `--events jsonl` 面向后续脚本、CI 和轻量 GUI 外壳；`v1.0` 前不会把 GUI 放进核心，但事件流会保持足够稳定，让 UI 只做薄订阅层。当前 mock run 和 WJX HTTP dry-run 共用这套事件协议。
 
-问卷星 HTTP 路径目前提供本地预览入口，用于检查 answer plan 到 HTTP form 的映射，不执行网络请求。预览会校验配置计划和本地 fixture 的 URL、题目 ID、题型是否一致：
+问卷星 HTTP 路径目前提供本地预览入口，用于检查 answer plan 到 HTTP form 的映射，不执行网络请求。预览会校验配置计划和本地 fixture 的 URL、题目 ID、题型是否一致；示例 fixture 覆盖单选、多选、文本、评分和矩阵题，矩阵题会以行级答案进入 draft：
 
 ```powershell
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html --json
 ```
 
-需要经过完整 runner/worker pool 但仍然禁用网络时，可以使用问卷星 HTTP dry-run。它会从本地 fixture 构建 survey schema，运行 answer plan 和 HTTP pipeline，并用本地 dry-run executor 记录 draft：
+需要经过完整 runner/worker pool 但仍然禁用网络时，可以使用问卷星 HTTP dry-run。它会从本地 fixture 构建 survey schema，运行 answer plan 和 HTTP pipeline，并用本地 dry-run executor 记录 draft；当前本地 smoke 会检查矩阵题输出形如 `q5_r1:5;q5_r2:1`：
 
 ```powershell
 go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -559,7 +559,7 @@ func TestRunWJXHTTPPreviewPrintsSummary(t *testing.T) {
 	if code != exitOK {
 		t.Fatalf("run(wjx http preview) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
 	}
-	for _, want := range []string{"wjx http preview:", "provider: wjx", "mode: http", "method: POST", "endpoint: https://www.wjx.cn/joinnew/processjq.ashx", "survey_id: example", "q1: browser", "q2: q2_a,q2_b", "q4: 5", "network: disabled (preview)"} {
+	for _, want := range []string{"wjx http preview:", "provider: wjx", "mode: http", "method: POST", "endpoint: https://www.wjx.cn/joinnew/processjq.ashx", "survey_id: example", "q1: browser", "q2: q2_a,q2_b", "q4: 5", "q5: q5_r1:5;q5_r2:1", "network: disabled (preview)"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
@@ -596,6 +596,9 @@ func TestRunWJXHTTPPreviewJSONPrintsSummary(t *testing.T) {
 	if values := form["q4"].([]any); values[0] != "5" {
 		t.Fatalf("form = %+v, want q4 rating answer", form)
 	}
+	if values := form["q5"].([]any); values[0] != "q5_r1:5;q5_r2:1" {
+		t.Fatalf("form = %+v, want q5 matrix answer", form)
+	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
@@ -611,7 +614,7 @@ func TestRunWJXHTTPDryRunPrintsSummary(t *testing.T) {
 	if code != exitOK {
 		t.Fatalf("run(wjx http dry-run) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
 	}
-	for _, want := range []string{"wjx http dry-run:", "provider: wjx", "mode: http", "target: 2", "successes: 2", "completed: 2", "draft_count: 2", "first_draft:", "q1: browser", "q2: q2_a,q2_b", "q4: 5", "network: disabled (dry-run)"} {
+	for _, want := range []string{"wjx http dry-run:", "provider: wjx", "mode: http", "target: 2", "successes: 2", "completed: 2", "draft_count: 2", "first_draft:", "q1: browser", "q2: q2_a,q2_b", "q4: 5", "q5: q5_r1:5;q5_r2:1", "network: disabled (dry-run)"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
@@ -647,6 +650,9 @@ func TestRunWJXHTTPDryRunJSONPrintsSummary(t *testing.T) {
 	form := first["form"].(map[string]any)
 	if values := form["q1"].([]any); values[0] != "browser" {
 		t.Fatalf("form = %+v, want q1 browser", form)
+	}
+	if values := form["q5"].([]any); values[0] != "q5_r1:5;q5_r2:1" {
+		t.Fatalf("form = %+v, want q5 matrix answer", form)
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
@@ -938,6 +944,18 @@ questions:
       weights:
         - option_id: q4_5
           weight: 1
+  - id: q5
+    kind: matrix
+    options:
+      matrix_weights:
+        - row_id: q5_r1
+          weights:
+            - option_id: q5_c5
+              weight: 1
+        - row_id: q5_r2
+          weights:
+            - option_id: q5_c1
+              weight: 1
 `
 }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -96,7 +96,7 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 
 `--dry-run` 用于验证配置能否编译成运行计划；`--mock` 会实际经过答案计划生成、worker pool、运行状态和事件输出，但 submitter 是本地 mock，不访问任何平台。
 
-`--wjx-http-preview` 用于验证问卷星 answer plan 能否编译成 HTTP draft。它只读取本地 HTML fixture，不执行网络请求；输出中会明确标注 `network: disabled (preview)`。预览会校验配置计划和 fixture 的 provider、mode、URL、题目 ID、题型是否一致，避免把不匹配的配置误认为可提交路径。
+`--wjx-http-preview` 用于验证问卷星 answer plan 能否编译成 HTTP draft。它只读取本地 HTML fixture，不执行网络请求；输出中会明确标注 `network: disabled (preview)`。预览会校验配置计划和 fixture 的 provider、mode、URL、题目 ID、题型是否一致，避免把不匹配的配置误认为可提交路径。当前 fixture 覆盖矩阵行解析和行级答案映射，本地 smoke 会检查 `q5_r1:5;q5_r2:1` 这类矩阵 draft。
 
 `--wjx-http-dry-run` 用于验证问卷星 HTTP 路径的完整本地执行闭环。它会经过 runner、worker pool、答案计划生成、HTTP pipeline 和本地 dry-run executor，输出成功数、完成数、吞吐、资源指标、draft 数量和首个 draft 详情；JSON 输出会包含完整 drafts。该命令仍然只使用本地 fixture，输出中会明确标注 `network: disabled (dry-run)`。需要观察进度时可以使用 `--events text` 或 `--events jsonl`，事件语义和 mock run 保持一致。
 
@@ -108,7 +108,7 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 
 `scripts/wjx-http-dryrun-stress-matrix.ps1` 用于一次性跑 smoke、预算和可选 1000x1000 profile。日常快速检查可加 `-SkipFull`，完整 profile 留给发布前或专门性能验证。
 
-CI 的质量检查会运行 `scripts/wjx-http-dryrun-stress-matrix.ps1 -SkipFull`，用于覆盖 PowerShell 脚本、CLI 参数、本地 fixture 和 WJX HTTP dry-run runner 的基础兼容性；完整 1000x1000 profile 仍由本地显式参数触发。
+CI 的质量检查会运行 `scripts/wjx-http-dryrun-stress-matrix.ps1 -SkipFull`，用于覆盖 PowerShell 脚本、CLI 参数、本地 fixture、矩阵答案映射和 WJX HTTP dry-run runner 的基础兼容性；完整 1000x1000 profile 仍由本地显式参数触发。
 
 常用压测入口见 [性能与压测](performance.md)。默认脚本会运行 1000 target / 1000 concurrency 的本地 mock；`-Json` 输出最终 JSON 汇总，`-FailEvery` 可验证失败阈值和停止行为。
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -91,7 +91,7 @@ go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --f
 
 预览会经过配置编译、答案计划生成、问卷星 HTTP form 映射和 plan/fixture 兼容性校验，但不会调用 HTTP executor。输出中的 `network: disabled (preview)` 是这个阶段的安全边界。
 
-当前示例覆盖单选、多选和评分题，用于观察 answer plan 到 `processjq.ashx` form 的映射。后续真实网络运行必须继续复用 provider 能力门控，并在登录、验证、风控、设备次数上限或频控信号出现时停止并报告。
+当前示例覆盖单选、多选、文本、评分和矩阵题，用于观察 answer plan 到 `processjq.ashx` form 的映射。矩阵题在本地 draft 中使用稳定的行级表示，例如 `q5_r1:5;q5_r2:1`，便于脚本检查每一行是否都被计划和映射。后续真实网络运行必须继续复用 provider 能力门控，并在登录、验证、风控、设备次数上限或频控信号出现时停止并报告。
 
 ## WJX HTTP Dry-Run
 
@@ -109,7 +109,7 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 .\scripts\wjx-http-dryrun-stress-matrix.ps1
 ```
 
-text 输出只展示汇总和首个 draft，避免高并发 dry-run 时刷屏；JSON 输出包含完整 `drafts`，适合脚本检查 answer plan 到 form 的稳定性。输出中的 `network: disabled (dry-run)` 是安全边界。
+text 输出只展示汇总和首个 draft，避免高并发 dry-run 时刷屏；JSON 输出包含完整 `drafts`，适合脚本检查 answer plan 到 form 的稳定性，包括矩阵题的行级答案。输出中的 `network: disabled (dry-run)` 是安全边界。
 
 `--events text|jsonl` 可用于观察 dry-run 期间的 runner 事件。高并发 profile 中建议优先使用 `--json` 汇总或脚本预算；事件流更适合小规模诊断和后续轻量 UI 订阅。
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -83,7 +83,7 @@ CI smoke 使用：
 
 ## wjx-http-dryrun-stress.ps1
 
-问卷星 HTTP dry-run 压测入口。它会读取本地 fixture，经过 runner、worker pool、答案计划和 HTTP pipeline，最后由本地 dry-run executor 记录 draft，不访问网络：
+问卷星 HTTP dry-run 压测入口。它会读取本地 fixture，经过 runner、worker pool、答案计划和 HTTP pipeline，最后由本地 dry-run executor 记录 draft，不访问网络。当前示例 fixture 覆盖矩阵题，draft 中会保留行级答案，便于脚本检查矩阵每一行的映射：
 
 ```powershell
 .\scripts\wjx-http-dryrun-stress.ps1

--- a/examples/wjx-http-preview.yaml
+++ b/examples/wjx-http-preview.yaml
@@ -31,3 +31,15 @@ questions:
       weights:
         - option_id: q4_5
           weight: 1
+  - id: q5
+    kind: matrix
+    options:
+      matrix_weights:
+        - row_id: q5_r1
+          weights:
+            - option_id: q5_c5
+              weight: 1
+        - row_id: q5_r2
+          weights:
+            - option_id: q5_c1
+              weight: 1

--- a/internal/provider/parser_fixture_test.go
+++ b/internal/provider/parser_fixture_test.go
@@ -38,6 +38,7 @@ func TestParserFixturesProduceStandardSurveys(t *testing.T) {
 				domain.QuestionKindMultiple,
 				domain.QuestionKindText,
 				domain.QuestionKindRating,
+				domain.QuestionKindMatrix,
 			},
 		},
 		{
@@ -126,6 +127,10 @@ func TestParserFixturesPreserveProviderSignals(t *testing.T) {
 		first := survey.Questions[0]
 		if !first.Required || len(first.Options) != 2 || first.Options[0].Value != "browser" {
 			t.Fatalf("first WJX question = %+v, want required browser option", first)
+		}
+		matrix := survey.Questions[4]
+		if matrix.Kind != domain.QuestionKindMatrix || len(matrix.Rows) != 2 || len(matrix.Options) != 2 {
+			t.Fatalf("matrix WJX question = %+v, want rows and options", matrix)
 		}
 	})
 

--- a/internal/provider/wjx/parser.go
+++ b/internal/provider/wjx/parser.go
@@ -115,6 +115,7 @@ func parseQuestion(node *html.Node, fallbackNumber int) (domain.QuestionDefiniti
 		Kind:     kind,
 		Required: attr(node, "data-required") == "true",
 		Options:  parseOptions(node),
+		Rows:     parseRows(node),
 		ProviderRaw: map[string]any{
 			"data_question": id,
 		},
@@ -169,6 +170,25 @@ func parseOptions(node *html.Node) []domain.OptionDefinition {
 		})
 	}
 	return options
+}
+
+func parseRows(node *html.Node) []domain.OptionDefinition {
+	rowNodes := findAll(node, func(n *html.Node) bool {
+		return attr(n, "data-row") != ""
+	})
+	rows := make([]domain.OptionDefinition, 0, len(rowNodes))
+	for _, rowNode := range rowNodes {
+		id := strings.TrimSpace(attr(rowNode, "data-row"))
+		label := strings.TrimSpace(textContent(rowNode))
+		rows = append(rows, domain.OptionDefinition{
+			ID:    id,
+			Label: label,
+			ProviderRaw: map[string]any{
+				"data_row": id,
+			},
+		})
+	}
+	return rows
 }
 
 func firstTextByAttr(root *html.Node, name string) string {

--- a/internal/provider/wjx/parser_test.go
+++ b/internal/provider/wjx/parser_test.go
@@ -34,8 +34,8 @@ func TestParseHTML(t *testing.T) {
 	if survey.Title != "问卷星 HTML 样例" {
 		t.Fatalf("Title = %q, want fixture title", survey.Title)
 	}
-	if len(survey.Questions) != 4 {
-		t.Fatalf("len(Questions) = %d, want 4", len(survey.Questions))
+	if len(survey.Questions) != 5 {
+		t.Fatalf("len(Questions) = %d, want 5", len(survey.Questions))
 	}
 
 	first := survey.Questions[0]
@@ -49,6 +49,17 @@ func TestParseHTML(t *testing.T) {
 	text := survey.Questions[2]
 	if text.Kind != domain.QuestionKindText || len(text.Options) != 0 {
 		t.Fatalf("text question = %+v, want text without options", text)
+	}
+
+	matrix := survey.Questions[4]
+	if matrix.ID != "q5" || matrix.Kind != domain.QuestionKindMatrix {
+		t.Fatalf("matrix question = %+v, want q5 matrix", matrix)
+	}
+	if len(matrix.Rows) != 2 || matrix.Rows[0].ID != "q5_r1" || matrix.Rows[1].Label != "性能" {
+		t.Fatalf("matrix rows = %+v, want parsed data-row entries", matrix.Rows)
+	}
+	if len(matrix.Options) != 2 || matrix.Options[0].Value != "1" || matrix.Options[1].Value != "5" {
+		t.Fatalf("matrix options = %+v, want parsed matrix columns", matrix.Options)
 	}
 }
 

--- a/internal/provider/wjx/testdata/survey.html
+++ b/internal/provider/wjx/testdata/survey.html
@@ -32,6 +32,27 @@
         <span data-option="q4_1" data-value="1">1</span>
         <span data-option="q4_5" data-value="5">5</span>
       </section>
+
+      <section data-question="q5" data-number="5" data-kind="matrix">
+        <h2 data-question-title>请评价以下维度</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>维度</th>
+              <th data-option="q5_c1" data-value="1">不满意</th>
+              <th data-option="q5_c5" data-value="5">满意</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-row="q5_r1">
+              <th>体验</th>
+            </tr>
+            <tr data-row="q5_r2">
+              <th>性能</th>
+            </tr>
+          </tbody>
+        </table>
+      </section>
     </main>
   </body>
 </html>

--- a/scripts/verify-local.ps1
+++ b/scripts/verify-local.ps1
@@ -58,6 +58,17 @@ try {
         if (($configOutput -join "`n") -notmatch "mode:\s*fixed" -or ($configOutput -join "`n") -notmatch "sample answer") {
             Write-Error "generated config did not contain a text answer skeleton"
         }
+        if (($configOutput -join "`n") -notmatch "matrix_weights") {
+            Write-Error "generated config did not contain matrix_weights"
+        }
+
+        $previewOutput = & go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+        if (($previewOutput -join "`n") -notmatch "q5:\s*q5_r1:5;q5_r2:1") {
+            Write-Error "wjx http preview did not contain the matrix answer draft"
+        }
     }
 
     if (-not $SkipStress) {


### PR DESCRIPTION
## Summary
- parse data-row entries from the WJX HTML fixture into matrix rows
- extend the WJX HTTP preview example and CLI smoke coverage with matrix weights
- document row-level matrix draft coverage in README and local verification docs

## Validation
- gofmt internal/provider/wjx/parser.go internal/provider/wjx/parser_test.go internal/provider/parser_fixture_test.go cmd/surveyctl/main_test.go
- git diff --check
- go test ./internal/provider ./internal/provider/wjx ./cmd/surveyctl
- powershell -ExecutionPolicy Bypass -File scripts/verify-local.ps1 -SkipStress

Closes #177
