### PR TITLE
[codex] Benchmark WJX HTTP dry-run path

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -110,6 +110,12 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 
 CI 的质量检查会运行 `scripts/wjx-http-dryrun-stress-matrix.ps1 -SkipFull`，用于覆盖 PowerShell 脚本、CLI 参数、本地 fixture、矩阵答案映射和 WJX HTTP dry-run runner 的基础兼容性；完整 1000x1000 profile 仍由本地显式参数触发。
 
+需要看 Go benchmark 分配基线时，运行：
+
+```powershell
+go test -bench BenchmarkRunWJXHTTPDryRun -benchmem ./internal/app
+```
+
 常用压测入口见 [性能与压测](performance.md)。默认脚本会运行 1000 target / 1000 concurrency 的本地 mock；`-Json` 输出最终 JSON 汇总，`-FailEvery` 可验证失败阈值和停止行为。
 
 事件流和汇总输出的边界要保持清晰：

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -111,6 +111,12 @@ go run ./cmd/surveyctl run --wjx-http-dry-run examples/wjx-http-preview.yaml --f
 
 text 输出只展示汇总和首个 draft，避免高并发 dry-run 时刷屏；JSON 输出包含完整 `drafts`，适合脚本检查 answer plan 到 form 的稳定性，包括矩阵题的行级答案。输出中的 `network: disabled (dry-run)` 是安全边界。
 
