### PR TITLE
[codex] Map WJX HTTP text answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ go run ./cmd/surveyctl run --mock examples/mock-run.yaml --events jsonl
 
 `--events jsonl` 面向后续脚本、CI 和轻量 GUI 外壳；`v1.0` 前不会把 GUI 放进核心，但事件流会保持足够稳定，让 UI 只做薄订阅层。当前 mock run 和 WJX HTTP dry-run 共用这套事件协议。
 
-问卷星 HTTP 路径目前提供本地预览入口，用于检查 answer plan 到 HTTP form 的映射，不执行网络请求。预览会校验配置计划和本地 fixture 的 URL、题目 ID、题型是否一致；示例 fixture 覆盖单选、多选、文本、评分和矩阵题，矩阵题会以行级答案进入 draft：
+问卷星 HTTP 路径目前提供本地预览入口，用于检查 answer plan 到 HTTP form 的映射，不执行网络请求。预览会校验配置计划和本地 fixture 的 URL、题目 ID、题型是否一致；示例 fixture 覆盖单选、多选、文本、评分和矩阵题，文本题会以直接值进入 draft，矩阵题会以行级答案进入 draft：
 
 ```powershell
 go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html

--- a/cmd/surveyctl/main_test.go
+++ b/cmd/surveyctl/main_test.go
@@ -589,7 +589,7 @@ func TestRunWJXHTTPPreviewPrintsSummary(t *testing.T) {
 	if code != exitOK {
 		t.Fatalf("run(wjx http preview) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
 	}
-	for _, want := range []string{"wjx http preview:", "provider: wjx", "mode: http", "method: POST", "endpoint: https://www.wjx.cn/joinnew/processjq.ashx", "survey_id: example", "q1: browser", "q2: q2_a,q2_b", "q4: 5", "q5: q5_r1:5;q5_r2:1", "network: disabled (preview)"} {
+	for _, want := range []string{"wjx http preview:", "provider: wjx", "mode: http", "method: POST", "endpoint: https://www.wjx.cn/joinnew/processjq.ashx", "survey_id: example", "q1: browser", "q2: q2_a,q2_b", "q3: local text answer", "q4: 5", "q5: q5_r1:5;q5_r2:1", "network: disabled (preview)"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
@@ -623,6 +623,9 @@ func TestRunWJXHTTPPreviewJSONPrintsSummary(t *testing.T) {
 	if values := form["q2"].([]any); values[0] != "q2_a,q2_b" {
 		t.Fatalf("form = %+v, want q2 multiple answer", form)
 	}
+	if values := form["q3"].([]any); values[0] != "local text answer" {
+		t.Fatalf("form = %+v, want q3 text answer", form)
+	}
 	if values := form["q4"].([]any); values[0] != "5" {
 		t.Fatalf("form = %+v, want q4 rating answer", form)
 	}
@@ -644,7 +647,7 @@ func TestRunWJXHTTPDryRunPrintsSummary(t *testing.T) {
 	if code != exitOK {
 		t.Fatalf("run(wjx http dry-run) exit code = %d, want %d; stderr=%q", code, exitOK, stderr.String())
 	}
-	for _, want := range []string{"wjx http dry-run:", "provider: wjx", "mode: http", "target: 2", "successes: 2", "completed: 2", "draft_count: 2", "first_draft:", "q1: browser", "q2: q2_a,q2_b", "q4: 5", "q5: q5_r1:5;q5_r2:1", "network: disabled (dry-run)"} {
+	for _, want := range []string{"wjx http dry-run:", "provider: wjx", "mode: http", "target: 2", "successes: 2", "completed: 2", "draft_count: 2", "first_draft:", "q1: browser", "q2: q2_a,q2_b", "q3: local text answer", "q4: 5", "q5: q5_r1:5;q5_r2:1", "network: disabled (dry-run)"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("stdout = %q, want %q", stdout.String(), want)
 		}
@@ -680,6 +683,9 @@ func TestRunWJXHTTPDryRunJSONPrintsSummary(t *testing.T) {
 	form := first["form"].(map[string]any)
 	if values := form["q1"].([]any); values[0] != "browser" {
 		t.Fatalf("form = %+v, want q1 browser", form)
+	}
+	if values := form["q3"].([]any); values[0] != "local text answer" {
+		t.Fatalf("form = %+v, want q3 text answer", form)
 	}
 	if values := form["q5"].([]any); values[0] != "q5_r1:5;q5_r2:1" {
 		t.Fatalf("form = %+v, want q5 matrix answer", form)
@@ -968,6 +974,13 @@ questions:
           weight: 1
         - option_id: q2_c
           weight: 0
+  - id: q3
+    kind: text
+    options:
+      text:
+        mode: fixed
+        values:
+          - local text answer
   - id: q4
     kind: rating
     options:

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -91,7 +91,7 @@ go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --f
 
 预览会经过配置编译、答案计划生成、问卷星 HTTP form 映射和 plan/fixture 兼容性校验，但不会调用 HTTP executor。输出中的 `network: disabled (preview)` 是这个阶段的安全边界。
 
-当前示例覆盖单选、多选、文本、评分和矩阵题，用于观察 answer plan 到 `processjq.ashx` form 的映射。矩阵题在本地 draft 中使用稳定的行级表示，例如 `q5_r1:5;q5_r2:1`，便于脚本检查每一行是否都被计划和映射。后续真实网络运行必须继续复用 provider 能力门控，并在登录、验证、风控、设备次数上限或频控信号出现时停止并报告。
+当前示例覆盖单选、多选、文本、评分和矩阵题，用于观察 answer plan 到 `processjq.ashx` form 的映射。文本题会以直接值进入本地 draft；矩阵题使用稳定的行级表示，例如 `q5_r1:5;q5_r2:1`，便于脚本检查每一行是否都被计划和映射。后续真实网络运行必须继续复用 provider 能力门控，并在登录、验证、风控、设备次数上限或频控信号出现时停止并报告。
 
 ## WJX HTTP Dry-Run
 

--- a/examples/wjx-http-preview.yaml
+++ b/examples/wjx-http-preview.yaml
@@ -25,6 +25,13 @@ questions:
           weight: 1
         - option_id: q2_c
           weight: 0
+  - id: q3
+    kind: text
+    options:
+      text:
+        mode: fixed
+        values:
+          - local text answer
   - id: q4
     kind: rating
     options:

--- a/internal/app/wjx_http_benchmark_test.go
+++ b/internal/app/wjx_http_benchmark_test.go
@@ -77,6 +77,13 @@ questions:
           weight: 1
         - option_id: c
           weight: 0
+  - id: q3
+    kind: text
+    options:
+      text:
+        mode: fixed
+        values:
+          - benchmark answer
   - id: q4
     kind: rating
     options:
@@ -121,6 +128,11 @@ func benchmarkWJXHTTPSurvey() domain.SurveyDefinition {
 					{ID: "b", Label: "B", Value: "B"},
 					{ID: "c", Label: "C", Value: "C"},
 				},
+			},
+			{
+				ID:    "q3",
+				Title: "Text",
+				Kind:  domain.QuestionKindText,
 			},
 			{
 				ID:    "q4",
@@ -168,8 +180,11 @@ func TestBenchmarkWJXHTTPDryRunFixturesStayCompatible(t *testing.T) {
 		t.Fatalf("drafts = %d, want 3", len(result.Drafts))
 	}
 	firstDraft := result.Drafts[0]
-	if firstDraft.AnswerCount != 4 {
-		t.Fatalf("AnswerCount = %d, want 4", firstDraft.AnswerCount)
+	if firstDraft.AnswerCount != 5 {
+		t.Fatalf("AnswerCount = %d, want 5", firstDraft.AnswerCount)
+	}
+	if got := firstDraft.Form["q3"][0]; got != "benchmark answer" {
+		t.Fatalf("text draft = %q, want direct mapped text answer", got)
 	}
 	if got := firstDraft.Form["q5"][0]; got != "row1:5;row2:3" {
 		t.Fatalf("matrix draft = %q, want row-level mapped answer", got)

--- a/internal/provider/wjx/http_answer_plan.go
+++ b/internal/provider/wjx/http_answer_plan.go
@@ -161,6 +161,8 @@ func (q httpQuestionSpec) mapAnswer(planned answerplan.QuestionAnswer) (string, 
 		return q.mapRatingAnswer(planned)
 	case domain.QuestionKindMatrix:
 		return q.mapMatrixAnswer(planned)
+	case domain.QuestionKindText, domain.QuestionKindTextarea:
+		return q.mapTextAnswer(planned)
 	default:
 		return "", fmt.Errorf("kind %q is not supported for HTTP answer plan", q.kind)
 	}
@@ -254,6 +256,17 @@ func (q httpQuestionSpec) mapMatrixRowValue(row answerplan.RowAnswer) (string, e
 		return q.optionValue(row.OptionIDs[0])
 	}
 	return directAnswerValue(row.Value)
+}
+
+func (q httpQuestionSpec) mapTextAnswer(planned answerplan.QuestionAnswer) (string, error) {
+	_ = q
+	if planned.HasOptionIDs() {
+		return "", fmt.Errorf("text answer expects direct value")
+	}
+	if planned.HasRows() {
+		return "", fmt.Errorf("text answer does not support row answers")
+	}
+	return directAnswerValue(planned.Value)
 }
 
 func directAnswerValue(value string) (string, error) {

--- a/internal/provider/wjx/http_answer_plan_test.go
+++ b/internal/provider/wjx/http_answer_plan_test.go
@@ -17,6 +17,7 @@ func TestBuildHTTPAnswers(t *testing.T) {
 			{QuestionID: "q2", OptionIDs: []string{"a", "c"}},
 			{QuestionID: "q3", OptionIDs: []string{"score5"}},
 			{QuestionID: "q4", OptionIDs: []string{"city2"}},
+			{QuestionID: "q5", Value: "local text"},
 			{QuestionID: "q6", Rows: []answerplan.RowAnswer{
 				{RowID: "row1", OptionIDs: []string{"agree"}},
 				{RowID: "row2", OptionIDs: []string{"neutral"}},
@@ -32,6 +33,7 @@ func TestBuildHTTPAnswers(t *testing.T) {
 		"q2": "A,C",
 		"q3": "5",
 		"q4": "shanghai",
+		"q5": "local text",
 		"q6": "row1:5;row2:3",
 	}
 	if len(got) != len(want) {
@@ -192,7 +194,7 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 			name:   "unsupported kind",
 			survey: survey,
 			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
-				{QuestionID: "q5", Value: "hello"},
+				{QuestionID: "q7", Value: "hello"},
 			}},
 			want: "not supported",
 		},
@@ -227,6 +229,22 @@ func TestBuildHTTPAnswersRejectsInvalidPlan(t *testing.T) {
 				{QuestionID: "q3", Value: " "},
 			}},
 			want: "answer value",
+		},
+		{
+			name:   "text option ids",
+			survey: survey,
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
+				{QuestionID: "q5", OptionIDs: []string{"a"}},
+			}},
+			want: "direct value",
+		},
+		{
+			name:   "text row answers",
+			survey: survey,
+			plan: answerplan.Plan{Answers: []answerplan.QuestionAnswer{
+				{QuestionID: "q5", Rows: []answerplan.RowAnswer{{RowID: "row1", Value: "x"}}},
+			}},
+			want: "row answers",
 		},
 		{
 			name:   "matrix top-level options",
@@ -384,6 +402,11 @@ func testAnswerPlanSurvey() domain.SurveyDefinition {
 					{ID: "agree", Label: "Agree", Value: "5"},
 					{ID: "neutral", Label: "Neutral", Value: "3"},
 				},
+			},
+			{
+				ID:    "q7",
+				Title: "Unsupported",
+				Kind:  domain.QuestionKindUnknown,
 			},
 		},
 	}

--- a/scripts/verify-local.ps1
+++ b/scripts/verify-local.ps1
@@ -69,6 +69,9 @@ try {
         if (($previewOutput -join "`n") -notmatch "q5:\s*q5_r1:5;q5_r2:1") {
             Write-Error "wjx http preview did not contain the matrix answer draft"
         }
