### PR TITLE
[codex] Add JSON config generation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ go run ./cmd/surveyctl version
 go run ./cmd/surveyctl link extract --text "https://www.wjx.cn/vm/example.aspx"
 go run ./cmd/surveyctl config validate examples/run.yaml
 go run ./cmd/surveyctl config generate --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx
+go run ./cmd/surveyctl config generate --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx --json
 go run ./cmd/surveyctl run --dry-run examples/run.yaml
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --seed 7
 go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
@@ -78,7 +79,7 @@ go run ./cmd/surveyctl link extract --text "问卷 https://www.wjx.cn/vm/example
 go run ./cmd/surveyctl link extract .\example-survey\qr.txt --json
 ```
 
-`config generate` 会为文本题生成可编辑的 `options.text` 骨架，默认使用 `mode: fixed` 和 `sample answer`，后续可改成 `words`、`digits`、`phone` 或 `template` 文本策略。
+`config generate` 默认输出适合人工编辑的 YAML；加 `--json` 时输出同一份配置的机器可读 JSON，适合脚本、CI 和后续轻量 GUI 外壳。它会为文本题生成可编辑的 `options.text` 骨架，默认使用 `mode: fixed` 和 `sample answer`，后续可改成 `words`、`digits`、`phone` 或 `template` 文本策略。
 
 当前 `surveyctl run` 已经支持两个本地预览入口：
 

--- a/cmd/surveyctl/main.go
+++ b/cmd/surveyctl/main.go
@@ -32,7 +32,7 @@ Usage:
   surveyctl version
   surveyctl link extract [path] [--text <value>] [--json]
   surveyctl config validate [path]
-  surveyctl config generate [--provider <id|auto>] --fixture <path> --url <url>
+  surveyctl config generate [--provider <id|auto>] --fixture <path> --url <url> [--json]
   surveyctl run --dry-run [path] [--json] [--target <n>] [--concurrency <n>]
   surveyctl run --mock [path] [--json] [--seed <n>] [--mock-fail-every <n>] [--events <text|jsonl>] [--target <n>] [--concurrency <n>] [--min-throughput <n>] [--max-heap-delta <bytes>] [--max-goroutines <n>] [--expect-failure-threshold <true|false>]
   surveyctl run --wjx-http-preview [path] --fixture <html> [--json] [--seed <n>] [--target <n>] [--concurrency <n>]
@@ -52,7 +52,7 @@ Commands:
 
 const configUsage = `Usage:
   surveyctl config validate [path]
-  surveyctl config generate [--provider <id|auto>] --fixture <path> --url <url>
+  surveyctl config generate [--provider <id|auto>] --fixture <path> --url <url> [--json]
 `
 
 const linkUsage = `Usage:
