### PR TITLE
[codex] Smoke three-provider config generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --target 1000 --concurr
 .\scripts\wjx-http-dryrun-stress.ps1
 .\scripts\wjx-http-dryrun-stress-matrix.ps1 -SkipFull
 .\scripts\wjx-http-dryrun-stress.ps1 -Target 1000 -Concurrency 1000 -Json
+.\scripts\config-generate-smoke.ps1
 .\scripts\verify-local.ps1
 .\scripts\verify-local.ps1 -IncludeWJXHTTPDryRunStress
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,7 +28,7 @@ gofmt -w (git ls-files '*.go')
 
 默认会执行 `go test ./...`、`go vet ./...`、`staticcheck` 和轻量 mock stress matrix。需要完整 1000 并发 profile 时：
 
-默认验证还会运行一个本地 CLI smoke，覆盖 `surveyctl link extract` 和 `surveyctl config generate` 的 provider 自动识别链路。这个 smoke 不访问网络，只使用内置 fixture。
+默认验证还会运行本地 CLI smoke，覆盖 `surveyctl link extract`、WJX HTTP preview 矩阵 draft，以及问卷星、腾讯问卷、Credamo 三个平台的 `surveyctl config generate` fixture 输出。这个 smoke 不访问网络，只使用内置 fixture。
 
 ```powershell
 .\scripts\verify-local.ps1 -IncludeFullStress
@@ -66,7 +66,7 @@ go run ./cmd/surveyctl link extract .\example-survey\qr.txt --json
 
 这一步适合作为配置生成前的轻量预检。后续如果要支持图片二维码，应作为可选能力进入，不影响 core 的纯文本路径。
 
-`surveyctl config generate` 会在未传 `--provider` 或传入 `--provider auto` 时根据 `--url` 自动识别平台。显式传入 `--provider wjx|tencent|credamo` 时仍以显式值为准，方便调试 fixture。
+`surveyctl config generate` 会在未传 `--provider` 或传入 `--provider auto` 时根据 `--url` 自动识别平台。显式传入 `--provider wjx|tencent|credamo` 时仍以显式值为准，方便调试 fixture。三平台 fixture 输出由 `scripts/config-generate-smoke.ps1` 覆盖，并被默认本地验证调用。
 
 生成配置遇到 `text` 或 `textarea` 题时，会写入一个可编辑的 `options.text` 骨架。默认是 `mode: fixed` 和 `sample answer`，确保生成配置能直接进入 answer plan；后续可按题目需要改成 `words`、`digits`、`phone` 或 `template`。
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -31,7 +31,7 @@ pwsh -File scripts/verify-local.ps1
 - `go test ./...`
 - `go vet ./...`
 - `staticcheck ./...`
-- CLI local precheck smoke：`link extract` + `config generate` provider auto-detection + generated text answer skeleton
+- CLI local precheck smoke：`link extract`、WJX HTTP preview 矩阵 draft、三平台 `config generate` fixture 输出
 - 轻量 mock stress matrix
 
 常用参数：
@@ -51,7 +51,17 @@ CI smoke 使用：
 .\scripts\verify-local.ps1 -SkipGoChecks -SkipStaticcheck -SkipStress -IncludeWJXHTTPDryRunStress
 ```
 
-`-SkipGoChecks` 只用于上层流程已经单独跑过 Go 检查的场景，例如 CI quality job。普通本地提交前不建议跳过 Go 检查。`-SkipCLISmoke` 会跳过链接预检和配置生成的 CLI smoke，通常只在调试脚本自身时使用。
+`-SkipGoChecks` 只用于上层流程已经单独跑过 Go 检查的场景，例如 CI quality job。普通本地提交前不建议跳过 Go 检查。`-SkipCLISmoke` 会跳过链接预检、WJX HTTP preview 和配置生成的 CLI smoke，通常只在调试脚本自身时使用。
+
+## config-generate-smoke.ps1
+
+三平台配置生成 smoke。它会分别读取问卷星、腾讯问卷和 Credamo 的本地 fixture，运行 `surveyctl config generate`，并检查 provider、题型、文本骨架和矩阵权重等关键输出：
+
+```powershell
+.\scripts\config-generate-smoke.ps1
+```
+
+这个脚本只读取仓库内 fixture，不访问网络。`verify-local.ps1` 默认会调用它，确保 `v1.0` 的三平台配置生成闭环不会在后续推进中退化。
 
 ## mock-stress.ps1
 