+        if (($previewOutput -join "`n") -notmatch "q3:\s*local text answer") {
+            Write-Error "wjx http preview did not contain the text answer draft"
+        }
 
         $commandArgs = New-SurveyControllerPowerShellFileArgs -Command $powerShellCommand -File "scripts/config-generate-smoke.ps1"
         & $powerShellCommand.Source @commandArgs


### PR DESCRIPTION
## Summary
- map WJX text and textarea answer plan values into HTTP preview/dry-run form values
- include text answers in the WJX preview example and CLI smoke assertions
- extend the WJX HTTP dry-run benchmark to include text plus matrix answers
- document text answer draft coverage

## Validation
- gofmt internal/provider/wjx/http_answer_plan.go internal/provider/wjx/http_answer_plan_test.go cmd/surveyctl/main_test.go internal/app/wjx_http_benchmark_test.go
- git diff --check
- go test ./internal/provider/wjx ./cmd/surveyctl ./internal/app
- go run ./cmd/surveyctl run --wjx-http-preview examples/wjx-http-preview.yaml --fixture internal/provider/wjx/testdata/survey.html
- powershell -ExecutionPolicy Bypass -File scripts/verify-local.ps1 -SkipGoChecks -SkipStaticcheck -SkipStress
- go test -bench BenchmarkRunWJXHTTPDryRun -benchmem ./internal/app
- go test ./...
- go vet ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #185