@@ -244,6 +244,7 @@ func runConfigGenerate(args []string, stdout io.Writer) error {
 	var providerID string
 	var fixturePath string
 	var rawURL string
+	jsonOutput := false
 	for i := 0; i < len(args); i++ {
 		arg := strings.TrimSpace(args[i])
 		switch strings.ToLower(arg) {
@@ -273,6 +274,8 @@ func runConfigGenerate(args []string, stdout io.Writer) error {
 			}
 			rawURL = value
 			i = next
+		case "--json":
+			jsonOutput = true
 		default:
 			return usageError(fmt.Sprintf("unknown config generate argument %q", arg), configUsage)
 		}
@@ -287,6 +290,11 @@ func runConfigGenerate(args []string, stdout io.Writer) error {
 	cfg, err := generateConfigFromFixture(providerID, fixturePath, rawURL)
 	if err != nil {
 		return commandError(exitFailure, fmt.Sprintf("config generate failed: %v", err), "")
+	}
+	if jsonOutput {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(cfg)
 	}
 	encoder := yaml.NewEncoder(stdout)
 	if err := encoder.Encode(cfg); err != nil {

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -227,6 +227,36 @@ func TestRunConfigGenerateDetectsProviderFromURL(t *testing.T) {
 	}
 }
 
+func TestRunConfigGenerateJSONPrintsMachineReadableConfig(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	fixture := filepath.Join("..", "..", "internal", "provider", "wjx", "testdata", "survey.html")
+
+	code := run([]string{"config", "generate", "--fixture", fixture, "--url", "https://www.wjx.cn/vm/example.aspx", "--json"}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run(config generate json) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
+	}
+	var cfg config.RunConfig
+	if err := json.Unmarshal(stdout.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode generated json: %v; output=%q", err, stdout.String())
+	}
+	if cfg.Survey.Provider != "wjx" || cfg.Survey.URL != "https://www.wjx.cn/vm/example.aspx" {
+		t.Fatalf("Survey = %+v, want detected wjx provider", cfg.Survey)
+	}
+	if len(cfg.Questions) != 5 {
+		t.Fatalf("len(Questions) = %d, want 5", len(cfg.Questions))
+	}
+	if !strings.Contains(stdout.String(), `"schema_version": 1`) {
+		t.Fatalf("stdout = %q, want indented json config", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "schema_version:") {
+		t.Fatalf("stdout = %q, want json not yaml", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestRunConfigGenerateAcceptsAutoProvider(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,7 +66,7 @@ go run ./cmd/surveyctl link extract .\example-survey\qr.txt --json
 
 这一步适合作为配置生成前的轻量预检。后续如果要支持图片二维码，应作为可选能力进入，不影响 core 的纯文本路径。
 
-`surveyctl config generate` 会在未传 `--provider` 或传入 `--provider auto` 时根据 `--url` 自动识别平台。显式传入 `--provider wjx|tencent|credamo` 时仍以显式值为准，方便调试 fixture。三平台 fixture 输出由 `scripts/config-generate-smoke.ps1` 覆盖，并被默认本地验证调用。
+`surveyctl config generate` 会在未传 `--provider` 或传入 `--provider auto` 时根据 `--url` 自动识别平台。显式传入 `--provider wjx|tencent|credamo` 时仍以显式值为准，方便调试 fixture。默认输出 YAML；加 `--json` 时输出同一份配置的机器可读 JSON，适合脚本、CI 和后续轻量 GUI 外壳。三平台 fixture 输出由 `scripts/config-generate-smoke.ps1` 覆盖，并被默认本地验证调用。
 
 生成配置遇到 `text` 或 `textarea` 题时，会写入一个可编辑的 `options.text` 骨架。默认是 `mode: fixed` 和 `sample answer`，确保生成配置能直接进入 answer plan；后续可按题目需要改成 `words`、`digits`、`phone` 或 `template`。
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -55,10 +55,11 @@ CI smoke 使用：
 
 ## config-generate-smoke.ps1
 
-三平台配置生成 smoke。它会分别读取问卷星、腾讯问卷和 Credamo 的本地 fixture，运行 `surveyctl config generate`，并检查 provider、题型、文本骨架和矩阵权重等关键输出：
+三平台配置生成 smoke。它会分别读取问卷星、腾讯问卷和 Credamo 的本地 fixture，运行 `surveyctl config generate`，并检查 provider、题型、文本骨架和矩阵权重等关键输出。脚本默认检查 YAML；需要机器可读配置时可以直接给 `config generate` 增加 `--json`：
 
 ```powershell
 .\scripts\config-generate-smoke.ps1
+go run ./cmd/surveyctl config generate --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx --json
 ```
 
 这个脚本只读取仓库内 fixture，不访问网络。`verify-local.ps1` 默认会调用它，确保 `v1.0` 的三平台配置生成闭环不会在后续推进中退化。


### PR DESCRIPTION
## Summary
- add `--json` to `surveyctl config generate`
- keep YAML as the default editable output
- test machine-readable generated config output
- document YAML versus JSON config generation usage

## Validation
- gofmt cmd/surveyctl/main.go cmd/surveyctl/main_test.go
- git diff --check
- go test ./cmd/surveyctl
- go run ./cmd/surveyctl config generate --fixture internal/provider/wjx/testdata/survey.html --url https://www.wjx.cn/vm/example.aspx --json
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #181