+需要观察完整 Go 热路径的分配基线时，可以运行 WJX HTTP dry-run benchmark。它覆盖 runner、答案计划、HTTP draft 映射、本地 dry-run executor 和矩阵题行级答案：
+
+```powershell
+go test -bench BenchmarkRunWJXHTTPDryRun -benchmem ./internal/app
+```
+
 `--events text|jsonl` 可用于观察 dry-run 期间的 runner 事件。高并发 profile 中建议优先使用 `--json` 汇总或脚本预算；事件流更适合小规模诊断和后续轻量 UI 订阅。
 
 WJX HTTP dry-run 支持和 mock run 相同的预算参数。预算失败时 CLI 会先输出 dry-run 报告，再以非零退出码返回失败原因，便于 CI 和脚本保留诊断信息。

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -87,11 +87,11 @@ questions:
 `
 }
 
-func writeRunConfig(t *testing.T, body string) string {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "survey.yaml")
+func writeRunConfig(tb testing.TB, body string) string {
+	tb.Helper()
+	path := filepath.Join(tb.TempDir(), "survey.yaml")
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
+		tb.Fatalf("write config: %v", err)
 	}
 	return path
 }

--- a/internal/app/wjx_http_benchmark_test.go
+++ b/internal/app/wjx_http_benchmark_test.go
@@ -1,0 +1,187 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/LING71671/SurveyController-Go/internal/domain"
+	"github.com/LING71671/SurveyController-Go/internal/runner"
+)
+
+var benchmarkWJXHTTPDryRunResult WJXHTTPDryRunResult
+
+func BenchmarkRunWJXHTTPDryRun(b *testing.B) {
+	for _, target := range []int{10, 1000} {
+		b.Run(fmt.Sprintf("target_%d", target), func(b *testing.B) {
+			benchmarkRunWJXHTTPDryRun(b, target)
+		})
+	}
+}
+
+func benchmarkRunWJXHTTPDryRun(b *testing.B, target int) {
+	b.Helper()
+	plan, err := CompileRunPlanFromFile(writeRunConfig(b, benchmarkWJXHTTPRunConfig()), RunPlanOverrides{
+		Target:      target,
+		Concurrency: target,
+	})
+	if err != nil {
+		b.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+	survey := benchmarkWJXHTTPSurvey()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, err := RunWJXHTTPDryRun(context.Background(), plan, WJXHTTPRunOptions{
+			Seed:   int64(i + 1),
+			Survey: survey,
+		})
+		if err != nil {
+			b.Fatalf("RunWJXHTTPDryRun() error = %v", err)
+		}
+		if result.Report.Successes != target || len(result.Drafts) != target {
+			b.Fatalf("result = %+v drafts=%d, want %d successes and drafts", result.Report, len(result.Drafts), target)
+		}
+		benchmarkWJXHTTPDryRunResult = result
+	}
+}
+
+func benchmarkWJXHTTPRunConfig() string {
+	return `schema_version: 1
+survey:
+  url: "https://www.wjx.cn/vm/benchmark.aspx"
+  provider: "wjx"
+run:
+  target: 1
+  concurrency: 1
+  mode: http
+  failure_threshold: 1
+  fail_stop_enabled: true
+questions:
+  - id: q1
+    kind: single
+    options:
+      weights:
+        - option_id: a
+          weight: 1
+  - id: q2
+    kind: multiple
+    options:
+      min_selected: 2
+      max_selected: 2
+      weights:
+        - option_id: a
+          weight: 1
+        - option_id: b
+          weight: 1
+        - option_id: c
+          weight: 0
+  - id: q4
+    kind: rating
+    options:
+      weights:
+        - option_id: score5
+          weight: 1
+  - id: q5
+    kind: matrix
+    options:
+      matrix_weights:
+        - row_id: row1
+          weights:
+            - option_id: agree
+              weight: 1
+        - row_id: row2
+          weights:
+            - option_id: neutral
+              weight: 1
+`
+}
+
+func benchmarkWJXHTTPSurvey() domain.SurveyDefinition {
+	return domain.SurveyDefinition{
+		Provider: domain.ProviderWJX,
+		Title:    "WJX HTTP Benchmark",
+		URL:      "https://www.wjx.cn/vm/benchmark.aspx",
+		Questions: []domain.QuestionDefinition{
+			{
+				ID:    "q1",
+				Title: "Single",
+				Kind:  domain.QuestionKindSingle,
+				Options: []domain.OptionDefinition{
+					{ID: "a", Label: "A", Value: "1"},
+				},
+			},
+			{
+				ID:    "q2",
+				Title: "Multiple",
+				Kind:  domain.QuestionKindMultiple,
+				Options: []domain.OptionDefinition{
+					{ID: "a", Label: "A", Value: "A"},
+					{ID: "b", Label: "B", Value: "B"},
+					{ID: "c", Label: "C", Value: "C"},
+				},
+			},
+			{
+				ID:    "q4",
+				Title: "Rating",
+				Kind:  domain.QuestionKindRating,
+				Options: []domain.OptionDefinition{
+					{ID: "score5", Label: "5", Value: "5"},
+				},
+			},
+			{
+				ID:    "q5",
+				Title: "Matrix",
+				Kind:  domain.QuestionKindMatrix,
+				Rows: []domain.OptionDefinition{
+					{ID: "row1", Label: "UX"},
+					{ID: "row2", Label: "Performance"},
+				},
+				Options: []domain.OptionDefinition{
+					{ID: "agree", Label: "Agree", Value: "5"},
+					{ID: "neutral", Label: "Neutral", Value: "3"},
+				},
+			},
+		},
+	}
+}
+
+func TestBenchmarkWJXHTTPDryRunFixturesStayCompatible(t *testing.T) {
+	plan, err := CompileRunPlanFromFile(writeRunConfig(t, benchmarkWJXHTTPRunConfig()), RunPlanOverrides{
+		Target:      3,
+		Concurrency: 2,
+	})
+	if err != nil {
+		t.Fatalf("CompileRunPlanFromFile() error = %v", err)
+	}
+
+	result, err := RunWJXHTTPDryRun(context.Background(), plan, WJXHTTPRunOptions{
+		Seed:   7,
+		Survey: benchmarkWJXHTTPSurvey(),
+	})
+	if err != nil {
+		t.Fatalf("RunWJXHTTPDryRun() error = %v", err)
+	}
+	assertBenchmarkDryRunReport(t, result.Report, 3)
+	if len(result.Drafts) != 3 {
+		t.Fatalf("drafts = %d, want 3", len(result.Drafts))
+	}
+	firstDraft := result.Drafts[0]
+	if firstDraft.AnswerCount != 4 {
+		t.Fatalf("AnswerCount = %d, want 4", firstDraft.AnswerCount)
+	}
+	if got := firstDraft.Form["q5"][0]; got != "row1:5;row2:3" {
+		t.Fatalf("matrix draft = %q, want row-level mapped answer", got)
+	}
+}
+
+func assertBenchmarkDryRunReport(t *testing.T, report runner.RunPlanReport, target int) {
+	t.Helper()
+	if report.Target != target || report.Successes != target || report.Failures != 0 || report.Completed != target {
+		t.Fatalf("report = %+v, want successful target %d", report, target)
+	}
+	if report.TotalAllocDelta == 0 {
+		t.Fatalf("report = %+v, want allocation metrics", report)
+	}
+}


### PR DESCRIPTION
## Summary
- add a full WJX HTTP dry-run benchmark for target 10 and target 1000 profiles
- cover runner, answer planning, matrix answer mapping, HTTP draft generation, and dry-run executor together
- keep a compatibility test for the benchmark fixture/config
- document the benchmem command in development and performance docs

## Validation
- gofmt internal/app/run_test.go internal/app/wjx_http_benchmark_test.go
- git diff --check
- go test ./internal/app
- go test -bench BenchmarkRunWJXHTTPDryRun -benchmem ./internal/app
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #183