--- a/scripts/config-generate-smoke.ps1
+++ b/scripts/config-generate-smoke.ps1
@@ -1,0 +1,81 @@
+param(
+    [string]$WJXFixture = "internal/provider/wjx/testdata/survey.html",
+    [string]$TencentFixture = "internal/provider/tencent/testdata/survey_api.json",
+    [string]$CredamoFixture = "internal/provider/credamo/testdata/snapshot.json"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Invoke-ConfigGenerateSmoke {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Provider,
+        [Parameter(Mandatory = $true)]
+        [string]$Fixture,
+        [Parameter(Mandatory = $true)]
+        [string]$URL,
+        [Parameter(Mandatory = $true)]
+        [string[]]$ExpectedPatterns
+    )
+
+    Write-Host "== config generate $Provider =="
+    $output = & go run ./cmd/surveyctl config generate --provider $Provider --fixture $Fixture --url $URL
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    $text = $output -join "`n"
+    foreach ($pattern in $ExpectedPatterns) {
+        if ($text -notmatch $pattern) {
+            Write-Error "config generate $Provider did not contain expected pattern '$pattern': $text"
+        }
+    }
+}
+
+Push-Location $repoRoot
+try {
+    Invoke-ConfigGenerateSmoke `
+        -Provider "wjx" `
+        -Fixture $WJXFixture `
+        -URL "https://www.wjx.cn/vm/example.aspx" `
+        -ExpectedPatterns @(
+            "provider:\s*wjx",
+            "kind:\s*text",
+            "mode:\s*fixed",
+            "sample answer",
+            "kind:\s*matrix",
+            "matrix_weights"
+        )
+
+    Invoke-ConfigGenerateSmoke `
+        -Provider "tencent" `
+        -Fixture $TencentFixture `
+        -URL "https://wj.qq.com/s2/example" `
+        -ExpectedPatterns @(
+            "provider:\s*tencent",
+            "kind:\s*dropdown",
+            "kind:\s*matrix",
+            "matrix_weights",
+            "option_id:\s*q2_a"
+        )
+
+    Invoke-ConfigGenerateSmoke `
+        -Provider "credamo" `
+        -Fixture $CredamoFixture `
+        -URL "https://www.credamo.com/answer.html#/s/demo" `
+        -ExpectedPatterns @(
+            "provider:\s*credamo",
+            "id:\s*question-10",
+            "kind:\s*text",
+            "mode:\s*fixed",
+            "sample answer",
+            "option_id:\s*""1"""
+        )
+
+    Write-Host "config generate smoke passed"
+}
+finally {
+    Pop-Location
+}

--- a/scripts/verify-local.ps1
+++ b/scripts/verify-local.ps1
@@ -69,6 +69,12 @@ try {
         if (($previewOutput -join "`n") -notmatch "q5:\s*q5_r1:5;q5_r2:1") {
             Write-Error "wjx http preview did not contain the matrix answer draft"
         }
+
+        $commandArgs = New-SurveyControllerPowerShellFileArgs -Command $powerShellCommand -File "scripts/config-generate-smoke.ps1"
+        & $powerShellCommand.Source @commandArgs
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
     }
 
     if (-not $SkipStress) {


### PR DESCRIPTION
## Summary
- add a reusable config-generate smoke script for WJX, Tencent, and Credamo fixtures
- wire the smoke into verify-local CLI prechecks
- document the three-provider config generation smoke path

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/config-generate-smoke.ps1
- powershell -ExecutionPolicy Bypass -File scripts/verify-local.ps1 -SkipGoChecks -SkipStaticcheck -SkipStress
- go test ./cmd/surveyctl ./internal/config ./internal/provider
- git diff --check

Closes #179


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced local verification process documentation with clarified smoke test coverage across three providers (WJX, Tencent, Credamo).
  * Updated script documentation to detail expanded configuration generation testing capabilities.
  * Added new script invocation examples to README.

* **New Features**
  * Added comprehensive configuration generation smoke test script to improve local verification coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->